### PR TITLE
Replace error return values with AxeWindowsAutomationException

### DIFF
--- a/src/Automation/ExecutionWrapper.cs
+++ b/src/Automation/ExecutionWrapper.cs
@@ -13,9 +13,8 @@ namespace Axe.Windows.Automation
         /// Synchronously (and blocking) execute the passed-in command, handling errors appropriately
         /// </summary>
         /// <param name="command">The command to execute</param>
-        /// <param name="errorFactory">The factory to create the appropriate error object</param>
         /// <returns>An object of Type T that describes the command result</returns>
-        internal static T ExecuteCommand<T>(Func<T> command, Func<string, T> errorFactory)
+        internal static T ExecuteCommand<T>(Func<T> command)
         {
             lock (lockObject)
             {
@@ -23,23 +22,14 @@ namespace Axe.Windows.Automation
                 {
                     return command();
                 }
+                catch (AxeWindowsAutomationException ex)
+                {
+                    throw ex;
+                }
                 catch (Exception ex)
                 {
-                    // No need to report this Exception, since telemetry is not available in automation
-                    string errorDetail;
-
-                    AxeWindowsAutomationException automationException = ex as AxeWindowsAutomationException;
-
-                    if (automationException == null)
-                    {
-                        errorDetail = string.Format(CultureInfo.InvariantCulture, DisplayStrings.ErrorUnhandledExceptionFormat, ex.ToString());
-                    }
-                    else
-                    {
-                        errorDetail = automationException.Message;
-                    }
-
-                    return errorFactory(errorDetail);
+                    string message = string.Format(CultureInfo.InvariantCulture, DisplayStrings.ErrorUnhandledExceptionFormat, ex.ToString());
+                    throw new AxeWindowsAutomationException(message, ex);
                 }
             }
         }

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -112,8 +112,7 @@ namespace Axe.Windows.Automation
                     }
                 }
                 throw new AxeWindowsAutomationException(DisplayStrings.ErrorUnableToSetDataContext);
-            },
-            ErrorCommandResultFactory);
+            });
         }
 
         /// <summary>
@@ -156,15 +155,6 @@ namespace Axe.Windows.Automation
                     AccumulateScanResults(accumulator, child);
                 }
             }
-        }
-
-        private static SnapshotCommandResult ErrorCommandResultFactory(string errorDetail)
-        {
-            return new SnapshotCommandResult
-            {
-                Completed = false,
-                SummaryMessage = errorDetail,
-            };
         }
     }
 }

--- a/src/Automation/StartCommand.cs
+++ b/src/Automation/StartCommand.cs
@@ -29,17 +29,7 @@ namespace Axe.Windows.Automation
                     SummaryMessage = DisplayStrings.SuccessStart,
                     Succeeded = true,
                 };
-            }, ErrorCommandResultFactory);
-        }
-
-        private static StartCommandResult ErrorCommandResultFactory(string errorDetail)
-        {
-            return new StartCommandResult
-            {
-                Completed = false,
-                SummaryMessage = errorDetail,
-                Succeeded = false,
-            };
+            });
         }
     }
 }

--- a/src/Automation/StopCommand.cs
+++ b/src/Automation/StopCommand.cs
@@ -24,7 +24,7 @@ namespace Axe.Windows.Automation
                     SummaryMessage = DisplayStrings.SuccessStop,
                     Succeeded = true,
                 };
-            }, ErrorCommandResultFactory);
+            });
         }
 
         private static StopCommandResult ErrorCommandResultFactory(string errorDetail)

--- a/src/AutomationTests/ExecutionWrapperUnitTests.cs
+++ b/src/AutomationTests/ExecutionWrapperUnitTests.cs
@@ -26,56 +26,55 @@ namespace Axe.Windows.AutomationTests
 
         [TestMethod]
         [Timeout (5000)]
