### PR TITLE
Attempt to sign just the NuGet package, not the binaries that it contains

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -6,8 +6,8 @@ variables:
   DropFolder: 'signed'
   MAICreateNuget: 'true'
   PublicRelease: 'true'
-  SignAppForRelease: 'true'
-  MicroBuild_NuPkgSigningEnabled: 'true'
+  SignAppForRelease: 'false'
+  MicroBuild_NuPkgSigningEnabled: 'false'
   TeamName: 'Axe Windows'
   system.debug: 'true' #set to true in case our signed build flakes out again
   FAKES_SUPPORTED: 1
@@ -18,8 +18,6 @@ jobs:
     vmImage: 'vs2017-win2016'
   variables:
     PublicRelease: 'false'
-    SignAppForRelease: 'false'
-    MicroBuild_NuPkgSigningEnabled: 'false'
   steps:
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet 5.0.0'
@@ -79,8 +77,6 @@ jobs:
     vmImage: 'vs2017-win2016'
   variables:
     PublicRelease: 'false'
-    SignAppForRelease: 'false'
-    MicroBuild_NuPkgSigningEnabled: 'false'
   steps:
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet 5.0.0'
@@ -295,6 +291,8 @@ jobs:
   - ComplianceDebug
   condition: and(succeeded(), succeeded())
   pool: VSEng-MicroBuildVS2017
+  variables:
+    MicroBuild_NuPkgSigningEnabled: 'true'
   steps:
   - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
     displayName: 'Install Localization Plugin'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -176,6 +176,8 @@ jobs:
   - ComplianceDebug
   condition: and(succeeded(), succeeded())
   pool: VSEng-MicroBuildVS2017
+  variables:
+    MicroBuild_NuPkgSigningEnabled: 'true'
   steps:
   - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
     displayName: 'Install Localization Plugin'
@@ -291,8 +293,6 @@ jobs:
   - ComplianceDebug
   condition: and(succeeded(), succeeded())
   pool: VSEng-MicroBuildVS2017
-  variables:
-    MicroBuild_NuPkgSigningEnabled: 'true'
   steps:
   - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
     displayName: 'Install Localization Plugin'

--- a/src/CI/CI.csproj
+++ b/src/CI/CI.csproj
@@ -64,7 +64,7 @@
     <Error Condition="!Exists('..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets'))" />
   </Target>
   <Import Project="..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" Condition="Exists('..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" />
-  <Target Name="SignNuGetPackage" Condition=" '$(MicroBuild_NuPkgSigningEnabled)' != 'false' and '$(MicroBuild_SigningEnabled)' == 'true' and '$(IsPackable)' == 'true' and '$(NonShipping)' != 'true' and '$(SignType)' != '' and '$(SignAppForRelease)'=='true' and '$(Configuration)' == 'Release'" DependsOnTargets="@(SignNuGetPackageDependsOn)" AfterTargets="Pack">
+  <Target Name="SignNuGetPackage" Condition=" '$(MicroBuild_NuPkgSigningEnabled)' != 'false' and '$(MicroBuild_SigningEnabled)' == 'true' and '$(IsPackable)' == 'true' and '$(NonShipping)' != 'true' and '$(SignType)' != '' and '$(Configuration)' == 'Release'" DependsOnTargets="@(SignNuGetPackageDependsOn)" AfterTargets="Pack">
     <ItemGroup>
       <SignNuGetPackFiles Include="bin\$(Configuration)\NuGet\$(SemVerNumber)$(SemVerSuffix)\Axe.Windows.$(SemVerNumber)$(SemVerSuffix).nupkg" />
     </ItemGroup>


### PR DESCRIPTION
#### Describe the change
Attempt to sign just the NuGet package, not the binaries that it contains. This change intentionally leaves it easy to re-enable the digital signing, if needed (a fuller scrub can be performed in the future, as needed). The best way to test these would probably be to create a branch in the Microsoft repo (not in a fork), queue a signed build against that branch, and examine the files that get build. The NuGet package should be signed, but the DLLs should not.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



