### PR TITLE
Change EvaluationCode of BoundingRectangleContainedInParent to Warning

### DIFF
--- a/src/Rules/Library/BoundingRectangleContainedInParent.cs
+++ b/src/Rules/Library/BoundingRectangleContainedInParent.cs
@@ -37,7 +37,7 @@ namespace Axe.Windows.Rules.Library
                 // if the element is not contained in the parent element, go further 
                 var container = e.FindContainerElement();
 
-                return IsBoundingRectangleContained(container, e) ? EvaluationCode.Pass : EvaluationCode.Error;
+                return IsBoundingRectangleContained(container, e) ? EvaluationCode.Pass : EvaluationCode.Warning;
             }
 
             return EvaluationCode.Pass;

--- a/src/RulesTest/Library/BoundingRectangleContainedInParentTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleContainedInParentTest.cs
@@ -108,7 +108,7 @@ namespace Axe.Windows.RulesTest.Library
                 e.Parent = parent;
                 parent.Parent = grandparent;
 
-                Assert.AreEqual(Rule.Evaluate(e), EvaluationCode.Error);
+                Assert.AreEqual(EvaluationCode.Warning, Rule.Evaluate(e));
             } // using
         }
 


### PR DESCRIPTION
#### Describe the change

This change is based on a discussion with the Accessibility Tooling Advisory Board.

BoundingRectangleContainedInParent was created based on a similar rule which is part of another automated accessibility scanning tool. And while the rule seems to make sense logically, there is no known documentation to support it. In addition, there are numerous violations in existence in the wild, and there is no evidence it presents an accessibility barrier to users. Therefore, we are demoting this rule to a warning.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



