### PR TITLE
Add code to expose Axe.Windows package version

### DIFF
--- a/src/Axe.Windows.Core/Core.csproj
+++ b/src/Axe.Windows.Core/Core.csproj
@@ -83,6 +83,7 @@
     <Compile Include="HelpLinks\HelpUrl.cs" />
     <Compile Include="Misc\BoundedCounter.cs" />
     <Compile Include="Misc\FileHelpers.cs" />
+    <Compile Include="Misc\PackageInfo.cs" />
     <Compile Include="Misc\Preconditions.cs" />
     <Compile Include="Misc\Utility.cs" />
     <Compile Include="Results\RuleResult.cs" />

--- a/src/Axe.Windows.Core/Misc/PackageInfo.cs
+++ b/src/Axe.Windows.Core/Misc/PackageInfo.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Axe.Windows.Core.Misc
+{
+    /// <summary>
+    /// Provides information about the Axe.Windows package
+    /// </summary>
+    public static class PackageInfo
+    {
+        private static Lazy<Assembly> ThisAssembly = new Lazy<Assembly>(() => Assembly.GetExecutingAssembly(), true);
+        private static Lazy<string> LazyInformationalVersion = new Lazy<string>(GetInformationalVersion, true);
+
+        private static String GetInformationalVersion()
+        {
+            var attribute = ThisAssembly.Value.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+
+            return attribute?.InformationalVersion;
+        }
+
+        /// <summary>
+        /// Version string with suffix (e.g., "-prerelease") if the suffix exists
+        /// </summary>
+        public static string InformationalVersion => LazyInformationalVersion.Value;
+    } // class
+} // namespace

--- a/src/Axe.Windows.Core/Misc/Utility.cs
+++ b/src/Axe.Windows.Core/Misc/Utility.cs
@@ -8,16 +8,6 @@ namespace Axe.Windows.Core.Misc
 {
     public static class Utility
     {
-        /// <summary>
-        /// Get version from Axe.Windows.Core Assembly
-        /// </summary>
-        /// <returns></returns>
-        public static string GetAppVersion()
-        {
-            string fileVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(System.Reflection.Assembly.GetExecutingAssembly().Location).FileVersion;
-            return fileVersion;
-        }
-
         public static string GetProcessName(int processId)
         {
             if (!TryGetProcessById(processId, out Process process)) return null;

--- a/src/Axe.Windows.CoreTests/CoreTests.csproj
+++ b/src/Axe.Windows.CoreTests/CoreTests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Fingerprint\OutputFileIssueStoreUnitTests.cs" />
     <Compile Include="Fingerprint\IssueStoreExtensionsUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1" />
     <Compile Include="Misc\MiscTests.cs" />
+    <Compile Include="Misc\PackageInfoTests.cs" />
     <Compile Include="Misc\PreconditionsUnitTests.cs" />
     <Compile Include="Misc\BoundedCounterUnitTests.cs" />
     <Compile Include="Misc\UtilityTests.cs" />

--- a/src/Axe.Windows.CoreTests/Misc/PackageInfoTests.cs
+++ b/src/Axe.Windows.CoreTests/Misc/PackageInfoTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Misc;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Reflection;
+
+namespace Axe.Windows.CoreTests.Misc
+{
+    [TestClass]
+    public class PackageInfoTests
+    {
+        [TestMethod]
+        public void PackageInfo_ExpectedInformationalVersion()
+        {
+            var assembly = Assembly.GetAssembly(typeof(PackageInfo));
+            var attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            Assert.IsNotNull(attribute?.InformationalVersion);
+            Assert.AreEqual(PackageInfo.InformationalVersion, attribute.InformationalVersion);
+        }
+    } // class
+} // namespace

--- a/src/Axe.Windows.Desktop/Settings/SnapshotMetaInfo.cs
+++ b/src/Axe.Windows.Desktop/Settings/SnapshotMetaInfo.cs
@@ -63,7 +63,7 @@ namespace Axe.Windows.Desktop.Settings
         {
             this.Mode = mode;
             this.RuleVersion = ruleVersion;
-            this.Version = Axe.Windows.Core.Misc.Utility.GetAppVersion();
+            this.Version = Axe.Windows.Core.Misc.PackageInfo.InformationalVersion;
 
             if (selected.HasValue)
             {


### PR DESCRIPTION
#### Describe the change

- used the informational version because it represents the semver version, whereas the file version cannot.
- Moved the code that exposes the version out of Utility and into PackageInfo to make it more obvious how to get the version

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



