### PR TITLE
Remove "Microsoft." from Axe.Windows package name

### DIFF
--- a/docs/Automation.md
+++ b/docs/Automation.md
@@ -159,7 +159,7 @@ CommandConstStrings.TeamName | “TeamName” | Value for Team name in telemetry
 
 ### Using the assembly
 You can get the files via a NuGet package Configure NuGet to retrieve the
-**Microsoft.Axe.Windows** package from
+**Axe.Windows** package from
 <https://api.nuget.org/v3/index.json>,
 then use the classes in the Axe.Windows.Automation namespace (see
 examples below):

--- a/src/CI/Axe.Windows.nuspec
+++ b/src/CI/Axe.Windows.nuspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package>
   <metadata>
-    <id>Microsoft.Axe.Windows</id>
+    <id>Axe.Windows</id>
     <version>$VersionString$</version>
     <title>axe-windows</title>
     <summary>Automated accessibility analysis for Windows applications</summary>

--- a/src/CI/CI.csproj
+++ b/src/CI/CI.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="Microsoft.Axe.Windows.nuspec">
+    <None Include="Axe.Windows.nuspec">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
@@ -54,7 +54,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Condition=" '$(MAICreateNuget)' == 'true' " Name="Pack" AfterTargets="Build">
-    <Exec Command="nuget.exe pack -properties Configuration=$(Configuration);VersionString=&quot;$(SemVerNumber)$(SemVerSuffix)&quot; Microsoft.Axe.Windows.nuspec -OutputDirectory bin\$(Configuration)\NuGet\$(SemVerNumber)$(SemVerSuffix) -NonInteractive" />
+    <Exec Command="nuget.exe pack -properties Configuration=$(Configuration);VersionString=&quot;$(SemVerNumber)$(SemVerSuffix)&quot; Axe.Windows.nuspec -OutputDirectory bin\$(Configuration)\NuGet\$(SemVerNumber)$(SemVerSuffix) -NonInteractive" />
   </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -66,7 +66,7 @@
   <Import Project="..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" Condition="Exists('..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" />
   <Target Name="SignNuGetPackage" Condition=" '$(MicroBuild_NuPkgSigningEnabled)' != 'false' and '$(MicroBuild_SigningEnabled)' == 'true' and '$(IsPackable)' == 'true' and '$(NonShipping)' != 'true' and '$(SignType)' != '' and '$(SignAppForRelease)'=='true' and '$(Configuration)' == 'Release'" DependsOnTargets="@(SignNuGetPackageDependsOn)" AfterTargets="Pack">
     <ItemGroup>
-      <SignNuGetPackFiles Include="bin\$(Configuration)\NuGet\$(SemVerNumber)$(SemVerSuffix)\Microsoft.Axe.Windows.$(SemVerNumber)$(SemVerSuffix).nupkg" />
+      <SignNuGetPackFiles Include="bin\$(Configuration)\NuGet\$(SemVerNumber)$(SemVerSuffix)\Axe.Windows.$(SemVerNumber)$(SemVerSuffix).nupkg" />
     </ItemGroup>
     <SignFiles Files="@(SignNuGetPackFiles)" Type="$(SignType)" BinariesDirectory="$(OutputPath)" IntermediatesDirectory="$(IntermediateOutputPath)" ESRPSigning="$(ESRPSigning)" UseBearerToken="$(UseBearerToken)" Condition=" '@(SignNuGetPackFiles)' != '' " />
   </Target>


### PR DESCRIPTION
#### Describe the change

This decision was based on Microsoft's collaboration with the open source community. 

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



