### PR TITLE
Add InternalScanner class

### DIFF
--- a/src/Automation/Automation.csproj
+++ b/src/Automation/Automation.csproj
@@ -76,11 +76,13 @@
     <Compile Include="Enums\OutputFileFormat.cs" />
     <Compile Include="Factory.cs" />
     <Compile Include="Interfaces\IFactory.cs" />
+    <Compile Include="Interfaces\IInternalScanner.cs" />
     <Compile Include="Interfaces\IScanTools.cs" />
     <Compile Include="Interfaces\IScanToolsBuilder.cs" />
     <Compile Include="Interfaces\ITargetElementLocator.cs" />
     <Compile Include="Interfaces\IOutputFileHelper.cs" />
     <Compile Include="Interfaces\IScanner.cs" />
+    <Compile Include="InternalScanner.cs" />
     <Compile Include="OutputFileHelper.cs" />
     <Compile Include="Interfaces\IScanResultsAssembler.cs" />
     <Compile Include="DisplayStrings.Designer.cs">

--- a/src/Automation/Factory.cs
+++ b/src/Automation/Factory.cs
@@ -38,5 +38,10 @@ namespace Axe.Windows.Automation
         {
             return new TargetElementLocator();
         }
+
+        public IInternalScanner CreateInternalScanner()
+        {
+            return new InternalScanner();
+        }
     } // class
 } // namespace

--- a/src/Automation/Interfaces/IFactory.cs
+++ b/src/Automation/Interfaces/IFactory.cs
@@ -12,5 +12,6 @@ namespace Axe.Windows.Automation
         IOutputFileHelper CreateOutputFileHelper(string outputDirectory);
         IScanResultsAssembler CreateResultsAssembler();
         ITargetElementLocator CreateTargetElementLocator();
+        IInternalScanner CreateInternalScanner();
     } // interface
 } // namespace

--- a/src/Automation/Interfaces/IInternalScanner.cs
+++ b/src/Automation/Interfaces/IInternalScanner.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using System;
+
+namespace Axe.Windows.Automation
+{
+    delegate ResultsT InternalScannerCallback<ResultsT>(A11yElement element, Guid elementId);
+
+    /// <summary>
+    /// The Interface representing the boundary between this Automation library
+    /// and the other parts (in other projects) of AxeWindows which perform the actual scan.
+    /// The code behind this interface should be unit tested as part of the projects where it is implemented,
+    /// not as part of this (Automation) project.
+    /// </summary>
+    internal interface IInternalScanner
+    {
+        /// <summary>
+        /// Runs a scan and calls a callback which can transform the results
+        /// into another form and/or save output files
+        /// </summary>
+        /// <typeparam name="ResultsT">The type of results object to be returned by the callback</typeparam>
+        /// <param name="element">The element from which to start the scan</param>
+        /// <param name="resultsCallback">A delegate which can act on results and transform them into a specified type</param>
+        /// <returns></returns>
+        ResultsT Scan<ResultsT>(A11yElement element, InternalScannerCallback<ResultsT> resultsCallback);
+    } // interface
+} // namespace

--- a/src/Automation/Interfaces/IScanTools.cs
+++ b/src/Automation/Interfaces/IScanTools.cs
@@ -11,5 +11,6 @@ namespace Axe.Windows.Automation
         IOutputFileHelper OutputFileHelper { get; }
         IScanResultsAssembler ResultsAssembler { get; }
         ITargetElementLocator TargetElementLocator { get; }
+        IInternalScanner InternalScanner { get; }
     } // interface
 } // namespace

