### PR TITLE
Enable code coverage in build result

### DIFF
--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -53,6 +53,7 @@ jobs:
         !**\obj\**
       vsTestVersion: 15.0
       codeCoverageEnabled: true
+      publishRunAttachments: true
       platform: '$(BuildPlatform)'
       configuration: release
       rerunFailedTests: true

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -52,7 +52,7 @@ jobs:
         **\*test*.dll
         !**\obj\**
       vsTestVersion: 15.0
-      codeCoverageEnabled: false
+      codeCoverageEnabled: true
       platform: '$(BuildPlatform)'
       configuration: release
       rerunFailedTests: true


### PR DESCRIPTION
#### Describe the change
Enable code coverage to see how much we cover and act based on that.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



