### PR TITLE
Exclude hyperlinks from unique name rule for siblings

### DIFF
--- a/src/Core/Enums/RuleId.cs
+++ b/src/Core/Enums/RuleId.cs
@@ -155,9 +155,10 @@ namespace Axe.Windows.Core.Enums
         PatternsExpectedBasedOnControlType,
 
         HelpTextExists,
-
-        // Axe.Windows.Rules
         HelpTextNotEqualToName,
+
+        HyperlinkNameShouldBeUnique,
+
         IsControlElementPropertyExists,
         IsControlElementPropertyCorrect,
 

--- a/src/Rules/Library/HyperlinkNameShouldBeUnique.cs
+++ b/src/Rules/Library/HyperlinkNameShouldBeUnique.cs
@@ -1,4 +1,6 @@
-﻿using Axe.Windows.Core.Bases;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
@@ -30,7 +32,6 @@ namespace Axe.Windows.Rules.Library
             var siblings = SiblingCount(EligibleHyperlink
                 & Name.Is(e.Name));
             var count = siblings.GetValue(e);
-            if (count < 1) return EvaluationCode.RuleExecutionError;
 
             return count == 1 ? EvaluationCode.Pass : EvaluationCode.Warning;
         }

--- a/src/Rules/Library/HyperlinkNameShouldBeUnique.cs
+++ b/src/Rules/Library/HyperlinkNameShouldBeUnique.cs
@@ -29,11 +29,8 @@ namespace Axe.Windows.Rules.Library
             if (e == null) throw new ArgumentException(nameof(e));
             if (e.Parent == null) throw new ArgumentNullException(nameof(e.Parent));
 
-            var siblings = SiblingCount(EligibleHyperlink
-                & Name.Is(e.Name));
-            var count = siblings.GetValue(e);
-
-            return count == 1 ? EvaluationCode.Pass : EvaluationCode.Warning;
+            var siblings = SiblingCount(EligibleHyperlink & Name.Is(e.Name)) <= 1;
+            return siblings.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Warning;
         }
 
         protected override Condition CreateCondition() => EligibleHyperlink;

--- a/src/Rules/Library/HyperlinkNameShouldBeUnique.cs
+++ b/src/Rules/Library/HyperlinkNameShouldBeUnique.cs
@@ -1,0 +1,49 @@
+﻿using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Rules.PropertyConditions;
+using Axe.Windows.Rules.Resources;
+using System;
+using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
+using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Relationships;
+using static Axe.Windows.Rules.PropertyConditions.StringProperties;
+
+namespace Axe.Windows.Rules.Library
+{
+    [RuleInfo(ID = RuleId.HyperlinkNameShouldBeUnique)]
+    class HyperlinkNameShouldBeUnique : Rule
+    {
+        private static Condition EligibleHyperlink = CreateHyperlinkSiblingCondition();
+
+        public HyperlinkNameShouldBeUnique()
+        {
+            this.Info.Description = Descriptions.HyperlinkNameShouldBeUnique;
+            this.Info.HowToFix = HowToFix.HyperlinkNameShouldBeUnique;
+            this.Info.Standard = A11yCriteriaId.NameRoleValue;
+        }
+
+        public override EvaluationCode Evaluate(IA11yElement e)
+        {
+            if (e == null) throw new ArgumentException(nameof(e));
+            if (e.Parent == null) throw new ArgumentNullException(nameof(e.Parent));
+
+            var siblings = SiblingCount(EligibleHyperlink
+                & Name.Is(e.Name));
+            var count = siblings.GetValue(e);
+            if (count < 1) return EvaluationCode.RuleExecutionError;
+
+            return count == 1 ? EvaluationCode.Pass : EvaluationCode.Warning;
+        }
+
+        protected override Condition CreateCondition() => EligibleHyperlink;
+
+        private static Condition CreateHyperlinkSiblingCondition()
+        {
+            return Hyperlink
+                & IsContentOrControlElement
+                & ParentExists
+                & Name.NotNullOrEmpty
+                & BoundingRectangle.Valid;
+        }
+    } // class
+} // namespace