--- a/src/Automation/InternalScanner.cs
+++ b/src/Automation/InternalScanner.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Actions;
+using Axe.Windows.Actions.Contexts;
+using Axe.Windows.Actions.Enums;
+using Axe.Windows.Actions.Misc;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using System;
+using System.Globalization;
+
+namespace Axe.Windows.Automation
+{
+    class InternalScanner : IInternalScanner
+    {
+        public ResultsT Scan<ResultsT>(A11yElement element, InternalScannerCallback<ResultsT> resultsCallback)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (resultsCallback == null) throw new ArgumentNullException(nameof(resultsCallback));
+
+            using (var dataManager = DataManager.GetDefaultInstance())
+            using (var sa = SelectAction.GetDefaultInstance())
+            {
+                sa.SetCandidateElement(element);
+
+                if (!sa.Select())
+                    throw new AxeWindowsAutomationException(DisplayStrings.ErrorUnableToSetDataContext);
+
+                using (ElementContext ec2 = sa.POIElementContext)
+                {
+                    GetDataAction.GetProcessAndUIFrameworkOfElementContext(ec2.Id);
+                    if (!CaptureAction.SetTestModeDataContext(ec2.Id, DataContextMode.Test, TreeViewMode.Control))
+                        throw new AxeWindowsAutomationException(DisplayStrings.ErrorUnableToSetDataContext);
+
+                        // send telemetry of scan results. 
+                        var dc = GetDataAction.GetElementDataContext(ec2.Id);
+                        dc.PublishScanResults();
+
+                        if (dc.ElementCounter.UpperBoundExceeded)
+                        {
+                            throw new AxeWindowsAutomationException(string.Format(CultureInfo.InvariantCulture,
+                                DisplayStrings.ErrorTooManyElementsToSetDataContext,
+                                dc.ElementCounter.UpperBound));
+                        }
+
+                    return resultsCallback(ec2.Element, ec2.Id);
+                } // using
+            } // using
+        }
+    } // class
+} // namespace

--- a/src/Automation/ScanTools.cs
+++ b/src/Automation/ScanTools.cs
@@ -9,15 +9,19 @@ namespace Axe.Windows.Automation
         public IOutputFileHelper OutputFileHelper { get; }
         public IScanResultsAssembler ResultsAssembler { get; }
         public ITargetElementLocator TargetElementLocator { get; }
+        public IInternalScanner InternalScanner { get; }
 
-        public ScanTools(IOutputFileHelper outputFileHelper, IScanResultsAssembler resultsAssembler, ITargetElementLocator targetElementLocator)
+        public ScanTools(IOutputFileHelper outputFileHelper, IScanResultsAssembler resultsAssembler, ITargetElementLocator targetElementLocator, IInternalScanner internalScanner)
         {
             if (outputFileHelper == null) throw new ArgumentNullException(nameof(outputFileHelper));
             if (resultsAssembler == null) throw new ArgumentNullException(nameof(resultsAssembler));
             if (targetElementLocator == null) throw new ArgumentNullException(nameof(targetElementLocator));
+            if (internalScanner == null) throw new ArgumentNullException(nameof(internalScanner));
+
             OutputFileHelper = outputFileHelper;
             ResultsAssembler = resultsAssembler;
             TargetElementLocator = targetElementLocator;
+            InternalScanner = internalScanner;
         }
     } // class
 } // namespace

--- a/src/Automation/ScanToolsBuilder.cs
+++ b/src/Automation/ScanToolsBuilder.cs
@@ -27,7 +27,8 @@ namespace Axe.Windows.Automation
             return new ScanTools(
                 _outputFileHelper ?? _factory.CreateOutputFileHelper(null),
                     _factory.CreateResultsAssembler(),
-                    _factory.CreateTargetElementLocator());
+                    _factory.CreateTargetElementLocator(),
+                    _factory.CreateInternalScanner());
         }
     } // class
 } // namespace

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -1,15 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Actions;
-using Axe.Windows.Actions.Contexts;
-using Axe.Windows.Actions.Enums;
-using Axe.Windows.Actions.Misc;
 using Axe.Windows.Core.Bases;
-using Axe.Windows.Core.Enums;
 using Axe.Windows.Desktop.Settings;
 using System;
