### PR TITLE
Update nuspec with correct authors and suggested copyright

### DIFF
--- a/src/CI/Axe.Windows.nuspec
+++ b/src/CI/Axe.Windows.nuspec
@@ -8,12 +8,12 @@
     <description>The package provides the assemblies necessary to automate accessibility testing for Windows applications using the included axe-windows rule set.</description>
     <projectUrl>https://github.com/Microsoft/axe-windows</projectUrl>
     <iconUrl>https://github.com/Microsoft/axe-windows/raw/master/brand/brand-blue-128px.png</iconUrl>
-    <authors>Microsoft, Deque Systems</authors>
+    <authors>AccessibilityInsights</authors>
     <owners></owners>
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <language>en-US</language>
-    <copyright>© Microsoft Corporation, Deque Systems. All rights reserved.</copyright>
+    <copyright>© Microsoft and contributors</copyright>
     <tags>axe windows accessibility automation</tags>
   </metadata>
   <files>


### PR DESCRIPTION
#### Describe the change

- The author should match the name of our NuGet org
- And the copyright is what we agreed to with legal

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



