### PR TITLE
Revert AxeWindows version to 2.0

### DIFF
--- a/src/props/version.props
+++ b/src/props/version.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SemVerNumber Condition="$(SemVerNumber) == ''">0.2.1</SemVerNumber>
+    <SemVerNumber Condition="$(SemVerNumber) == ''">0.2.0</SemVerNumber>
     <SemVerSuffix>-prerelease</SemVerSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### Describe the change

We need to do this in order to make another build which has an updated nupkg file.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



