### PR TITLE
Make ScanResultsAssembler non-static and add interface

### DIFF
--- a/src/Automation/Automation.csproj
+++ b/src/Automation/Automation.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Data\ScanResults.cs" />
     <Compile Include="Enums\OutputFileFormat.cs" />
     <Compile Include="Interfaces\IScanner.cs" />
+    <Compile Include="Interfaces\IScanResultsAssembler.cs" />
     <Compile Include="Results\BaseCommandResult.cs" />
     <Compile Include="DisplayStrings.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Automation/Interfaces/IScanResultsAssembler.cs
+++ b/src/Automation/Interfaces/IScanResultsAssembler.cs
@@ -2,12 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 
-namespace Axe.Windows.Automation.Interfaces
+namespace Axe.Windows.Automation
 {
     /// <summary>
     /// Provides methods used to assemble a <see cref="ScanResults"/> object
     /// </summary>
-    public interface IScanResultsAssembler
+    internal interface IScanResultsAssembler
     {
         /// <summary>
         /// Assembles failed scans from the provided element

--- a/src/Automation/Interfaces/IScanResultsAssembler.cs
+++ b/src/Automation/Interfaces/IScanResultsAssembler.cs
@@ -1,0 +1,17 @@
+﻿using Axe.Windows.Core.Bases;
+
+namespace Axe.Windows.Automation.Interfaces
+{
+    /// <summary>
+    /// Provides methods used to assemble a <see cref="ScanResults"/> object
+    /// </summary>
+    public interface IScanResultsAssembler
+    {
+        /// <summary>
+        /// Assembles failed scans from the provided element
+        /// </summary>
+        /// <param name="element">Root element from which scan results will be assembled</param>
+        /// <returns>A ScanResults object containing the relevant errors and error count</returns>
+        ScanResults AssembleScanResultsFromElement(A11yElement element);
+    }
+}

--- a/src/Automation/Interfaces/IScanResultsAssembler.cs
+++ b/src/Automation/Interfaces/IScanResultsAssembler.cs
@@ -1,4 +1,6 @@
-﻿using Axe.Windows.Core.Bases;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
 
 namespace Axe.Windows.Automation.Interfaces
 {

--- a/src/Automation/ScanResultsAssembler.cs
+++ b/src/Automation/ScanResultsAssembler.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Automation.Interfaces;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Results;
 using System;
@@ -11,14 +12,14 @@ namespace Axe.Windows.Automation
     /// <summary>
     /// Provides methods used to assemble a <see cref="ScanResults"/> object
     /// </summary>
-    public static class ScanResultsAssembler
+    public class ScanResultsAssembler : IScanResultsAssembler
     {
         /// <summary>
         /// Assembles failed scans from the provided element
         /// </summary>
         /// <param name="element">Root element from which scan results will be assembled</param>
         /// <returns>A ScanResults object containing the relevant errors and error count</returns>
-        public static ScanResults AssembleScanResultsFromElement(A11yElement element)
+        public ScanResults AssembleScanResultsFromElement(A11yElement element)
         {
             var errors = new List<ScanResult>();
 
@@ -37,7 +38,7 @@ namespace Axe.Windows.Automation
         /// <param name="errors">Where the <see cref="ScanResult"/> objects created from errors will be added</param>
         /// <param name="element">Root element from which errors will be assembled</param>
         /// <param name="parent">The parent of element</param>
-        internal static void AssembleErrorsFromElement(List<ScanResult> errors, A11yElement element, ElementInfo parent)
+        internal void AssembleErrorsFromElement(List<ScanResult> errors, A11yElement element, ElementInfo parent)
         {
             if (errors == null) throw new ArgumentNullException(nameof(errors));
 
@@ -64,7 +65,7 @@ namespace Axe.Windows.Automation
             }
         }
 
-        private static ElementInfo MakeElementInfoFromElement(A11yElement element, ElementInfo parent)
+        private ElementInfo MakeElementInfoFromElement(A11yElement element, ElementInfo parent)
         {
             return new ElementInfo
             {
@@ -74,7 +75,7 @@ namespace Axe.Windows.Automation
             };
         }
 
-        private static IEnumerable<RuleResult> GetFailedRuleResultsFromElement(A11yElement element)
+        private IEnumerable<RuleResult> GetFailedRuleResultsFromElement(A11yElement element)
         {
            return from scanResult in element.ScanResults.Items
                   where scanResult.Status == ScanStatus.Fail

--- a/src/Automation/ScanResultsAssembler.cs
+++ b/src/Automation/ScanResultsAssembler.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Automation.Interfaces;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Results;
 using System;
@@ -12,7 +11,7 @@ namespace Axe.Windows.Automation
     /// <summary>
     /// Provides methods used to assemble a <see cref="ScanResults"/> object
     /// </summary>
-    public class ScanResultsAssembler : IScanResultsAssembler
+    internal class ScanResultsAssembler : IScanResultsAssembler
     {
         /// <summary>
         /// Assembles failed scans from the provided element
@@ -38,7 +37,7 @@ namespace Axe.Windows.Automation
         /// <param name="errors">Where the <see cref="ScanResult"/> objects created from errors will be added</param>
         /// <param name="element">Root element from which errors will be assembled</param>
         /// <param name="parent">The parent of element</param>
-        internal void AssembleErrorsFromElement(List<ScanResult> errors, A11yElement element, ElementInfo parent)
+        internal static void AssembleErrorsFromElement(List<ScanResult> errors, A11yElement element, ElementInfo parent)
         {
             if (errors == null) throw new ArgumentNullException(nameof(errors));
 
@@ -65,7 +64,7 @@ namespace Axe.Windows.Automation
             }
         }
 
-        private ElementInfo MakeElementInfoFromElement(A11yElement element, ElementInfo parent)
+        private static ElementInfo MakeElementInfoFromElement(A11yElement element, ElementInfo parent)
         {
             return new ElementInfo
             {
@@ -75,7 +74,7 @@ namespace Axe.Windows.Automation
             };
         }
 
-        private IEnumerable<RuleResult> GetFailedRuleResultsFromElement(A11yElement element)
+        private static IEnumerable<RuleResult> GetFailedRuleResultsFromElement(A11yElement element)
         {
            return from scanResult in element.ScanResults.Items
                   where scanResult.Status == ScanStatus.Fail

--- a/src/AutomationTests/ScanResultsAssemblerTests.cs
+++ b/src/AutomationTests/ScanResultsAssemblerTests.cs
@@ -15,6 +15,8 @@ namespace Axe.Windows.AutomationTests
     [TestClass()]
     public class ScanResultsAssemblerTests
     {
+        ScanResultsAssembler assembler = new ScanResultsAssembler();
+
         [TestMethod]
         [Timeout(2000)]
         public void AssembleScanResultsFromElement_AssemblesErrors()
@@ -34,7 +36,7 @@ namespace Axe.Windows.AutomationTests
                 Properties = element.Children[0].Properties.ToDictionary(p => p.Value.Name, p => p.Value.TextValue)
             };
 
-            var scanResults = ScanResultsAssembler.AssembleScanResultsFromElement(element);
+            var scanResults = assembler.AssembleScanResultsFromElement(element);
 
             var errors = scanResults.Errors.ToList();
 
@@ -82,7 +84,7 @@ namespace Axe.Windows.AutomationTests
         {
             A11yElement element = UnitTestSharedLibrary.Utility.LoadA11yElementsFromJSON("Snapshots/MonsterEdit.snapshot");
 
-            var scanResults = ScanResultsAssembler.AssembleScanResultsFromElement(element);
+            var scanResults = assembler.AssembleScanResultsFromElement(element);
 
             // if there were no rule violations, there should be no results.
             Assert.AreEqual(0, scanResults.ErrorCount);
@@ -95,7 +97,7 @@ namespace Axe.Windows.AutomationTests
         {
             A11yElement element = new A11yElement() { ScanResults = null };
 
-            Assert.ThrowsException<ArgumentNullException>(() => ScanResultsAssembler.AssembleErrorsFromElement(null, element, null));
+            Assert.ThrowsException<ArgumentNullException>(() => assembler.AssembleErrorsFromElement(null, element, null));
         }
 
         [TestMethod]
@@ -104,7 +106,7 @@ namespace Axe.Windows.AutomationTests
         {
             var errors = new List<Automation.ScanResult>();
 
-            Assert.ThrowsException<ArgumentNullException>(() => ScanResultsAssembler.AssembleErrorsFromElement(errors, null, null));
+            Assert.ThrowsException<ArgumentNullException>(() => assembler.AssembleErrorsFromElement(errors, null, null));
         }
 
         private List<RuleId> GetExpectedRuleIDs() => new List<RuleId>()

--- a/src/AutomationTests/ScanResultsAssemblerTests.cs
+++ b/src/AutomationTests/ScanResultsAssemblerTests.cs
@@ -97,7 +97,7 @@ namespace Axe.Windows.AutomationTests
         {
             A11yElement element = new A11yElement() { ScanResults = null };
 
-            Assert.ThrowsException<ArgumentNullException>(() => assembler.AssembleErrorsFromElement(null, element, null));
+            Assert.ThrowsException<ArgumentNullException>(() => ScanResultsAssembler.AssembleErrorsFromElement(null, element, null));
         }
 
         [TestMethod]
@@ -106,7 +106,7 @@ namespace Axe.Windows.AutomationTests
         {
             var errors = new List<Automation.ScanResult>();
 
-            Assert.ThrowsException<ArgumentNullException>(() => assembler.AssembleErrorsFromElement(errors, null, null));
+            Assert.ThrowsException<ArgumentNullException>(() => ScanResultsAssembler.AssembleErrorsFromElement(errors, null, null));
         }
 
         private List<RuleId> GetExpectedRuleIDs() => new List<RuleId>()


### PR DESCRIPTION
#### Describe the change
To improve future unit testing scenarios, this PR makes ScanResultsAssembler non-static and introduces the IScanResultsAssembler interface. ScanResultsAssembler is still not in use, so there is no impact on other classes.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



