### PR TITLE
Add new interface model for Axe.Windows.Automation

### DIFF
--- a/src/Automation/Automation.csproj
+++ b/src/Automation/Automation.csproj
@@ -62,6 +62,13 @@
   <ItemGroup>
     <Compile Include="$(TEMP)\A11yInsightsVersionInfo.cs" />
     <Compile Include="AutomationSession.cs" />
+    <Compile Include="AxeWindowsAutomationException.cs" />
+    <Compile Include="Data\Config.cs" />
+    <Compile Include="Data\ElementInfo.cs" />
+    <Compile Include="Data\ScanResult.cs" />
+    <Compile Include="Data\ScanResults.cs" />
+    <Compile Include="Enums\OutputFileFormat.cs" />
+    <Compile Include="Interfaces\IScanner.cs" />
     <Compile Include="PowerShell\AppDomainAdjuster.cs" />
     <Compile Include="Results\BaseCommandResult.cs" />
     <Compile Include="DisplayStrings.Designer.cs">
@@ -75,6 +82,8 @@
     <Compile Include="A11yAutomationException.cs" />
     <Compile Include="LocationHelper.cs" />
     <Compile Include="PowerShell\InvokeSnapshotCmdlet.cs" />
+    <Compile Include="Scanner.cs" />
+    <Compile Include="ScannerFactory.cs" />
     <Compile Include="SnapshotCommand.cs" />
     <Compile Include="Results\SnapshotCommandResult.cs" />
     <Compile Include="StartCommand.cs" />
@@ -92,6 +101,7 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="packages.config" />
+    <None Include="ReadMe.md" />
   </ItemGroup>
   <ItemGroup>
     <DropSignedFile Include="$(OutDir)\Axe.Windows.Automation.dll" />

--- a/src/Automation/AxeWindowsAutomationException.cs
+++ b/src/Automation/AxeWindowsAutomationException.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+namespace Axe.Windows.Automation
+{
+    /// <summary>
+    /// The exception type thrown for all unhandled errors in Axe.Windows.Automation.
+    /// If an exception was thrown from code not owned by Axe.Windows.Automation,
+    /// that exception will be wrapped in <see cref="AxeWindowsAutomationException"/>
+    /// In the <see cref="Exception.InnerException"/> property.
+    /// </summary>
+    public class AxeWindowsAutomationException : Exception
+    {
+        /// <summary>
+        /// Constructor taking a text description of the exception
+        /// </summary>
+        /// <param name="message">A text description of the exception</param>
+        public AxeWindowsAutomationException(string message)
+            : base(message)
+        { }
+    } // class
+} // namespace

--- a/src/Automation/Data/Config.cs
+++ b/src/Automation/Data/Config.cs
@@ -20,7 +20,8 @@ namespace Axe.Windows.Automation
         /// This value is ignored if <see cref="Config.OutputFileFormat"/> is set to <see cref="OutputFileFormat.None"/>.
         /// If this value is null, and if <see cref="Config.OutputFileFormat"/> is not set to <see cref="OutputFileFormat.None"/>,
         /// files will be written to a directory named "AxeWindowsScanResults" under the current directory.
-        /// If the value is not null, and the given directory does not exist, the automation session will throw an <see cref="AxeWindowsAutomationException"/>.
+        /// If the value is not null, and the given directory does not exist, the <see cref="IScanner"/> object will attempt to create it.
+        /// If the directory cannot be created, an <see cref="AxeWindowsAutomationException"/> will be thrown.
         /// </summary>
         /// <remarks>
         /// No output files will be written if no errors were found during the automation session.

