### PR TITLE
Fixing missing name for NuGet file

### DIFF
--- a/src/CI/CI.csproj
+++ b/src/CI/CI.csproj
@@ -69,7 +69,7 @@
           DependsOnTargets="@(SignNuGetPackageDependsOn)"
           AfterTargets="Pack">
     <ItemGroup>
-      <SignNuGetPackFiles Include="bin\$(Configuration)\NuGet\$(SemVerNumber)$(SemVerSuffix)\Axe.Windows.$(SemVerNumber)$(SemVerSuffix).nupkg" />
+      <SignNuGetPackFiles Include="bin\$(Configuration)\NuGet\$(SemVerNumber)$(SemVerSuffix)\Microsoft.Axe.Windows.$(SemVerNumber)$(SemVerSuffix).nupkg" />
     </ItemGroup>
     <SignFiles Files="@(SignNuGetPackFiles)"
                Type="$(SignType)"


### PR DESCRIPTION
The name of the NuGet package should be Microsoft.Axe.Windows, but the csproj signing looked for Axe.Windows.