--- a/src/Rules/Library/SiblingUniqueAndFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndFocusable.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.Rules.Library
 
         private static Condition CreateEligibleChildCondition()
         {
-            var ExcludedType = DataItem | Image | Pane | ScrollBar | Thumb | TreeItem | ListItem;
+            var ExcludedType = DataItem | Image | Pane | ScrollBar | Thumb | TreeItem | ListItem | Hyperlink;
 
             return IsKeyboardFocusable
                 & IsContentOrControlElement

--- a/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.Rules.Library
 
         private static Condition CreateEligibleChildCondition()
         {
-            var ExcludedType = DataItem | Image | Pane | ScrollBar | Thumb | TreeItem | ListItem;
+            var ExcludedType = DataItem | Image | Pane | ScrollBar | Thumb | TreeItem | ListItem | Hyperlink;
 
             return IsNotKeyboardFocusable
                 & IsContentOrControlElement

--- a/src/Rules/Resources/Descriptions.Designer.cs
+++ b/src/Rules/Resources/Descriptions.Designer.cs
@@ -430,6 +430,15 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Links with different purposes and destinations should have different names..
+        /// </summary>
+        internal static string HyperlinkNameShouldBeUnique {
+            get {
+                return ResourceManager.GetString("HyperlinkNameShouldBeUnique", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The recommended value of the IsContentElement property for the given control type is false. Please consider if this is an element that should be reported to an assistive technology user as content..
         /// </summary>
         internal static string IsContentElementFalseOptional {

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -358,7 +358,7 @@
     <value>A page must not have multiple elements with LocalizedLandmarkType "contentinfo."</value>
   </data>
   <data name="LandmarkOneMain" xml:space="preserve">
-      <value>A page must have exactly one element with the LocalizedLandmarkType "main."</value>
+    <value>A page must have exactly one element with the LocalizedLandmarkType "main."</value>
   </data>
   <data name="LocalizedLandmarkTypeExcludesSpecialCharacters" xml:space="preserve">
     <value>The LocalizedLandmarkType property must not contain any special characters.</value>
@@ -419,5 +419,8 @@
   </data>
   <data name="ListItemSiblingsUnique" xml:space="preserve">
     <value>The Name property of sibling list items should be unique.</value>
+  </data>
+  <data name="HyperlinkNameShouldBeUnique" xml:space="preserve">
+    <value>Links with different purposes and destinations should have different names.</value>
   </data>
 </root>

--- a/src/Rules/Resources/HowToFix.Designer.cs
+++ b/src/Rules/Resources/HowToFix.Designer.cs
@@ -464,6 +464,15 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to If the sibling hyperlink with the same Name navigates to a different destination, change the Name of either hyperlink..
+        /// </summary>
+        internal static string HyperlinkNameShouldBeUnique {
+            get {
+                return ResourceManager.GetString("HyperlinkNameShouldBeUnique", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The recommended value of the IsContentElement property for the given control type is false. Please consider if this is an element that should be reported to an assistive technology user as content..
         /// </summary>
         internal static string IsContentElementFalseOptional {

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -540,4 +540,7 @@ If possible, use a predefined (non-custom) control type and the default localize
   <data name="ListItemSiblingsUnique" xml:space="preserve">
     <value>Provide unique names for sibling list items.</value>
   </data>
+  <data name="HyperlinkNameShouldBeUnique" xml:space="preserve">
+    <value>If the sibling hyperlink with the same Name navigates to a different destination, change the Name of either hyperlink.</value>
+  </data>
 </root>

--- a/src/Rules/Rules.csproj
+++ b/src/Rules/Rules.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Library\ButtonInvokeAndExpandeCollapsePatterns.cs" />
     <Compile Include="Library\ButtonInvokeAndTogglePatterns.cs" />
     <Compile Include="Library\ComboBoxShouldNotSupportScrollPattern.cs" />
+    <Compile Include="Library\HyperlinkNameShouldBeUnique.cs" />
     <Compile Include="Library\ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs" />
     <Compile Include="Library\SelectionItemPatternSingleSelection.cs" />
     <Compile Include="Library\ListItemSiblingsUnique.cs" />

--- a/src/RulesTest/Library/HyperlinkNameShouldBeUniqueTest.cs
+++ b/src/RulesTest/Library/HyperlinkNameShouldBeUniqueTest.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Drawing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
+
+namespace Axe.Windows.RulesTest.Library
+{
+    [TestClass]
+    public class HyperlinkNameShouldBeUniqueTest
+    {
+        private static Rules.IRule Rule = new Axe.Windows.Rules.Library.HyperlinkNameShouldBeUnique();
+
+        [TestMethod]
+        public void TestNameMismatchPass()
+        {
+            var parent = new MockA11yElement();
+            var child1 = new MockA11yElement();
+            var child2 = new MockA11yElement();
+            child1.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child2.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child1.IsContentElement = true;
+            child2.IsContentElement = true;
+            child1.ControlTypeId = ControlType.Hyperlink;
+            child2.ControlTypeId = ControlType.Hyperlink;
+            child1.Name = "Alice";
+            child2.Name = "Bob";
+            child1.Parent = parent;
+            child2.Parent = parent;
+            parent.Children.Add(child1);
+            parent.Children.Add(child2);
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+        }
+
+        [TestMethod]
+        public void TestMatchWarning()
+        {
+            var parent = new MockA11yElement();
+            var child1 = new MockA11yElement();
+            var child2 = new MockA11yElement();
+            child1.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child2.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child1.IsContentElement = true;
+            child2.IsContentElement = true;
+            child1.ControlTypeId = ControlType.Hyperlink;
+            child2.ControlTypeId = ControlType.Hyperlink;
+            child1.Name = "Alice";
+            child2.Name = "Alice";
+            child1.Parent = parent;
+            child2.Parent = parent;
+            parent.Children.Add(child1);
+            parent.Children.Add(child2);
+
+            Assert.AreEqual(EvaluationCode.Warning, Rule.Evaluate(child2));
+        }
+    } // class
+} // namespace

--- a/src/RulesTest/RulesTests.csproj
+++ b/src/RulesTest/RulesTests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Library\ControlShouldNotSupportScrollPatternTests.cs" />
     <Compile Include="Library\ControlShouldSupportSetInfoTest.cs" />
     <Compile Include="Library\ControlShouldSupportTablePattern.cs" />
+    <Compile Include="Library\HyperlinkNameShouldBeUniqueTest.cs" />
     <Compile Include="Library\IsKeyboardFocusableTopLevelTextPattern.cs" />
     <Compile Include="Library\IsKeyboardFocusableOnEmptyContainer.cs" />
     <Compile Include="Library\LandmarkIsTopLevel.cs" />


### PR DESCRIPTION
We had a false positive described in issue #42 . This PR removes the hyperlink from the unique name check for siblings. Instead a new rule is created for sibling hyperlinks and a warning is returned if the names are identical.