### PR TITLE
More TSA fixes

### DIFF
--- a/src/Automation/OutputFileHelper.cs
+++ b/src/Automation/OutputFileHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Abstractions;
 using System;
+using System.Globalization;
 using Path = System.IO.Path;
 
 using static System.FormattableString;
@@ -59,7 +60,7 @@ namespace Axe.Windows.Automation
             }
             catch (Exception ex)
             {
-                throw new AxeWindowsAutomationException(String.Format(DisplayStrings.ErrorDirectoryInvalid, path), ex);
+                throw new AxeWindowsAutomationException(string.Format(CultureInfo.InvariantCulture, DisplayStrings.ErrorDirectoryInvalid, path), ex);
             }
         }
 

--- a/src/Rules/PropertyConditions/StringProperty.cs
+++ b/src/Rules/PropertyConditions/StringProperty.cs
@@ -134,10 +134,10 @@ namespace Axe.Windows.Rules.PropertyConditions
             if (that == null) throw new ArgumentNullException(nameof(that));
 
             string s1 = this.GetStringPropertyValue(e);
-            if (String.IsNullOrWhiteSpace(s1)) return false;
+            if (string.IsNullOrWhiteSpace(s1)) return false;
 
             string s2 = that.GetStringPropertyValue(e);
-            if (String.IsNullOrWhiteSpace(s2)) return false;
+            if (string.IsNullOrWhiteSpace(s2)) return false;
 
             return string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase);
         }
@@ -149,7 +149,7 @@ namespace Axe.Windows.Rules.PropertyConditions
                 Regex r = new Regex(s);
                 return r.IsMatch(GetStringPropertyValue(e));
             },
-            String.Format(CultureInfo.InvariantCulture, ConditionDescriptions.MatchesRegEx, PropertyDescription, s));
+            string.Format(CultureInfo.InvariantCulture, ConditionDescriptions.MatchesRegEx, PropertyDescription, s));
         }
 
         public Condition MatchesRegEx(string s, RegexOptions options)
@@ -159,7 +159,7 @@ namespace Axe.Windows.Rules.PropertyConditions
                 Regex r = new Regex(s, options);
                 return r.IsMatch(GetStringPropertyValue(e));
                 },
-                String.Format(ConditionDescriptions.MatchesRegExWithOptions, PropertyDescription, s, options.ToString()));
+                string.Format(CultureInfo.InvariantCulture, ConditionDescriptions.MatchesRegExWithOptions, PropertyDescription, s, options.ToString()));
         }
     } // class
 } // namespace


### PR DESCRIPTION
#### Describe the change
Add a couple of CultureInfo.InvariantCulture (wanted by FxCop). Use lower-case string instead of mixed-case String within the files being touched. 

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



