### PR TITLE
Rename the nuget package to Microsoft.Axe.Windows

### DIFF
--- a/src/CI/CI.csproj
+++ b/src/CI/CI.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="Axe.Windows.nuspec">
+    <None Include="Microsoft.Axe.Windows.nuspec">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
@@ -54,7 +54,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Condition=" '$(MAICreateNuget)' == 'true' " Name="Pack" AfterTargets="Build">
-    <Exec Command="nuget.exe pack -properties Configuration=$(Configuration);VersionString=&quot;$(SemVerNumber)$(SemVerSuffix)&quot; Axe.Windows.nuspec -OutputDirectory bin\$(Configuration)\NuGet\$(SemVerNumber)$(SemVerSuffix) -NonInteractive" />
+    <Exec Command="nuget.exe pack -properties Configuration=$(Configuration);VersionString=&quot;$(SemVerNumber)$(SemVerSuffix)&quot; Microsoft.Axe.Windows.nuspec -OutputDirectory bin\$(Configuration)\NuGet\$(SemVerNumber)$(SemVerSuffix) -NonInteractive" />
   </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/CI/Microsoft.Axe.Windows.nuspec
+++ b/src/CI/Microsoft.Axe.Windows.nuspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package>
   <metadata>
-    <id>Axe.Windows</id>
+    <id>Microsoft.Axe.Windows</id>
     <version>$VersionString$</version>
     <title>axe-windows</title>
     <summary>Automated accessibility analysis for Windows applications</summary>


### PR DESCRIPTION
This PR updates the .nuspec file so that the NuGet package id includes 'Microsoft'. This allows us to be consistent with guidelines for publishing to NuGet.org via Microsoft.