### PR TITLE
Add prerelease suffix for first NuGet push

### DIFF
--- a/src/props/version.props
+++ b/src/props/version.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SemVerNumber Condition="$(SemVerNumber) == ''">0.1.0</SemVerNumber>
-    <SemVerSuffix></SemVerSuffix>
+    <SemVerSuffix>-prerelease</SemVerSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### Describe the change

In the long term, the "-prerelease" suffix should not be stored in the version.props file. But in order to create our first package suitable to be pushed to nuget.org, I have included it here to simplify building and signing the package.


> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



