### PR TITLE
Rename InternalScanner to AxeWindowsActions

### DIFF
--- a/src/Automation/Automation.csproj
+++ b/src/Automation/Automation.csproj
@@ -76,13 +76,13 @@
     <Compile Include="Enums\OutputFileFormat.cs" />
     <Compile Include="Factory.cs" />
     <Compile Include="Interfaces\IFactory.cs" />
-    <Compile Include="Interfaces\IInternalScanner.cs" />
+    <Compile Include="Interfaces\IAxeWindowsActions.cs" />
     <Compile Include="Interfaces\IScanTools.cs" />
     <Compile Include="Interfaces\IScanToolsBuilder.cs" />
     <Compile Include="Interfaces\ITargetElementLocator.cs" />
     <Compile Include="Interfaces\IOutputFileHelper.cs" />
     <Compile Include="Interfaces\IScanner.cs" />
-    <Compile Include="InternalScanner.cs" />
+    <Compile Include="AxeWindowsActions.cs" />
     <Compile Include="OutputFileHelper.cs" />
     <Compile Include="Interfaces\IScanResultsAssembler.cs" />
     <Compile Include="DisplayStrings.Designer.cs">

--- a/src/Automation/AxeWindowsActions.cs
+++ b/src/Automation/AxeWindowsActions.cs
@@ -12,12 +12,12 @@ using System.Globalization;
 
 namespace Axe.Windows.Automation
 {
-    class InternalScanner : IInternalScanner
+    class AxeWindowsActions : IAxeWindowsActions
     {
-        public ResultsT Scan<ResultsT>(A11yElement element, InternalScannerCallback<ResultsT> resultsCallback)
+        public ResultsT Scan<ResultsT>(A11yElement element, ScanActionCallback<ResultsT> scanCallback)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
-            if (resultsCallback == null) throw new ArgumentNullException(nameof(resultsCallback));
+            if (scanCallback == null) throw new ArgumentNullException(nameof(scanCallback));
 
             using (var dataManager = DataManager.GetDefaultInstance())
             using (var sa = SelectAction.GetDefaultInstance())
@@ -44,7 +44,7 @@ namespace Axe.Windows.Automation
                                 dc.ElementCounter.UpperBound));
                         }
 
-                    return resultsCallback(ec2.Element, ec2.Id);
+                    return scanCallback(ec2.Element, ec2.Id);
                 } // using
             } // using
         }

--- a/src/Automation/Factory.cs
+++ b/src/Automation/Factory.cs
@@ -39,9 +39,9 @@ namespace Axe.Windows.Automation
             return new TargetElementLocator();
         }
 
-        public IInternalScanner CreateInternalScanner()
+        public IAxeWindowsActions CreateAxeWindowsActions()
         {
-            return new InternalScanner();
+            return new AxeWindowsActions();
         }
     } // class
 } // namespace

--- a/src/Automation/Interfaces/IAxeWindowsActions.cs
+++ b/src/Automation/Interfaces/IAxeWindowsActions.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Axe.Windows.Automation
 {
-    delegate T InternalScannerCallback<T>(A11yElement element, Guid elementId);
+    delegate T ScanActionCallback<T>(A11yElement element, Guid elementId);
 
     /// <summary>
     /// The Interface representing the boundary between this Automation library
@@ -13,7 +13,7 @@ namespace Axe.Windows.Automation
     /// The code behind this interface should be unit tested as part of the projects where it is implemented,
     /// not as part of this (Automation) project.
     /// </summary>
-    internal interface IInternalScanner
+    internal interface IAxeWindowsActions
     {
         /// <summary>
         /// Runs a scan and calls a callback which can transform the results
@@ -23,7 +23,7 @@ namespace Axe.Windows.Automation
         /// <param name="element">The element from which to start the scan</param>
         /// <param name="resultsCallback">A delegate which can act on results and transform them into a specified type</param>
         /// <returns></returns>
-        T Scan<T>(A11yElement element, InternalScannerCallback<T> resultsCallback);
+        T Scan<T>(A11yElement element, ScanActionCallback<T> resultsCallback);
 
         /// <summary>
         /// Takes a screenshot, highlighting the given element

--- a/src/Automation/Interfaces/IFactory.cs
+++ b/src/Automation/Interfaces/IFactory.cs
@@ -12,6 +12,6 @@ namespace Axe.Windows.Automation
         IOutputFileHelper CreateOutputFileHelper(string outputDirectory);
         IScanResultsAssembler CreateResultsAssembler();
         ITargetElementLocator CreateTargetElementLocator();
-        IInternalScanner CreateInternalScanner();
+        IAxeWindowsActions CreateAxeWindowsActions();
     } // interface
 } // namespace

--- a/src/Automation/Interfaces/IScanTools.cs
+++ b/src/Automation/Interfaces/IScanTools.cs
@@ -11,6 +11,6 @@ namespace Axe.Windows.Automation
         IOutputFileHelper OutputFileHelper { get; }
         IScanResultsAssembler ResultsAssembler { get; }
         ITargetElementLocator TargetElementLocator { get; }
-        IInternalScanner InternalScanner { get; }
+        IAxeWindowsActions Actions { get; }
     } // interface
 } // namespace

--- a/src/Automation/ScanTools.cs
+++ b/src/Automation/ScanTools.cs
@@ -9,19 +9,19 @@ namespace Axe.Windows.Automation
         public IOutputFileHelper OutputFileHelper { get; }
         public IScanResultsAssembler ResultsAssembler { get; }
         public ITargetElementLocator TargetElementLocator { get; }
