### PR TITLE
Enable TSA in Axe Windows 

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -112,6 +112,7 @@ jobs:
     displayName: 'Run BinSkim'
     inputs:
       InputType: Basic
+      continueOnError: true
       # Double-quote syntax with trailing backslash on each line concatenates lines without spaces
       AnalyzeTarget: "src\\Actions\\bin\\Debug\\*.dll;\
                       src\\Automation\\bin\\Debug\\*.dll;\
@@ -126,12 +127,14 @@ jobs:
     displayName: 'Run CredScan'
     inputs:
       verboseOutput: true
+      continueOnError: true
       debugMode: false
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-fxcop.FxCop@2
     displayName: 'Run FxCop'
     inputs:
       inputType: Basic
+      continueOnError: true
       # Double-quote syntax with trailing backslash on each line concatenates lines without spaces
       targets: "src\\Actions\\bin\\Debug\\Axe.Windows.*.dll;\
                 src\\Automation\\bin\\Debug\\Axe.Windows.*.dll;\
@@ -143,12 +146,19 @@ jobs:
                 src\\Win32\\bin\\Debug\\Axe.Windows.*.dll;"
       ignoreGeneratedCode: true
 
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+    displayName: 'Run PoliCheck'
+    inputs:
+      targetType: F
+      continueOnError: true
+
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@1
     displayName: 'Create Security Analysis Report'
     inputs:
       BinSkim: true
       CredScan: true
       FxCop: true
+      PoliCheck: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
     displayName: 'Publish Security Analysis Logs'
@@ -160,6 +170,7 @@ jobs:
       CredScan: true
       FxCop: true
       FxCopBreakOn: CriticalError
+      PoliCheck: true
 
   - task: VSTest@2
     displayName: 'Test Assemblies **\debug\*test*.dll;-:**\obj\**'
@@ -173,6 +184,29 @@ jobs:
       platform: '$(BuildPlatform)'
       configuration: debug
       rerunFailedTests: true
+
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
+    displayName: 'TSA upload to Codebase: accessibility-insights-windows_master Version: TsaV2'
+    inputs:
+      tsaVersion: TsaV2
+      codebase: NewOrUpdate
+      codeBaseName: 'accessibility-insights-windows_master'
+      notificationAlias: 'a11y-insights-eng@microsoft.com'
+      codeBaseAdmins: 'REDMOND\mreay;REDMOND\ahmohame'
+      instanceUrlForTsaV2: MSENG
+      projectNameMSENG: AzureDevOps
+      areaPath: 'AzureDevOps\VSTS\enSPIRe\Keros\Desktop'
+      iterationPath: 'AzureDevOps\OneVS'
+      uploadFxCop: true
+      uploadBinSkim: true
+      uploadCredScan: true
+      uploadAPIScan: false
+      uploadFortifySCA: false
+      uploadModernCop: false
+      uploadPoliCheck: true
+      uploadPREfast: false
+      uploadRoslyn: false
+      uploadTSLint: false
 
 - job: SignedRelease
   dependsOn: 
@@ -219,6 +253,7 @@ jobs:
     displayName: 'Run BinSkim'
     inputs:
       InputType: Basic
+      continueOnError: true
       # Double-quote syntax with trailing backslash on each line concatenates lines without spaces
       AnalyzeTarget: "src\\Actions\\bin\\Release\\*.dll;\
                       src\\Automation\\bin\\Release\\*.dll;\
@@ -283,7 +318,30 @@ jobs:
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
-      
+
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
+    displayName: 'TSA upload to Codebase: accessibility-insights-windows_master Version: TsaV2'
+    inputs:
+      tsaVersion: TsaV2
+      codebase: NewOrUpdate
+      codeBaseName: 'accessibility-insights-windows_master'
+      notificationAlias: 'a11y-insights-eng@microsoft.com'
+      codeBaseAdmins: 'REDMOND\mreay;REDMOND\ahmohame'
+      instanceUrlForTsaV2: MSENG
+      projectNameMSENG: AzureDevOps
+      areaPath: 'AzureDevOps\VSTS\enSPIRe\Keros\Desktop'
+      iterationPath: 'AzureDevOps\OneVS'
+      uploadFxCop: true
+      uploadBinSkim: true
+      uploadCredScan: true
+      uploadAPIScan: false
+      uploadFortifySCA: false
+      uploadModernCop: false
+      uploadPoliCheck: false
+      uploadPREfast: false
+      uploadRoslyn: false
+      uploadTSLint: false
+
   - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
     displayName: 'Perform Cleanup Tasks'
     condition: succeededOrFailed()
@@ -328,12 +386,14 @@ jobs:
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
     displayName: 'Run CredScan'
     inputs:
+      continueOnError: true
       debugMode: false
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-fxcop.FxCop@2
     displayName: 'Run FxCop'
     inputs:
       inputType: Basic
+      continueOnError: true
       # Double-quote syntax with trailing backslash on each line concatenates lines without spaces
       targets: "src\\Actions\\bin\\Debug\\Axe.Windows.*.dll;\
                 src\\Automation\\bin\\Debug\\Axe.Windows.*.dll;\
@@ -371,7 +431,30 @@ jobs:
       platform: '$(BuildPlatform)'
       configuration: debug
       rerunFailedTests: true
-      
+
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
+    displayName: 'TSA upload to Codebase: accessibility-insights-windows_master Version: TsaV2'
+    inputs:
+      tsaVersion: TsaV2
+      codebase: NewOrUpdate
+      codeBaseName: 'accessibility-insights-windows_master'
+      notificationAlias: 'a11y-insights-eng@microsoft.com'
+      codeBaseAdmins: 'REDMOND\mreay;REDMOND\ahmohame'
+      instanceUrlForTsaV2: MSENG
+      projectNameMSENG: AzureDevOps
+      areaPath: 'AzureDevOps\VSTS\enSPIRe\Keros\Desktop'
+      iterationPath: 'AzureDevOps\OneVS'
+      uploadFxCop: true
+      uploadBinSkim: true
+      uploadCredScan: true
+      uploadAPIScan: false
+      uploadFortifySCA: false
+      uploadModernCop: false
+      uploadPoliCheck: false
+      uploadPREfast: false
+      uploadRoslyn: false
+      uploadTSLint: false
+
   - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
     displayName: 'Perform Cleanup Tasks'
     condition: succeededOrFailed()


### PR DESCRIPTION
#### Describe the change
Enable TSA in Axe Windows as recommended by the SDL process.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



