### PR TITLE
Rework ScanToolsBuilder unit tests using Moq

### DIFF
--- a/src/Automation/ScanToolsBuilder.cs
+++ b/src/Automation/ScanToolsBuilder.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Axe.Windows.Automation
 {
-    class ScanToolsBuilder : IScanToolsBuilder
+    internal class ScanToolsBuilder : IScanToolsBuilder
     {
         private IFactory _factory;
         private IOutputFileHelper _outputFileHelper;


### PR DESCRIPTION
#### Describe the change

These tests now ensure that all the properties of the resultant ScanTools object were _probably_ generated by the IFactory. 

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



