### PR TITLE
Don't run integration tests on signed build

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -251,6 +251,7 @@ jobs:
       testAssemblyVer2: |
         **\*test*.dll
         !**\obj\**
+      testFiltercriteria: 'TestCategory!=Integration'
       vsTestVersion: 15.0
       codeCoverageEnabled: false
       platform: '$(BuildPlatform)'
@@ -366,6 +367,7 @@ jobs:
       testAssemblyVer2: |  
         **\*test*.dll
         !**\obj\**
+      testFiltercriteria: 'TestCategory!=Integration'
       vsTestVersion: 15.0
       codeCoverageEnabled: false
       platform: '$(BuildPlatform)'

--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -34,7 +34,7 @@ namespace Axe.Windows.AutomationTests
         }
 
         [TestMethod]
-        [Timeout(10000)]
+        [Timeout(17000)]
         public void Scan_Integration()
         {
             var config = Config.Builder.ForProcessId(TestProcess.Id)
@@ -66,7 +66,9 @@ namespace Axe.Windows.AutomationTests
             TestProcess?.Kill();
             TestProcess = Process.Start(TestAppPath);
             TestProcess.WaitForInputIdle();
-            Thread.Sleep(3000);
+
+            // this is painfully long, but the build agents will fail the test without it
+            Thread.Sleep(10000);
         }
 
         private void StopTestApp()


### PR DESCRIPTION
#### Describe the change

Our signed build can't handle ui-inclusive tests. Also, our normal build needs more time to properly run the integration tests. This PR stops running the integration tests on signed builds and gives them more time in other scenarios.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