--- a/src/Automation/Data/Config.cs
+++ b/src/Automation/Data/Config.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+namespace Axe.Windows.Automation
+{
+    /// <summary>
+    /// Configuration options for creating an AxeWindows automation session
+    /// </summary>
+    public class Config
+    {
+        /// <summary>
+        /// The process Id of the application to test.
+        /// If the value is invalid, the automation session will throw an <see cref="AxeWindowsAutomationException"/>.
+        /// </summary>
+        public int ProcessId { get; private set; }
+
+        /// <summary>
+        /// The directory to which any output files should be written.
+        /// This value is ignored if <see cref="Config.OutputFileFormat"/> is set to <see cref="OutputFileFormat.None"/>.
+        /// If this value is null, and if <see cref="Config.OutputFileFormat"/> is not set to <see cref="OutputFileFormat.None"/>,
+        /// files will be written to a directory named "AxeWindowsScanResults" under the current directory.
+        /// If the value is not null, and the given directory does not exist, the automation session will throw an <see cref="AxeWindowsAutomationException"/>.
+        /// </summary>
+        /// <remarks>
+        /// No output files will be written if no errors were found during the automation session.
+        /// </remarks>
+        public string OutputDirectory { get; private set; }
+
+        /// <summary>
+        /// Flags specifying the type of output file to create.
+        /// Multiple values may be specified using the '|' (or) operator
+        /// </summary>
+        /// <remarks>
+        /// No output files will be written if no errors were found during the automation session.
+        /// </remarks>
+        public OutputFileFormat OutputFileFormat { get; private set; }
+
+        private Config()
+        { }
+
+        /// <summary>
+        /// Builds an instance of the <see cref="Config"/> class
+        /// </summary>
+        public class Builder
+        {
+            private readonly Config _config;
+
+            private Builder(int processId)
+            {
+                _config = new Config();
+                _config.ProcessId = processId;
+            }
+
+            /// <summary>
+            /// Create the builder for the specified process
+            /// </summary>
+            /// <param name="processId"></param>
+            /// <returns></returns>
+            public static Builder ForProcessId(int processId)
+            {
+                return new Builder(processId);
+            }
+
+            /// <summary>
+            /// Specify the directory where any output files should be written
+            /// </summary>
+            /// <param name="directory"></param>
+            /// <returns></returns>
+            public Builder WithOutputDirectory(string directory)
+            {
+                _config.OutputDirectory = directory;
+                return this;
+            }
+
+            /// <summary>
+            /// Specify the type(s) of output files you wish AxeWindows to create
+            /// </summary>
+            /// <param name="format"></param>
+            /// <returns></returns>
+            public Builder WithOutputFileFormat(OutputFileFormat format)
+            {
+                _config.OutputFileFormat = format;
+                return this;
+            }
+
+            /// <summary>
+            /// Build an instance of <see cref="Config"/>
+            /// </summary>
+            /// <returns></returns>
+            public Config Build()
+            {
+                return _config;
+            }
+        } // Builder
+    } // class
+} // namespace

--- a/src/Automation/Data/ElementInfo.cs
+++ b/src/Automation/Data/ElementInfo.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+
+namespace Axe.Windows.Automation
+{
+    /// <summary>
+    /// Contains identifying information about an element
+    /// </summary>
+    public class ElementInfo
+    {
+        /// <summary>
+        /// This element's parent element.
+        /// </summary>
+        public ElementInfo Parent { get; internal set;  }
+
+        /// <summary>
+        /// A string to string dictionary where the key is a UIAutomation property name
+        /// and the value is the corresponding UI Automation property value.
+        /// </summary>
+        /// <remarks>
+        /// The key strings are likely to be very stable, so it will be safe to index certain keys
+        /// without fear of breaking changes.
+        /// Only properties with values set will be included.
+        /// </remarks>
+        public IReadOnlyDictionary<string, string> Properties { get; internal set; }
+
+        /// <summary>
+        /// A list of names of supported patterns
+        /// </summary>
+        /// <remarks>
+        /// The names are likely to be very stable.
+        /// </remarks>
+        public IEnumerable<string> Patterns { get; internal set; }
+    } // class
+} // namespace

--- a/src/Automation/Data/ScanResult.cs
+++ b/src/Automation/Data/ScanResult.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using Axe.Windows.Rules;
+
+namespace Axe.Windows.Automation
+{
+    /// <summary>
+    /// The result of a single rule test on a single element
+    /// </summary>
+    public class ScanResult
+    {
+        /// <summary>
+        /// Information about the rule that evaluated the element specified by <see cref="Element"/>
+        /// </summary>
+        public RuleInfo Rule { get; internal set; }
+
+        /// <summary>
+        /// The element which was tested against the rule specified in <see cref="Rule"/>
+        /// </summary>
+        public ElementInfo Element { get; internal set; }
+    } // class
+} // namespace

--- a/src/Automation/Data/ScanResults.cs
+++ b/src/Automation/Data/ScanResults.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+
+namespace Axe.Windows.Automation
+{
+    /// <summary>
+    /// Contains information about an AxeWindows automated scan
+    /// </summary>
+    public class ScanResults
+    {
+        /// <summary>
+        /// A Tuple with paths to any output files written as a result of a scan.
+        /// Tuple members are A11yTest and Sarif (not implemented yet)
+        /// </summary>
+        /// <remarks>
+        /// This property's members may be null if no output files were written.
+        /// That may happen if no <see cref="Config.OutputFileFormat"/> was specified
+        /// or was set to <see cref="OutputFileFormat.None"/>.
+        /// This property's members will also be null if no errors were found.
+        /// </remarks>
+        public (string A11yTest, string Sarif) OutputFile { get; internal set; }
+
+        /// <summary>
+        /// A count of all errors across all elements scanned.
+        /// </summary>
+        /// <remarks>
+        /// This may be useful as a simple test to determine if the number of errors between scans of the same area
+        /// of an application has increased or (hopefully) decreased.
+        /// </remarks>
+        public int ErrorCount { get; internal set; }
+
+        /// <summary>
+        /// A collection of errors found during the scan.
+        /// </summary>
+        /// <remarks>
+        /// Use this to get in-depth information about the rule + element combination for each error. 
+        /// </remarks>
+        public IEnumerable<ScanResult> Errors { get; internal set; }
+    } // class 
+} // namespace