-        public void ExecuteCommand_CommandIsNull_CallsErrorFactory_Automation003InDetail()
+        public void ExecuteCommand_CommandIsNull_ThrowsInnerNullReferenceException_Automation003InMessage()
         {
-            TestResult result = ExecutionWrapper.ExecuteCommand<TestResult>(
-                null,
-                (errorDetail) =>
-                {
-                    return new TestResult(errorDetail, true);
-                });
-
-            Assert.IsTrue(result.IsError);
-            Assert.IsTrue(result.Detail.Contains(" Automation003:"));
-            Assert.IsTrue(result.Detail.Contains("System.NullReferenceException"));
+            try
+            {
+                ExecutionWrapper.ExecuteCommand<TestResult>(null);
+            }
+            catch (AxeWindowsAutomationException ex)
+            {
+                Assert.IsInstanceOfType(ex.InnerException, typeof(NullReferenceException));
+                Assert.IsTrue(ex.Message.Contains(" Automation003:"));
+            }
         }
 
         [TestMethod]
         [Timeout (1000)]
-        public void ExecuteCommand_CommandThrowsNonAutomationException_CallsErrorFactory_Automation003InDetail()
+        public void ExecuteCommand_CommandThrowsNonAutomationException_WrapsInAutomationException_Automation003InMessage()
         {
-            TestResult result = ExecutionWrapper.ExecuteCommand<TestResult>(
-                () =>
-                {
-                    throw new ArgumentException(TestString);
-                },
-                (errorDetail) =>
-                {
-                    return new TestResult(errorDetail, true);
-                });
-
-            Assert.IsTrue(result.IsError);
-            Assert.IsTrue(result.Detail.Contains(" Automation003:"));
-            Assert.IsTrue(result.Detail.Contains("System.ArgumentException"));
-            Assert.IsTrue(result.Detail.Contains(TestString));
+            try
+            {
+                ExecutionWrapper.ExecuteCommand<TestResult>(
+                    () =>
+                    {
+                        throw new ArgumentException(TestString);
+                    });
+            }
+            catch (AxeWindowsAutomationException ex)
+            {
+                Assert.IsInstanceOfType(ex.InnerException, typeof(ArgumentException));
+                Assert.IsTrue(ex.Message.Contains(" Automation003:"));
+                Assert.IsTrue(ex.Message.Contains(TestString));
+            }
         }
 
         [TestMethod]
         [Timeout (1000)]
-        public void ExecuteCommand_CommandThrowsAutomationException_CallsErrorFactory_Automation003InDetail()
+        public void ExecuteCommand_CommandThrowsAutomationException_TestStringInMessage()
         {
-            TestResult result = ExecutionWrapper.ExecuteCommand<TestResult>(
+            try
+            {
+                ExecutionWrapper.ExecuteCommand<TestResult>(
                 () =>
                 {
                     throw new AxeWindowsAutomationException(TestString);
-                },
-                (errorDetail) =>
-                {
-                    return new TestResult(errorDetail, true);
                 });
-
-            Assert.IsTrue(result.IsError);
-            Assert.AreEqual(TestString, result.Detail);
+            }
+            catch (AxeWindowsAutomationException ex)
+            {
+                Assert.AreEqual(TestString, ex.Message);
+            }
         }
 
         [TestMethod]
@@ -83,8 +82,7 @@ namespace Axe.Windows.AutomationTests
         public void ExecuteCommand_CommandReturnsObject_SameObjectIsReturnedToCaller()
         {
             TestResult result = ExecutionWrapper.ExecuteCommand<TestResult>(
-                () => new TestResult(TestString),
-                null);
+                () => new TestResult(TestString));
 
             Assert.AreEqual(TestString, result.Detail);
         }

--- a/src/AutomationTests/SnapshotCommandUnitTests.cs
+++ b/src/AutomationTests/SnapshotCommandUnitTests.cs
@@ -100,7 +100,7 @@ namespace Axe.Windows.AutomationTests
 #if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(2000)]
