### PR TITLE
Enable flow analysis in all projects

### DIFF
--- a/build/common.targets
+++ b/build/common.targets
@@ -1,0 +1,13 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"> 
+
+  <!--
+  Settings file which is indirectly imported by all of the projects in the repo.
+  -->
+
+  <!--
+  Explicitly enable the flow-analysis feature
+  -->
+  <PropertyGroup>
+    <Features>$(Features);flow-analysis</Features> 
+  </PropertyGroup>  
+</Project>

--- a/build/delaysign.targets
+++ b/build/delaysign.targets
@@ -1,8 +1,10 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"> 
   
   <!--
-  Settings file which is included by all the shipping code projects in the repo.
+  Settings file which is directly imported by all of the test code projects in the repo.
   -->
+
+  <Import Project="common.targets" />
 
   <Choose>
     <When Condition=" '$(SignAppForRelease)'=='true' AND '$(Configuration)' == 'Release'">
@@ -14,5 +16,5 @@
       </PropertyGroup>
     </When>
   </Choose>
-  
+
 </Project>

--- a/build/settings.targets
+++ b/build/settings.targets
@@ -1,5 +1,9 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"> 
   
+  <!--
+  Settings file which is directly included imported all of the shipping code projects in the repo.
+  -->
+
   <Import Project="delaysign.targets" />
 
   <Choose>


### PR DESCRIPTION
#### Describe the change
The new Roslyn changes are generating errors because flow-analysis isn't enabled. It's enabled by default in the official build environment, but not when building locally. This explicitly enables it locally, as well. It will be doubly-enabled in the official build, but that shouldn't be a problem.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



