### PR TITLE
Rename MAICreateNuget to CreateAxeWindowsNugetPackage

### DIFF
--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -3,7 +3,7 @@ trigger: none
 pr: none
 variables:
   BuildPlatform: 'x86'
-  CreateAxeWindowsNuget: 'true'
+  CreateAxeWindowsNugetPackage: 'true'
   PublicRelease: 'false'
   SignAppForRelease: 'false'
 

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -3,7 +3,7 @@ trigger: none
 pr: none
 variables:
   BuildPlatform: 'x86'
-  MAICreateNuget: 'true'
+  CreateAxeWindowsNuget: 'true'
   PublicRelease: 'false'
   SignAppForRelease: 'false'
 

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -3,7 +3,7 @@ trigger: none
 pr: none
 variables:
   BuildPlatform: 'x86'
-  MAICreateNuget: 'true'
+  CreateAxeWindowsNuget: 'true'
   PublicRelease: 'false'
   SignAppForRelease: 'false'
   MicroBuild_NuPkgSigningEnabled: 'false'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -3,7 +3,7 @@ trigger: none
 pr: none
 variables:
   BuildPlatform: 'x86'
-  CreateAxeWindowsNuget: 'true'
+  CreateAxeWindowsNugetPackage: 'true'
   PublicRelease: 'false'
   SignAppForRelease: 'false'
   MicroBuild_NuPkgSigningEnabled: 'false'

--- a/src/CI/CI.csproj
+++ b/src/CI/CI.csproj
@@ -53,7 +53,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Condition=" '$(MAICreateNuget)' == 'true' " Name="Pack" AfterTargets="Build">
+  <Target Condition=" '$(CreateAxeWindowsNuget)' == 'true' " Name="Pack" AfterTargets="Build">
     <Exec Command="nuget.exe pack -properties Configuration=$(Configuration);VersionString=&quot;$(SemVerNumber)$(SemVerSuffix)&quot; Axe.Windows.nuspec -OutputDirectory bin\$(Configuration)\NuGet\$(SemVerNumber)$(SemVerSuffix) -NonInteractive" />
   </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/CI/CI.csproj
+++ b/src/CI/CI.csproj
@@ -53,7 +53,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Condition=" '$(CreateAxeWindowsNuget)' == 'true' " Name="Pack" AfterTargets="Build">
+  <Target Condition=" '$(CreateAxeWindowsNugetPackage)' == 'true' " Name="Pack" AfterTargets="Build">
     <Exec Command="nuget.exe pack -properties Configuration=$(Configuration);VersionString=&quot;$(SemVerNumber)$(SemVerSuffix)&quot; Axe.Windows.nuspec -OutputDirectory bin\$(Configuration)\NuGet\$(SemVerNumber)$(SemVerSuffix) -NonInteractive" />
   </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
#### Describe the change
NuGet package creation is gated by a environment variable. For historical reasons that no longer apply, this variable is named MAICreateNuget. I've updated this variable to CreateAxeWindowsNugetPackage both to reflect the current repo and to make it clearer what this flag does.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



