### PR TITLE
Enable code coverage as a test

### DIFF
--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -52,7 +52,7 @@ jobs:
         **\*test*.dll
         !**\obj\**
       vsTestVersion: 15.0
-      codeCoverageEnabled: false
+      codeCoverageEnabled: true
       platform: '$(BuildPlatform)'
       configuration: release
       rerunFailedTests: true
@@ -98,7 +98,7 @@ jobs:
         !**\obj\**
       testFiltercriteria: 'TestCategory!=RequiresNetwork'
       vsTestVersion: 15.0
-      codeCoverageEnabled: false
+      codeCoverageEnabled: true
       platform: '$(BuildPlatform)'
       configuration: debug
       rerunFailedTests: true


### PR DESCRIPTION
#### Describe the change
Enable code coverage in the PR build

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



