### PR TITLE
 Add ticks to OutputFileHelper filename for uniqueness

### DIFF
--- a/src/Automation/OutputFileHelper.cs
+++ b/src/Automation/OutputFileHelper.cs
@@ -72,7 +72,7 @@ namespace Axe.Windows.Automation
         {
             var now = _dateTime.Now;
 
-            var nowString = $"{now:yy-MM-dd_HH-mm-ss.FFFFFFF}";
+            var nowString = $"{now:yy-MM-dd_HH-mm-ss.fffffff}";
             return $"{DefaultFileNameBase}_{nowString}";
         }
     } // class

--- a/src/Automation/OutputFileHelper.cs
+++ b/src/Automation/OutputFileHelper.cs
@@ -72,7 +72,7 @@ namespace Axe.Windows.Automation
         {
             var now = _dateTime.Now;
 
-            var nowString = $"{now:yy-MM-dd_HH-mm-ss}";
+            var nowString = $"{now:yy-MM-dd_HH-mm-ss.FFFFFFF}";
             return $"{DefaultFileNameBase}_{nowString}";
         }
     } // class

--- a/src/AutomationTests/OutputFileHelperUnitTests.cs
+++ b/src/AutomationTests/OutputFileHelperUnitTests.cs
@@ -194,14 +194,15 @@ namespace Axe.Windows.AutomationTests
                 day: 1,
                 hour: 20,
                 minute: 8,
-                second: 8);
+                second: 8
+                ).AddTicks(12345);
 
             mockDateTime.Setup(x => x.Now).Returns(dateTime);
 
             var outputFileHelper = new OutputFileHelper(directory, mockSystemFactory.Object);
             var result = outputFileHelper.GetNewA11yTestFilePath();
 
-            var expectedFileName = $"{OutputFileHelper.DefaultFileNameBase}_19-04-01_20-08-08.a11ytest";
+            var expectedFileName = $"{OutputFileHelper.DefaultFileNameBase}_19-04-01_20-08-08.0012345.a11ytest";
             var actualFileName = Path.GetFileName(result);
             Assert.AreEqual(expectedFileName, actualFileName);
 


### PR DESCRIPTION
#### Describe the change
There was some concern that using seconds for test file output names would result duplicate name generation. This PR adds ticks to the filename to alleviate that risk.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



