### PR TITLE
Add package dependencies to NuSpec file

### DIFF
--- a/src/CI/Axe.Windows.nuspec
+++ b/src/CI/Axe.Windows.nuspec
@@ -15,9 +15,13 @@
     <language>en-US</language>
     <copyright>© Microsoft and contributors</copyright>
     <tags>axe windows accessibility automation</tags>
+    <dependencies>
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
+        <dependency id="Sarif.SDK" version="2.0.0" />
+    </dependencies>
   </metadata>
   <files>
-    <file src="bin\$configuration$\*.dll" target="lib\net471" />
+    <file src="bin\$configuration$\*.dll" exclude="bin\$configuration$\newtonsoft.json.dll;bin\$configuration$\system.*.dll;bin\$configuration$\sarif.dll" target="lib\net471" />
     <file src="bin\$configuration$\Axe.Windows.Automation.xml" target="lib\net471" />
   </files> 
 </package>

--- a/src/CI/Axe.Windows.nuspec
+++ b/src/CI/Axe.Windows.nuspec
@@ -18,10 +18,11 @@
     <dependencies>
         <dependency id="Newtonsoft.Json" version="9.0.1" />
         <dependency id="Sarif.SDK" version="2.0.0" />
+        <dependency id="System.Collections.Immutable" version="1.5.0" />
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\$configuration$\*.dll" exclude="bin\$configuration$\newtonsoft.json.dll;bin\$configuration$\system.*.dll;bin\$configuration$\sarif.dll" target="lib\net471" />
+    <file src="bin\$configuration$\axe.windows.*.dll" target="lib\net471" />
     <file src="bin\$configuration$\Axe.Windows.Automation.xml" target="lib\net471" />
   </files> 
 </package>


### PR DESCRIPTION
#### Describe the change

This means we will allow NuGet to manage getting dependency packages, instead of including dependency package files in our package.

Also, removed inclusion of system files from our package. These files should already exist on target machines as part of the .Net runtime.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