-using System.Collections.Generic;
-using System.Globalization;
 
 namespace Axe.Windows.Automation
 {
@@ -29,62 +23,50 @@ namespace Axe.Windows.Automation
         {
             return ExecutionWrapper.ExecuteCommand<ScanResults>(() =>
             {
+                if (config == null) throw new ArgumentNullException(nameof(config));
                 if (scanTools == null) throw new ArgumentNullException(nameof(scanTools));
-                if (scanTools.OutputFileHelper == null) throw new ArgumentNullException(nameof(scanTools.OutputFileHelper));
-                if (scanTools.ResultsAssembler == null) throw new ArgumentNullException(nameof(scanTools.ResultsAssembler));
                 if (scanTools.TargetElementLocator == null) throw new ArgumentNullException(nameof(scanTools.TargetElementLocator));
+                if (scanTools.InternalScanner == null) throw new ArgumentNullException(nameof(scanTools.InternalScanner));
 
-                using (var dataManager = DataManager.GetDefaultInstance())
-                using (var sa = SelectAction.GetDefaultInstance())
+                var rootElement = scanTools.TargetElementLocator.LocateRootElement(config.ProcessId);
+                if (rootElement == null) throw new InvalidOperationException(nameof(rootElement));
+
+                return scanTools.InternalScanner.Scan(rootElement,
+                    (element, elementId) =>
                 {
-                    var rootElement = scanTools.TargetElementLocator.LocateRootElement(config.ProcessId);
-                    if (rootElement == null) throw new ArgumentNullException(nameof(rootElement));
-
-                    sa.SetCandidateElement(rootElement);
-
-                    if (sa.Select())
-                    {
-                        using (ElementContext ec2 = sa.POIElementContext)
-                        {
-                            GetDataAction.GetProcessAndUIFrameworkOfElementContext(ec2.Id);
-                            if (CaptureAction.SetTestModeDataContext(ec2.Id, DataContextMode.Test, TreeViewMode.Control))
-                            {
-                                // send telemetry of scan results. 
-                                var dc = GetDataAction.GetElementDataContext(ec2.Id);
-                                dc.PublishScanResults();
-
-                                if (dc.ElementCounter.UpperBoundExceeded)
-                                {
-                                    throw new AxeWindowsAutomationException(string.Format(CultureInfo.InvariantCulture,
-                                        DisplayStrings.ErrorTooManyElementsToSetDataContext,
-                                        dc.ElementCounter.UpperBound));
-                                }
-
-                                var results = scanTools.ResultsAssembler.AssembleScanResultsFromElement(ec2.Element);
-
-                                if (results.ErrorCount > 0)
-                                    results.OutputFile = WriteOutputFiles(config.OutputFileFormat, scanTools.OutputFileHelper, ec2);
-
-                                return results;
-                            }
-                        }
-                    }
-
-                    throw new AxeWindowsAutomationException(DisplayStrings.ErrorUnableToSetDataContext);
-                } // using
+                    return ProcessResults(element, elementId, config, scanTools);
+                });
             });
         }
 
-        private static (string A11yTest, string Sarif) WriteOutputFiles(OutputFileFormat outputFileFormat, IOutputFileHelper outputFileHelper, ElementContext elementContext)
+        private static ScanResults ProcessResults(A11yElement element, Guid elementId, Config config, IScanTools scanTools)
         {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            if (scanTools == null) throw new ArgumentNullException(nameof(scanTools));
+            if (scanTools.ResultsAssembler == null) throw new ArgumentNullException(nameof(scanTools.ResultsAssembler));
+
+            var results = scanTools.ResultsAssembler.AssembleScanResultsFromElement(element);
+
+            if (results.ErrorCount > 0)
+                results.OutputFile = WriteOutputFiles(config.OutputFileFormat, scanTools.OutputFileHelper, element, elementId);
+
+            return results;
+        }
+
+        private static (string A11yTest, string Sarif) WriteOutputFiles(OutputFileFormat outputFileFormat, IOutputFileHelper outputFileHelper, A11yElement element, Guid elementId)
+        {
+            if (outputFileHelper == null) throw new ArgumentNullException(nameof(OutputFileHelper));
+            if (element == null) throw new ArgumentNullException(nameof(element));
+
             string a11yTestOutputFile = null;
 
             if (outputFileFormat.HasFlag(OutputFileFormat.A11yTest))
             {
-                ScreenShotAction.CaptureScreenShot(elementContext.Id);
+                ScreenShotAction.CaptureScreenShot(elementId);
 
                 a11yTestOutputFile = outputFileHelper.GetNewA11yTestFilePath();
-                SaveAction.SaveSnapshotZip(a11yTestOutputFile, elementContext.Id, elementContext.Element.UniqueId, A11yFileMode.Test);
+                SaveAction.SaveSnapshotZip(a11yTestOutputFile, elementId, element.UniqueId, A11yFileMode.Test);
             }
 
 #if NOT_CURRENTLY_SUPPORTED


### PR DESCRIPTION
#### Describe the change


This class extracts out the logic from SnapshotCommand which talks  to parts of AxeWindows that are outside the Automation package. This now means the logic of SnapshotCommand is now testable without Fakes.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



