### PR TITLE
Don't use named Tuple for ScanResults.OutputFile

### DIFF
--- a/src/Automation/Automation.csproj
+++ b/src/Automation/Automation.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Concretions\SystemIODirectory.cs" />
     <Compile Include="Data\Config.cs" />
     <Compile Include="Data\ElementInfo.cs" />
+    <Compile Include="Data\OutputFile.cs" />
     <Compile Include="Data\ScanResult.cs" />
     <Compile Include="Data\ScanResults.cs" />
     <Compile Include="Enums\OutputFileFormat.cs" />

--- a/src/Automation/Data/OutputFile.cs
+++ b/src/Automation/Data/OutputFile.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Axe.Windows.Automation.Data
+namespace Axe.Windows.Automation
 {
     /// <summary>
     /// Represents the output file(s), if any, associated with a ScanResults object

--- a/src/Automation/Data/OutputFile.cs
+++ b/src/Automation/Data/OutputFile.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Axe.Windows.Automation.Data
+{
+    /// <summary>
+    /// Represents the output file(s), if any, associated with a ScanResults object
+    /// </summary>
+    public struct OutputFile
+    {
+        /// <summary>
+        /// The A11yTest file that was generated (or null if no file was generated)
+        /// </summary>
+        public string A11yTest { get; }
+
+        /// <summary>
+        /// The Sarif file that was generated (or null if no file was generated)
+        /// </summary>
+        public string Sarif { get; }
+
+        /// <summary>
+        /// Private ctor. Called by the BuildFrom* methods
+        /// </summary>
+        /// <param name="a11yTest">The A11yTest file that was created (if any)</param>
+        /// <param name="sarif">The Sarif file that was created (if any)</param>
+        private OutputFile(string a11yTest = null, string sarif = null)
+        {
+            A11yTest = a11yTest;
+            Sarif = sarif;
+        }
+
+        /// <summary>
+        /// Build an OutputFile containing just an A11yTest file
+        /// </summary>
+        /// <param name="a11yTestFile"></param>
+        /// <returns></returns>
+        static internal OutputFile BuildFromA11yTestFile(string a11yTestFile)
+        {
+            return new OutputFile(a11yTest: a11yTestFile);
+        }
+    }
+}

--- a/src/Automation/Data/ScanResults.cs
+++ b/src/Automation/Data/ScanResults.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Automation.Data;
-using System;
 using System.Collections.Generic;
 
 namespace Axe.Windows.Automation

--- a/src/Automation/Data/ScanResults.cs
+++ b/src/Automation/Data/ScanResults.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Automation.Data;
 using System;
 using System.Collections.Generic;
 
@@ -11,8 +12,8 @@ namespace Axe.Windows.Automation
     public class ScanResults
     {
         /// <summary>
-        /// A Tuple with paths to any output files written as a result of a scan.
-        /// Tuple members are A11yTest and Sarif (not implemented yet)
+        /// An OutputFile object containing paths to any output files written as
+        /// a result of a scan.
         /// </summary>
         /// <remarks>
         /// This property's members may be null if no output files were written.
@@ -20,7 +21,7 @@ namespace Axe.Windows.Automation
         /// or was set to <see cref="OutputFileFormat.None"/>.
         /// This property's members will also be null if no errors were found.
         /// </remarks>
-        public (string A11yTest, string Sarif) OutputFile { get; internal set; }
+        public OutputFile OutputFile { get; internal set; }
 
         /// <summary>
         /// A count of all errors across all elements scanned.

--- a/src/Automation/Data/ScanResults.cs
+++ b/src/Automation/Data/ScanResults.cs
@@ -10,7 +10,7 @@ namespace Axe.Windows.Automation
     public class ScanResults
     {
         /// <summary>
-        /// An OutputFile object containing paths to any output files written as
+        /// An OutputFile object <see cref="OutputFile"/> containing paths to any output files written as
         /// a result of a scan.
         /// </summary>
         /// <remarks>

--- a/src/Automation/Data/ScanResults.cs
+++ b/src/Automation/Data/ScanResults.cs
@@ -10,7 +10,7 @@ namespace Axe.Windows.Automation
     public class ScanResults
     {
         /// <summary>
-        /// An OutputFile object <see cref="OutputFile"/> containing paths to any output files written as
+        /// A <see cref="OutputFile"/> object containing paths to any output files written as
         /// a result of a scan.
         /// </summary>
         /// <remarks>

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Automation.Data;
 using Axe.Windows.Core.Bases;
 using System;
 

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Automation.Data;
 using Axe.Windows.Core.Bases;
 using System;
 
@@ -49,7 +50,7 @@ namespace Axe.Windows.Automation
             return results;
         }
 
-        private static (string A11yTest, string Sarif) WriteOutputFiles(OutputFileFormat outputFileFormat, IScanTools scanTools, A11yElement element, Guid elementId)
+        private static OutputFile WriteOutputFiles(OutputFileFormat outputFileFormat, IScanTools scanTools, A11yElement element, Guid elementId)
         {
             if (scanTools?.OutputFileHelper == null) throw new ArgumentNullException(nameof(scanTools.OutputFileHelper));
 
@@ -70,7 +71,7 @@ scanTools.Actions.SaveA11yTestFile(a11yTestOutputFile, element, elementId);
                                     // SaveAction.SaveSarifFile(outputFileHelper.GetNewSarifFilePath(), ec2.Id, !locationHelper.IsAllOption());
 #endif
 
-            return (a11yTestOutputFile, null);
+            return OutputFile.BuildFromA11yTestFile(a11yTestOutputFile);
         }
     } // class
 } // namespace


### PR DESCRIPTION
#### Describe the change
I came across an environment that provides only a partial implementation of .NET, and that implementation doesn't include the named Tuple struct. To enable the scan, I changed ScanResults.OutputFile from a Tuple to a struct? It's a struct (instead of a class) for compatibility with the named Tuple, which is a value type, not a reference type. We can certainly make it a class, but it's a potentially breaking change from the 0.2.0 interface, where ScanResults.OutputFile could never be null

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