-        public void Execute_AutomationSessionInstanceThrowsAutomationException_ReturnsIncomplete_MessageMatchesException()
+        public void Execute_AutomationSessionInstanceThrowsAutomationException_MessageMatchesException()
         {
             using (ShimsContext.Create())
             {
@@ -114,10 +114,16 @@ namespace Axe.Windows.AutomationTests
 
                 InitializeShims();
 
-                SnapshotCommandResult result = SnapshotCommand.Execute(new Dictionary<string, string>());
+                try
+                {
+                    SnapshotCommandResult result = SnapshotCommand.Execute(new Dictionary<string, string>());
+                }
+                catch (AxeWindowsAutomationException ex)
+                {
+                    Assert.IsTrue(ex.Message.Contains(TestMessage));
+                }
 
                 Assert.AreEqual(1, callsToInstance);
-                AssertIncompleteResult(result, TestMessage);
             }
         }
 
@@ -146,16 +152,22 @@ namespace Axe.Windows.AutomationTests
 
                 InitializeShims(populateLocationHelper: false);
 
-                SnapshotCommandResult result = SnapshotCommand.Execute(new Dictionary<string, string>());
+                try
+                {
+                    SnapshotCommandResult result = SnapshotCommand.Execute(new Dictionary<string, string>());
+                }
+                catch (AxeWindowsAutomationException ex)
+                {
+                    Assert.AreEqual(TestMessage, ex.InnerException.Message);
+                }
 
                 Utilities.AssertEqual(expectedParameters.ConfigCopy, actualParameters.ConfigCopy);
-                AssertIncompleteResult(result, TestMessage, false);
             }
         }
 
         [TestMethod]
         [Timeout(2000)]
-        public void Execute_UnableToSelectCandidateElement_ReturnsIncomplete_ErrorAutomation008()
+        public void Execute_UnableToSelectCandidateElement_ThrowsAutomationException_ErrorAutomation008()
         {
             using (ShimsContext.Create())
             {
@@ -167,15 +179,20 @@ namespace Axe.Windows.AutomationTests
 
                 InitializeShims(selectAction:selectAction, populateLocationHelper: false, enableRetention: true, shimTargetElementLocator: true);
 
-                SnapshotCommandResult result = SnapshotCommand.Execute(new Dictionary<string, string>());
-
-                AssertIncompleteResult(result, " Automation008:", false);
+                try
+                {
+                    SnapshotCommandResult result = SnapshotCommand.Execute(new Dictionary<string, string>());
+                }
+                catch (AxeWindowsAutomationException ex)
+                {
+                    Assert.IsTrue(ex.Message.Contains(" Automation008:"));
+                }
             }
         }
 
         [TestMethod]
         [Timeout(2000)]
-        public void Execute_UnableToSetTestModeDataContext_ReturnsIncomplete_ErrorAutomation008()
+        public void Execute_UnableToSetTestModeDataContext_ThrowsAutomationException_ErrorAutomation008()
         {
             using (ShimsContext.Create())
             {
@@ -189,15 +206,20 @@ namespace Axe.Windows.AutomationTests
                 InitializeShims(populateLocationHelper: false, enableRetention: true, shimTargetElementLocator: true,
                     shimUiFramework: true, setTestModeSucceeds: false);
 
-                SnapshotCommandResult result = SnapshotCommand.Execute(new Dictionary<string, string>());
-
-                AssertIncompleteResult(result, " Automation008:", false);
+                try
+                {
+                    SnapshotCommandResult result = SnapshotCommand.Execute(new Dictionary<string, string>());
+                }
+                catch (System.Exception ex)
+                {
+                    Assert.IsTrue(ex.Message.Contains(" Automation008:"));
+                }
             }
         }
 
         [TestMethod]
         [Timeout(2000)]
