### PR TITLE
Correct the code to rethrow an AxeWindowsAutomationException

### DIFF
--- a/src/Automation/ExecutionWrapper.cs
+++ b/src/Automation/ExecutionWrapper.cs
@@ -22,9 +22,9 @@ namespace Axe.Windows.Automation
                 {
                     return command();
                 }
-                catch (AxeWindowsAutomationException ex)
+                catch (AxeWindowsAutomationException)
                 {
-                    throw ex;
+                    throw;
                 }
                 catch (Exception ex)
                 {

--- a/src/AutomationTests/ExecutionWrapperUnitTests.cs
+++ b/src/AutomationTests/ExecutionWrapperUnitTests.cs
@@ -88,6 +88,7 @@ namespace Axe.Windows.AutomationTests
         }
 
         [TestMethod]
+        [Timeout(1000)]
         [ExpectedException(typeof(AxeWindowsAutomationException))]
         public void ExecuteCommand_CommandThrowsAxeWindowsAutomationException_StackTraceIsComplete()
         {

--- a/src/AutomationTests/ExecutionWrapperUnitTests.cs
+++ b/src/AutomationTests/ExecutionWrapperUnitTests.cs
@@ -86,5 +86,25 @@ namespace Axe.Windows.AutomationTests
 
             Assert.AreEqual(TestString, result.Detail);
         }
+
+        [TestMethod]
+        [ExpectedException(typeof(AxeWindowsAutomationException))]
+        public void ExecuteCommand_CommandThrowsAxeWindowsAutomationException_StackTraceIsComplete()
+        {
+            try
+            {
+                ExecutionWrapper.ExecuteCommand<TestResult>(ThrowAxeWindowsAutomationException);
+            }
+            catch (AxeWindowsAutomationException e)
+            {
+                Assert.IsTrue(e.StackTrace.Contains("ThrowAxeWindowsAutomationException"), "Stack Trace information has been lost");
+                throw;
+            }
+        }
+
+        private TestResult ThrowAxeWindowsAutomationException()
+        {
+            throw new AxeWindowsAutomationException("test");
+        }
     }
 }


### PR DESCRIPTION
#### Describe the change
The code to rethrow a caught AxeWindowsAutomationException was using the wrong syntax, causing the Exception to reach the caller without its stack trace. Reference: https://blogs.msdn.microsoft.com/perfworld/2009/06/15/how-can-i-throw-an-exception-without-losing-the-original-stack-trace-information-in-net/

Fixed the code, added a unit test to demonstrate the bad behavior and to pin the correct behavior.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



