### PR TITLE
Disable signing, bump version to 0.3.0 prerelease

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -188,7 +188,6 @@ jobs:
   pool: VSEng-MicroBuildVS2017
   variables:
     PublicRelease: 'true'
-    SignAppForRelease: 'true'
     MicroBuild_NuPkgSigningEnabled: 'false'
   steps:
   - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1

--- a/src/props/version.props
+++ b/src/props/version.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SemVerNumber Condition="$(SemVerNumber) == ''">0.2.1</SemVerNumber>
+    <SemVerNumber Condition="$(SemVerNumber) == ''">0.3.0</SemVerNumber>
     <SemVerSuffix>-prerelease</SemVerSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### Describe the change
Disable digital signing of axe-windows assemblies (consistent with our long-term plan). Bump the version number to reflect the following changes:
1. Referencing dependencies are no longer included in the package (#86)
2. The OutputFile is now a struct instead of a Tuple (#91)
3. The axe-windows assemblies are no longer digitally signed (included with this PR)

Note: This PR does not update any csproj files. That can happen at a later time without requiring a re-release.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