-        public void Execute_NoScanResultsInPOI_ReturnsIncomplete_ErrorAutomation012()
+        public void Execute_NoScanResultsInPOI_ThrowsAutomationException_ErrorAutomation012()
         {
             using (ShimsContext.Create())
             {
@@ -212,15 +234,20 @@ namespace Axe.Windows.AutomationTests
                     selectAction: selectAction, elementBoundExceeded: false, shimUiFramework: true,
                     setTestModeSucceeds: true);
 
-                SnapshotCommandResult result = SnapshotCommand.Execute(new Dictionary<string, string>());
-
-                AssertIncompleteResult(result, " Automation012:", false);
+                try
+                {
+                    SnapshotCommandResult result = SnapshotCommand.Execute(new Dictionary<string, string>());
+                }
+                catch (AxeWindowsAutomationException ex)
+                {
+                    Assert.IsTrue(ex.Message.Contains(" Automation012:"));
+                }
             }
         }
 
         [TestMethod]
         [Timeout(2000)]
-        public void Execute_UpperBoundIsReached_ReturnsIncomplete_ErrorAutomation017()
+        public void Execute_UpperBoundIsReached_ThrowsAutomationException_ErrorAutomation017()
         {
             using (ShimsContext.Create())
             {
@@ -236,9 +263,14 @@ namespace Axe.Windows.AutomationTests
                     selectAction: selectAction, elementBoundExceeded: true, shimUiFramework: true,
                     setTestModeSucceeds: true);
 
-                SnapshotCommandResult result = SnapshotCommand.Execute(new Dictionary<string, string>());
-
-                AssertIncompleteResult(result, " Automation017:", false);
+                try
+                {
+                    SnapshotCommandResult result = SnapshotCommand.Execute(new Dictionary<string, string>());
+                }
+                catch (System.Exception ex)
+                {
+                    Assert.IsTrue(ex.Message.Contains(" Automation017:"));
+                }
             }
         }
 

--- a/src/AutomationTests/StartCommandUnitTests.cs
+++ b/src/AutomationTests/StartCommandUnitTests.cs
@@ -53,12 +53,16 @@ namespace Axe.Windows.AutomationTests
                     throw new AxeWindowsAutomationException(exceptionMessage);
                 };
 
-                StartCommandResult result = StartCommand.Execute(new Dictionary<string, string>(), string.Empty);
+                try
+                {
+                    StartCommandResult result = StartCommand.Execute(new Dictionary<string, string>(), string.Empty);
+                }
+                catch (AxeWindowsAutomationException ex)
+                {
+                    Assert.AreEqual(exceptionMessage, ex.Message);
+                }
 
                 Assert.AreEqual(1, callsToNewInstance);
-                Assert.AreEqual(false, result.Completed);
-                Assert.AreEqual(false, result.Succeeded);
-                Assert.AreEqual(exceptionMessage, result.SummaryMessage);
             }
         }
 #endif

--- a/src/AutomationTests/StopCommandUnitTests.cs
+++ b/src/AutomationTests/StopCommandUnitTests.cs
@@ -37,7 +37,7 @@ namespace Axe.Windows.AutomationTests
 
         [TestMethod]
         [Timeout (1000)]
-        public void Execute_ClearInstanceThrowsAutomationException_ReturnsFailedResult()
+        public void Execute_ClearInstanceThrowsAutomationExceptionWithExpectedMessage()
         {
             const string exceptionMessage = "Hello from your local exception!";
 
@@ -51,12 +51,16 @@ namespace Axe.Windows.AutomationTests
                     throw new AxeWindowsAutomationException(exceptionMessage);
                 };
 
-                StopCommandResult result = StopCommand.Execute();
+                try
+                {
+                    StopCommand.Execute();
+                }
+                catch (AxeWindowsAutomationException ex)
+                {
+                    Assert.AreEqual(exceptionMessage, ex.Message);
+                }
 
                 Assert.AreEqual(1, callsToClearInstance);
-                Assert.AreEqual(false, result.Completed);
-                Assert.AreEqual(false, result.Succeeded);
-                Assert.AreEqual(exceptionMessage, result.SummaryMessage);
             }
         }
 #endif


### PR DESCRIPTION
#### Describe the change

We originally returned error messages in the results objects because it was thought that PowerShell couldn't handle exceptions. But it turns out PowerShell is fine with exceptions; so we can simply throw them and not return invalid data.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



