### PR TITLE
Remove Fakes dependency from DesktopTests project

### DIFF
--- a/src/DesktopTests/DesktopTests.csproj
+++ b/src/DesktopTests/DesktopTests.csproj
@@ -40,28 +40,12 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  <PropertyGroup Condition="$(FAKES_SUPPORTED) == 1">
-    <DefineConstants>$(DefineConstants);FAKES_SUPPORTED</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Axe.Windows.Core.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
-      <HintPath>..\Fakes.Prebuild\FakesAssemblies\Axe.Windows.Core.Fakes.dll</HintPath>
-    </Reference>
-    <Reference Include="Axe.Windows.Desktop.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
-      <HintPath>..\Fakes.Prebuild\FakesAssemblies\Axe.Windows.Desktop.Fakes.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.QualityTools.Testing.Fakes, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="$(FAKES_SUPPORTED) == 1">
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="mscorlib.4.0.0.0.Fakes, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0ae41878053f6703, processorArchitecture=MSIL" Condition="$(FAKES_SUPPORTED) == 1">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Fakes.Prebuild\FakesAssemblies\mscorlib.4.0.0.0.Fakes.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -84,7 +68,7 @@
     <Compile Include="ColorContrastAnalyzer\ImageTests.cs" />
     <Compile Include="Keyboard\HotkeyTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Settings\SnapshotMetaInfoTests.cs" Condition="$(FAKES_SUPPORTED) == 1" />
+    <Compile Include="Settings\SnapshotMetaInfoTests.cs" />
     <Compile Include="Utility\SupportedEventsTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/DesktopTests/Settings/SnapshotMetaInfoTests.cs
+++ b/src/DesktopTests/Settings/SnapshotMetaInfoTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.IO;
 using Axe.Windows.Desktop.Settings;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.IO;
 
 namespace Axe.Windows.DesktopTests.Settings
 {

--- a/src/DesktopTests/Settings/SnapshotMetaInfoTests.cs
+++ b/src/DesktopTests/Settings/SnapshotMetaInfoTests.cs
@@ -3,8 +3,6 @@
 using System.IO;
 using Axe.Windows.Desktop.Settings;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.QualityTools.Testing.Fakes;
-using System.IO.Fakes;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 
@@ -100,16 +98,12 @@ namespace Axe.Windows.DesktopTests.Settings
 
         private static Dictionary<SnapshotMetaPropertyName, object> GetDeserializedProperties(Dictionary<SnapshotMetaPropertyName, object> inputProperties)
         {
-            using (ShimsContext.Create())
+            SnapshotMetaInfo info = new SnapshotMetaInfo(A11yFileMode.Contrast,"Test", 0, 0, inputProperties);
+            var text = JsonConvert.SerializeObject(info);
+            using (var testStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(text)))
             {
-                SnapshotMetaInfo info = new SnapshotMetaInfo(A11yFileMode.Contrast,"Test", 0, 0, inputProperties);
-                var text = JsonConvert.SerializeObject(info);
-                ShimStreamReader.AllInstances.ReadToEnd = (_) => { return text; };
-                using (var testStream = new MemoryStream())
-                {
-                    SnapshotMetaInfo metaInfo = SnapshotMetaInfo.DeserializeFromStream(testStream);
-                    return metaInfo.OtherProperties;
-                }
+                SnapshotMetaInfo metaInfo = SnapshotMetaInfo.DeserializeFromStream(testStream);
+                return metaInfo.OtherProperties;
             }
         }
 


### PR DESCRIPTION
#### Describe the change
Remove Fakes dependency from DesktopTests project. There was only 1 Shim being used, and by initializing a Stream with the test input, I could completely remove the need for the Shim. DesktopTests is now independent of Fakes

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



