### PR TITLE
Add ScanToolsBuilder for creating IScanTools implementation

### DIFF
--- a/src/Automation/Automation.csproj
+++ b/src/Automation/Automation.csproj
@@ -75,7 +75,9 @@
     <Compile Include="Data\ScanResults.cs" />
     <Compile Include="Enums\OutputFileFormat.cs" />
     <Compile Include="Factory.cs" />
+    <Compile Include="Interfaces\IFactory.cs" />
     <Compile Include="Interfaces\IScanTools.cs" />
+    <Compile Include="Interfaces\IScanToolsBuilder.cs" />
     <Compile Include="Interfaces\ITargetElementLocator.cs" />
     <Compile Include="Interfaces\IOutputFileHelper.cs" />
     <Compile Include="Interfaces\IScanner.cs" />
@@ -93,6 +95,7 @@
     <Compile Include="ScannerFactory.cs" />
     <Compile Include="ScanResultsAssembler.cs" />
     <Compile Include="ScanTools.cs" />
+    <Compile Include="ScanToolsBuilder.cs" />
     <Compile Include="SnapshotCommand.cs" />
     <Compile Include="TargetElementLocator.cs" />
   </ItemGroup>

--- a/src/Automation/Factory.cs
+++ b/src/Automation/Factory.cs
@@ -6,17 +6,20 @@ using System;
 
 namespace Axe.Windows.Automation
 {
-    static class Factory
+    /// <summary>
+    /// Factory used to create objects for internal use
+    /// </summary>
+    internal class Factory : IFactory
     {
-        static public IScanTools CreateScanTools()
+        private Factory()
+        { }
+
+        static public IScanToolsBuilder CreateScanToolsBuilder()
         {
-            return new ScanTools(
-                CreateOutputFileHelper(null),
-                CreateResultsAssembler(),
-                CreateTargetElementLocator());
+            return new ScanToolsBuilder(new Factory());
         }
 
-        public static IOutputFileHelper CreateOutputFileHelper(string outputDirectory)
+        public IOutputFileHelper CreateOutputFileHelper(string outputDirectory)
         {
             return new OutputFileHelper(outputDirectory, CreateSystemFactory());
         }
@@ -26,12 +29,12 @@ namespace Axe.Windows.Automation
             return new SystemFactory();
         }
 
-        private static IScanResultsAssembler CreateResultsAssembler()
+        public IScanResultsAssembler CreateResultsAssembler()
         {
             return new ScanResultsAssembler();
         }
 
-        private static ITargetElementLocator CreateTargetElementLocator()
+        public ITargetElementLocator CreateTargetElementLocator()
         {
             return new TargetElementLocator();
         }

--- a/src/Automation/Interfaces/IFactory.cs
+++ b/src/Automation/Interfaces/IFactory.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+namespace Axe.Windows.Automation
+{
+    /// <summary>
+    /// Factory used to create objects for internal use
+    /// </summary>
+    interface IFactory
+    {
+        IOutputFileHelper CreateOutputFileHelper(string outputDirectory);
+        IScanResultsAssembler CreateResultsAssembler();
+        ITargetElementLocator CreateTargetElementLocator();
+    } // interface
+} // namespace

--- a/src/Automation/Interfaces/IScanToolsBuilder.cs
+++ b/src/Automation/Interfaces/IScanToolsBuilder.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+namespace Axe.Windows.Automation
+{
+    internal interface IScanToolsBuilder
+    {
+        IScanToolsBuilder WithOutputDirectory(string outputDirectory);
+        IScanTools Build();
+    } // interface
+} // namespace

--- a/src/Automation/ScanToolsBuilder.cs
+++ b/src/Automation/ScanToolsBuilder.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+namespace Axe.Windows.Automation
+{
+    class ScanToolsBuilder : IScanToolsBuilder
+    {
+        private IFactory _factory;
+        private IOutputFileHelper _outputFileHelper;
+
+        public ScanToolsBuilder(IFactory factory)
+        {
+            if (factory == null) throw new ArgumentNullException(nameof(factory));
+
+            _factory = factory;
+        }
+
+        public IScanToolsBuilder WithOutputDirectory(string outputDirectory)
+        {
+            _outputFileHelper = _factory.CreateOutputFileHelper(outputDirectory);
+            return this;
+        }
+
+        public IScanTools Build()
+        {
+            return new ScanTools(
+                _outputFileHelper ?? _factory.CreateOutputFileHelper(null),
+                    _factory.CreateResultsAssembler(),
+                    _factory.CreateTargetElementLocator());
+        }
+    } // class
+} // namespace

--- a/src/Automation/ScannerFactory.cs
+++ b/src/Automation/ScannerFactory.cs
@@ -16,8 +16,8 @@ namespace Axe.Windows.Automation
         /// <returns></returns>
         public static IScanner CreateScanner(Config config)
         {
-            // Factory.CreateOutputFileHelper(config.OutputDirectory)
-            var scanTools = Factory.CreateScanTools();
+            var scanToolsBuilder = Factory.CreateScanToolsBuilder();
+            var scanTools = scanToolsBuilder.WithOutputDirectory(config.OutputDirectory).Build();
             return new Scanner(config, scanTools);
         }
     } // class

--- a/src/AutomationTests/AutomationTests.csproj
+++ b/src/AutomationTests/AutomationTests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="ExecutionWrapperUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ScanResultsAssemblerTests.cs" />
+    <Compile Include="ScanToolsBuilderUnitTests.cs" />
   </ItemGroup>
   <Import Project="..\..\build\delaysign.targets" />
   <ItemGroup>

--- a/src/AutomationTests/ScanToolsBuilderUnitTests.cs
+++ b/src/AutomationTests/ScanToolsBuilderUnitTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Automation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Path = System.IO.Path;
+
+namespace Axe.Windows.AutomationTests
+{
+    [TestClass]
+    public class ScanToolsBuilderUnitTests
+    {
+        [TestMethod]
+        [Timeout(1000)]
+        public void ScanToolsBuilder_CreatesIOutputFileHelperWithExpectedPath()
+        {
+            const string testPath = @"c:\_TestPath";
+
+            // #ToDo update this test to use Moq
+            var builder = Factory.CreateScanToolsBuilder();
+            Assert.IsNotNull(builder);
+
+            var scanTools = builder.WithOutputDirectory(testPath).Build();
+            Assert.IsNotNull(scanTools);
+            Assert.IsNotNull(scanTools.OutputFileHelper);
+
+            var a11ytestFilePath = scanTools.OutputFileHelper.GetNewA11yTestFilePath();
+            Assert.AreEqual(testPath, Path.GetDirectoryName(a11ytestFilePath));
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ScanToolsBuilder_CreatesAllObjects()
+        {
+            // #ToDo use mock with the ScanResultsBuilder class to ensure 
+            // all IFactory methods are called
+        }
+    } // class
+} // namespace


### PR DESCRIPTION
#### Describe the change

Changes
- Create IScanToolsBuilder interface and implementation
	- Make ScanToolsBuilder take IFactory as a constructor parameter
- Create IFactory interface, used with ScanToolsBuilder
- Update Factory to implement IFactory
- Create the outline for ScanToolsBuilder unit tests to be implemented when Moq is introduced to the project

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