--- a/src/Automation/Enums/OutputFileFormat.cs
+++ b/src/Automation/Enums/OutputFileFormat.cs
@@ -5,7 +5,7 @@ using System;
 namespace Axe.Windows.Automation
 {
     /// <summary>
-    /// Bit flags to specify which output file formats an automation session should write
+    /// Bit flags to specify which output file formats a <see cref="IScanner"/> should write
     /// </summary>
     [Flags]
     public enum OutputFileFormat

--- a/src/Automation/Enums/OutputFileFormat.cs
+++ b/src/Automation/Enums/OutputFileFormat.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+namespace Axe.Windows.Automation
+{
+    /// <summary>
+    /// Bit flags to specify which output file formats an automation session should write
+    /// </summary>
+    [Flags]
+    public enum OutputFileFormat
+    {
+        /// <summary>
+        /// Create no output files
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Create output files which can be opened using <see href="https://accessibilityinsights.io/docs/en/windows/overview">Accessibility Insights for Windows</see>.
+        /// </summary>
+        A11yTest = 1,
+    } // enum
+} // namespace

--- a/src/Automation/Interfaces/IScanner.cs
+++ b/src/Automation/Interfaces/IScanner.cs
@@ -17,7 +17,7 @@ namespace Axe.Windows.Automation
         /// output files may be written to the specified directory.
         /// (Note: no output files will be written if no errors were found.)
         /// An exception may be thrown if the value of <see cref="Config.ProcessId"/> is invalid
-        /// or if the directory provided in <see cref="Config.OutputDirectory"/> does not exist.
+        /// or if the directory provided in <see cref="Config.OutputDirectory"/> cannot be created or accessed.
         /// All exceptions are wrapped in <see cref="AxeWindowsAutomationException"/>.
         /// If the exception was not thrown by AxeWindows automation, the <see cref="Exception.InnerException"/> property
         /// will contain the exception.

--- a/src/Automation/Interfaces/IScanner.cs
+++ b/src/Automation/Interfaces/IScanner.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+namespace Axe.Windows.Automation
+{
+    /// <summary>
+    /// Runs AxeWindows automated tests
+    /// </summary>
+    public interface IScanner
+    {
+        /// <summary>
+        /// Run AxeWindows automated tests
+        /// </summary>
+        /// <remarks>
+        /// If a value was provided in <see cref="Config.OutputDirectory"/>,
+        /// output files may be written to the specified directory.
+        /// (Note: no output files will be written if no errors were found.)
+        /// An exception may be thrown if the value of <see cref="Config.ProcessId"/> is invalid
+        /// or if the directory provided in <see cref="Config.OutputDirectory"/> does not exist.
+        /// All exceptions are wrapped in <see cref="AxeWindowsAutomationException"/>.
+        /// If the exception was not thrown by AxeWindows automation, the <see cref="Exception.InnerException"/> property
+        /// will contain the exception.
+        /// </remarks>
+        /// <returns>Information about the scan and any issues detected</returns>
+        /// <exception cref="AxeWindowsAutomationException"/>
+        ScanResults Scan();
+    } // interface
+} // namespace

--- a/src/Automation/ReadMe.md
+++ b/src/Automation/ReadMe.md
@@ -1,0 +1,65 @@
+﻿When looking at the workflow of this project, please start at
+`AutomationFactory.CreateAutomationSessionFactory`.
+
+## Compatibility practices
+
+The set of public interfaces defined in this project constitutes the
+requirements to run an AxeWindows automated scan of a given application
+and take action on the errors detected by the scan. We expect  the set
+of interfaces will grow as the requirements grow. Ideally, customers could
+update to new versions of the Axe.Windows package, taking advantage of rule
+improvements or updated element properties for example, without having to modify
+their code. To that end, the following sections describe types of
+changes to the interfaces.
+
+### Considerations
+
+Because this library is a strong-named .Net assembly, we can be sure 
+the code that depends on it will always link to the expected 
+version of the dll at runtime. The benefit is that we don't need 
+to design for the situation where the calling code might unintentionally link to a newer or older version of this assembly. 
+
+### Types of changes
+
+The following sections describe the three types of changes for
+[semantic versioning](https://semver.org/)
+as they relate to the public set of interfaces in this assembly.
+
+#### Non-breaking changes
+
+As long as the interfaces themselves have not changed, changes to this
+assembly **may** be considered non-breaking. It's conceivable  that changes
+to code behind the interfaces could be considered a feature or a
+breaking change. But to be considered a non-breaking change, the interfaces
+**must not** be modified in any way.
+
+#### Features
+
+The following modifications to the interfaces **must** at least be
+considered feature changes:
+
+- The addition of new methods or properties on an existing interface
+- The addition of a new interface
+
+These changes are additions to existing functionality which will not force
+package consumers to update their code. But of course, if these types
+of changes are combined with any breaking changes, the changes **must**
+be considered breaking.
+
+#### Breaking changes
+
+The following modifications to the interfaces **must** be
+considered breaking changes:
+
+- Deleted methods or properties
+- Changes to existing method or property signatures.
+
+### Relational Results Data
+
+Scan results data has been organized relationally to minimize the
+possible ripple effects of changing any single type of data. This is mainly
+done in the `IAutomationScanResult` interface. The interface contains only 
+the ids of a rule and an element. Therefore, the `IElementInfo` interface
+and the `IRuleInfo` interface can change completely independenly.
+And of course, unless something drastic happens, the `IAutomationScanResult` interface doesn't need to change.
+This has the added benefit of not duplicating data unnecessarily in memory.

--- a/src/Automation/Scanner.cs
+++ b/src/Automation/Scanner.cs
@@ -5,7 +5,7 @@ using System;
 namespace Axe.Windows.Automation
 {
     /// <summary>
-    /// Implementation of IScanner
+    /// Implementation of <see cref="IScanner"/>
     /// </summary>
     class Scanner : IScanner
     {

--- a/src/Automation/Scanner.cs
+++ b/src/Automation/Scanner.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+namespace Axe.Windows.Automation
+{
+    /// <summary>
+    /// Implementation of IScanner
+    /// </summary>
+    class Scanner : IScanner
+    {
+        private readonly Config _config;
+
+        internal Scanner(Config config)
+        {
+            if (config == null) throw new ArgumentNullException(nameof(config));
+
+            _config = config;
+        }
+
+        /// <summary>
+        /// See <see cref="IScanner.Scan"/>
+        /// </summary>
+        /// <returns></returns>
+        public ScanResults Scan()
+        {
+            throw new NotImplementedException();
+        }
+    } // class
+} // namespace

--- a/src/Automation/ScannerFactory.cs
+++ b/src/Automation/ScannerFactory.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+namespace Axe.Windows.Automation
+{
+    /// <summary>
+    /// Create objects that implement IScanner
+    /// </summary>
+    public static class ScannerFactory
+    {
+        /// <summary>
+        /// Create an object that implements IScanner
+        /// </summary>
+        /// <param name="config"></param>
+        /// <returns></returns>
+        public static IScanner CreateScanner(Config config)
+        {
+            return new Scanner(config);
+        }
+    } // class
+} // namespace

--- a/src/AutomationTests/SnapshotCommandUnitTests.cs
+++ b/src/AutomationTests/SnapshotCommandUnitTests.cs
@@ -17,6 +17,9 @@ using Microsoft.QualityTools.Testing.Fakes;
 
 namespace Axe.Windows.AutomationTests
 {
+    using ScanResult = Axe.Windows.Core.Results.ScanResult;
+    using ScanResults = Axe.Windows.Core.Results.ScanResults;
+
     [TestClass]
     public class SnapshotCommandUnitTests
     {

--- a/src/AutomationTests/StartCommandUnitTests.cs
+++ b/src/AutomationTests/StartCommandUnitTests.cs
@@ -22,7 +22,8 @@ namespace Axe.Windows.AutomationTests
             {
                 int callsToNewInstance = 0;
 
-                ShimAutomationSession.NewInstanceCommandParameters = (_) =>
+                ShimAutomationSession.
+                    NewInstanceCommandParameters = (_) =>
                 {
                     callsToNewInstance++;
                     return new ShimAutomationSession();


### PR DESCRIPTION
#### Describe the change

The model has not been implemented yet, except for the Config class and the ScannerFactory class.

Changes since the last design review:
- Change ScanResult.OutputFiles from an IEnumerable to a Tuple: (string A11yTest, string Sarif) so that output files are grouped together, but still distinguishable by type
- Removed Scanner.Builder and created ScannerFactory since creating new objects which implement a specific interface is the job of a factory. It also hides the implementation of Scanner entirely.
- For the returned data classes, changed private access to internal access because we don't need to manage construction of these classes with a builder.


> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