-        public IInternalScanner InternalScanner { get; }
+        public IAxeWindowsActions Actions { get; }
 
-        public ScanTools(IOutputFileHelper outputFileHelper, IScanResultsAssembler resultsAssembler, ITargetElementLocator targetElementLocator, IInternalScanner internalScanner)
+        public ScanTools(IOutputFileHelper outputFileHelper, IScanResultsAssembler resultsAssembler, ITargetElementLocator targetElementLocator, IAxeWindowsActions actions)
         {
             if (outputFileHelper == null) throw new ArgumentNullException(nameof(outputFileHelper));
             if (resultsAssembler == null) throw new ArgumentNullException(nameof(resultsAssembler));
             if (targetElementLocator == null) throw new ArgumentNullException(nameof(targetElementLocator));
-            if (internalScanner == null) throw new ArgumentNullException(nameof(internalScanner));
+            if (actions == null) throw new ArgumentNullException(nameof(actions));
 
             OutputFileHelper = outputFileHelper;
             ResultsAssembler = resultsAssembler;
             TargetElementLocator = targetElementLocator;
-            InternalScanner = internalScanner;
+            Actions = actions;
         }
     } // class
 } // namespace

--- a/src/Automation/ScanToolsBuilder.cs
+++ b/src/Automation/ScanToolsBuilder.cs
@@ -28,7 +28,7 @@ namespace Axe.Windows.Automation
                 _outputFileHelper ?? _factory.CreateOutputFileHelper(null),
                     _factory.CreateResultsAssembler(),
                     _factory.CreateTargetElementLocator(),
-                    _factory.CreateInternalScanner());
+                    _factory.CreateAxeWindowsActions());
         }
     } // class
 } // namespace

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -24,12 +24,12 @@ namespace Axe.Windows.Automation
                 if (config == null) throw new ArgumentNullException(nameof(config));
                 if (scanTools == null) throw new ArgumentNullException(nameof(scanTools));
                 if (scanTools.TargetElementLocator == null) throw new ArgumentNullException(nameof(scanTools.TargetElementLocator));
-                if (scanTools.InternalScanner == null) throw new ArgumentNullException(nameof(scanTools.InternalScanner));
+                if (scanTools.Actions == null) throw new ArgumentNullException(nameof(scanTools.Actions));
 
                 var rootElement = scanTools.TargetElementLocator.LocateRootElement(config.ProcessId);
                 if (rootElement == null) throw new InvalidOperationException(nameof(rootElement));
 
-                return scanTools.InternalScanner.Scan(rootElement,
+                return scanTools.Actions.Scan(rootElement,
                     (element, elementId) =>
                 {
                     return ProcessResults(element, elementId, config, scanTools);
@@ -57,12 +57,12 @@ namespace Axe.Windows.Automation
 
             if (outputFileFormat.HasFlag(OutputFileFormat.A11yTest))
             {
-                scanTools.InternalScanner.CaptureScreenshot(elementId);
+                scanTools.Actions.CaptureScreenshot(elementId);
 
                 a11yTestOutputFile = scanTools.OutputFileHelper.GetNewA11yTestFilePath();
                 if (a11yTestOutputFile == null) throw new InvalidOperationException(nameof(a11yTestOutputFile));
                 
-scanTools.InternalScanner.SaveA11yTestFile(a11yTestOutputFile, element, elementId);
+scanTools.Actions.SaveA11yTestFile(a11yTestOutputFile, element, elementId);
             }
 
 #if NOT_CURRENTLY_SUPPORTED

--- a/src/AutomationTests/ScanToolsBuilderUnitTests.cs
+++ b/src/AutomationTests/ScanToolsBuilderUnitTests.cs
@@ -15,13 +15,13 @@ namespace Axe.Windows.AutomationTests
         {
             var mockRepository = new MockRepository(MockBehavior.Strict);
 
-            var internalScannerMock = mockRepository.Create<IInternalScanner>();
+            var actionsMock = mockRepository.Create<IAxeWindowsActions>();
             var outputFileHelperMock = mockRepository.Create<IOutputFileHelper>();
             var resultsAssemblerMock = mockRepository.Create<IScanResultsAssembler>();
             var targetElementLocatorMock = mockRepository.Create<ITargetElementLocator>();
 
             var factoryMock = mockRepository.Create<IFactory>();
-            factoryMock.Setup(x => x.CreateInternalScanner()).Returns(internalScannerMock.Object);
+            factoryMock.Setup(x => x.CreateAxeWindowsActions()).Returns(actionsMock.Object);
             factoryMock.Setup(x => x.CreateResultsAssembler()).Returns(resultsAssemblerMock.Object);
             factoryMock.Setup(x => x.CreateTargetElementLocator()).Returns(targetElementLocatorMock.Object);
 
@@ -39,7 +39,7 @@ namespace Axe.Windows.AutomationTests
             var scanTools = builder.WithOutputDirectory(expectedPath).Build();
 
             Assert.IsNotNull(scanTools);
-            Assert.IsNotNull(scanTools.InternalScanner);
+            Assert.IsNotNull(scanTools.Actions);
             Assert.IsNotNull(scanTools.OutputFileHelper);
             Assert.IsNotNull(scanTools.ResultsAssembler);
             Assert.IsNotNull(scanTools.TargetElementLocator);


### PR DESCRIPTION
#### Describe the change

The new name more accurately reflects the purpose of the interface.

Note: Only rename actions were done in this PR.


> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



