### PR TITLE
Move ".github" folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# default owners for everything in the repository.
+*   @Microsoft/accessibility-insights-windows-code-owners

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: ''
+assignees: ''
+
+---
+Please check whether the bug has [already been filed](https://github.com/Microsoft/axe-windows/issues).
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+What actually happened.
+
+**Screenshots or .GIF**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. Windows 10 1809] (Get the version by running `winver` from the command line)
+ - Accessibility Insights for Windows Version:
+ - Target Application: [e.g. Chrome, Wildlife Manager]
+ - Target Application Version: [e.g. 22]
+
+
+**Additional context**
+Priority requested -
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature Request]"
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/general-question.md
+++ b/.github/ISSUE_TEMPLATE/general-question.md
@@ -1,0 +1,12 @@
+---
+name: General Question
+about: This is a template for people to ask questions that don't fit into any other issue categories
+title: "[General Question] "
+labels: ''
+assignees: ''
+
+---
+
+**Your question here**
+Make sure to provide enough context. If you have spoken to a team member please mention them here.
+Add any items (screenshots etc) that will help.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+#### Describe the change
+(Please provide an overview of the change in this PR)
+
+> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
+
+
+


### PR DESCRIPTION
- Move code owner and code request template.
- Check lists was removed from the template till we create a new one for the repo.
- in general-question folder, the recommendatio to ask on stackoverflow was removed till we have a new account for the repo.