### PR TITLE
Add integration TestCategory 

### DIFF
--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Automation;
+using Axe.Windows.UnitTestSharedLibrary;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Diagnostics;
 using System.IO;
@@ -10,7 +11,7 @@ using System.Threading;
 
 namespace Axe.Windows.AutomationTests
 {
-    [TestClass]
+    [TestClass, TestCategory(TestCategory.Integration)]
     public class AutomationIntegrationTests
     {
         readonly string TestAppPath = Path.GetFullPath("../../../../tools/WildlifeManager/WildlifeManager.exe");

--- a/src/UnitTestSharedLibrary/TestCategory.cs
+++ b/src/UnitTestSharedLibrary/TestCategory.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Axe.Windows.UnitTestSharedLibrary
+{
+    public static class TestCategory
+    {
+        public const string Integration = "Integration";
+    }
+}

--- a/src/UnitTestSharedLibrary/UnitTestSharedLibrary.csproj
+++ b/src/UnitTestSharedLibrary/UnitTestSharedLibrary.csproj
@@ -53,6 +53,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TestCategory.cs" />
     <Compile Include="Utility.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
#### Describe the change
Running our integration test is slower than unit tests and can be jarring. This PR adds a TestCategory static class and uses it to set the TestCategory attribute of our integration test. 
Now, devs can enter `-Trait:"Integration"` to their Test Explorer search box and continue to use "Run All" without running our integration test.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



