### PR TITLE
Update docs to move automation info to the foreground and contribution info to the background

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,4 +1,7 @@
-## Contributing
+<!-- Copyright (c) Microsoft Corporation. All rights reserved.
+     Licensed under the MIT License. -->
+     
+     ## Contributing
 
 ### Code of conduct
 Please review the [Code of Conduct](./CODE_OF_CONDUCT.md) for this project.

--- a/README.md
+++ b/README.md
@@ -3,48 +3,67 @@
 
 ## Overview
 
-Axe.Windows is a [NuGet](https://www.nuget.org/) package for running automated accessibility tests on Windows® applications.
+Axe.Windows is a NuGet package for running automated accessibility tests on Windows® applications.
+
+To get the latest version of the Axe.Windows NuGet package, visit
+[Axe.Windows on NuGet.org](https://www.nuget.org/packages/Axe.Windows/).
+
+### How to run automated accessibility tests
+
+1. Create a `Config` object using `Config.Builder`.
+
+        // Create config to specifically target a process
+        var myConfigBuilder = Config.Builder.ForProcessId(1234);
+
+        // Optional: configure to create an A11yTest file
+        myConfigBuilder.WithOutputFileFormat(OutputFileFormat.A11yTest);
+
+        // Optional: configure to output the file to a specific directory (otherwise, current directory will be used)
+        myConfigBuilder.WithOutputDirectory(".\test-directory");
+
+        // Ready to use config
+        var myConfig = myConfigBuilder.build();
+
+2. Create a `Scanner` object using the `ScannerFactory` object with the `Config`.
+
+        // Create scanner using myConfig
+        var scanner = ScannerFactory.CreateScanner(myConfig);
+
+3. Call  the `Scan` method on the `Scanner` object.
+
+        var scanResults;
+        try
+        {
+            scanResults = scanner.Scan();
+        }
+        catch(AxeWindowsAutomationException e)
+        {
+            Console.WriteLine(e.ToString());
+        }
+
+4. Check the results.
+
+        Console.WriteLine("Number of errors found in scan: " + scanResults.ErrorCount);
+
 
 - Use an automation test framework like [UI Automation](https://docs.microsoft.com/en-us/dotnet/framework/ui-automation/ui-automation-overview) or [WinAppDriver](https://github.com/microsoft/WinAppDriver) to manipulate your application
 - Scan your application as many times as you need to
 - Axe.Windows returns results with each scan and can optionally save each scan's results to an a11ytest file you can open with [Accessibility Insights](https://accessibilityinsights.io/docs/en/windows/overview)
 
-To get the latest version of the Axe.Windows NuGet package, visit
-[Axe.Windows on NuGet.org](https://www.nuget.org/packages/Axe.Windows/).
 
-## How to run automated accessibility tests
-     
-For information about how to use Axe.Windows to test a Windows® application, please see the [Automation Guide](./docs/Automation.md).
-     
+For more details and a complete code example, please visit the [automation reference page](./docs/AutomationReference.md)
+
+
 ## Contributing
+
 All contributions are welcome! Please read through our guidelines on [contributions](./Contributing.md) to this project.
 
-## Building the code
-You can find more information on how to set up your development environment [here](./docs/SetUpDevEnv.md).
+For instructions on how to build the code, please visit [building the code](./docs/BuildingTheCode.md).
 
-### 1. Clone the repository
-- Clone the repository using one of the following commands
-  ``` bash
-  git clone https://github.com/Microsoft/axe-windows.git
-  ```
-  or
-  ``` bash
-  git clone git@github.com:Microsoft/axe-windows.git
-  ```
-- Select the created directory
-  ``` bash
-  cd axe-windows
-  ```
-
-### 2. Open the solution in Visual Studio
-- Use the `src/AxeWindows.sln` file to open the solution.
-
-### 3. Build and run unit tests
-
-## Testing
-We use the unit test framework from Visual Studio. Find more information in our [FAQ section](./docs/FAQ.md).
+For an overview of the solution, please visit the [solution overview](./docs/solution.md).
 
 ### More information
+
 Visit the [Overview of Axe.Windows](./docs/Overview.md) page.
 
 ## Data/Telemetry

--- a/docs/AccessingInternals.md
+++ b/docs/AccessingInternals.md
@@ -9,7 +9,7 @@ You can safely ignore this entire file if you make everything publicly available
 
 ### Add the `InternalsVisibleTo` attribute
 Add the following block to the end of your AssemblyInfo.cs file, replacing <YourAssemblyName> with the file name of your assembly--note that the ENABLE_SIGNING flag is already set as part of the build and that the keys are ***intentionally different***:
-```
+```C#
 #if ENABLE_SIGNING
 [assembly: InternalsVisibleTo("<YourAssemblyName>Tests,PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
 [assembly:InternalsVisibleTo("DynamicProxyGenAssembly2,PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]    

--- a/docs/AutomationReference.md
+++ b/docs/AutomationReference.md
@@ -1,48 +1,4 @@
-## Axe.Windows - Automation
-
-### Overview
-To provide automated accessibility testing for Windows applications, we have created the `Axe.Windows.Automation` .NET assembly which exposes a subset of core
-AxeWindows functionality to automation systems.
-
-### How to run an automated scan
-
-1. Create a `Config` object using `Config.Builder`.
-
-        // Create config to specifically target a process
-        var myConfigBuilder = Config.Builder.ForProcessId(1234);
-
-        // Optional: configure to create an A11yTest file
-        myConfigBuilder.WithOutputFileFormat(OutputFileFormat.A11yTest);
-
-        // Optional: configure to output the file to a specific directory (otherwise, current directory will be used)
-        myConfigBuilder.WithOutputDirectory(".\test-directory");
-
-        // Ready to use config
-        var myConfig = myConfigBuilder.build();
-
-2. Create a `Scanner` object using the `ScannerFactory` object with the `Config`.
-
-        // Create scanner using myConfig
-        var scanner = ScannerFactory.CreateScanner(myConfig);
-
-3. Call  the `Scan` method on the `Scanner` object.
-
-        var scanResults;
-        try
-        {
-            scanResults = scanner.Scan();
-        }
-        catch(AxeWindowsAutomationException e)
-        {
-            Console.WriteLine(e.ToString());
-        }
-
-4. Check the results.
-
-        Console.WriteLine("Number of errors found in scan: " + scanResults.ErrorCount);
-
-
-A [complete code example](#example) can be found below.
+## Axe.Windows - automation reference
 
 ### Class details
 
@@ -195,7 +151,7 @@ example below):
 -   Follow the steps in [How To Run An Automated Scan](#how-to-run-an-automated-scan).
 
 #### Example
-```
+```C#
     using System;
     using System.Collections.Generic;
     using Axe.Windows.Automation;

--- a/docs/BuildingTheCode.md
+++ b/docs/BuildingTheCode.md
@@ -1,0 +1,31 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved.
+     Licensed under the MIT License. -->
+
+## Building the code
+
+### 1. Clone the repository
+- Clone the repository using one of the following commands
+  ``` bash
+  git clone https://github.com/Microsoft/axe-windows.git
+  ```
+  or
+  ``` bash
+  git clone git@github.com:Microsoft/axe-windows.git
+  ```
+- Select the created directory
+  ``` bash
+  cd axe-windows
+  ```
+
+### 2. Open the solution in Visual Studio
+- Use the `src/AxeWindows.sln` file to open the solution.
+
+### 3. Build and run unit tests
+
+For details about how the code is organized, please visit the [solution overview](./solution.md).
+
+If you need more information on how to set up your development environment, please visit the [development environment setup page](./SetUpDevEnv.md).
+
+## Testing
+
+We use the unit test framework from Visual Studio. Find more information in our [FAQ section](./FAQ.md).

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -9,7 +9,11 @@ Axe.Windows is a [NuGet](https://www.nuget.org/) package for running automated a
 By contributing you will help ensure that people with disabilities have full access to applications. Make the world a better place!
 
 ### Q. How do I get started?
-Visit the [Readme](../README.md) and the [Overview](Overview.md) page.
+Visit the [Readme](../README.md) and the [Overview](Overview.md) page to get started.
+
+For instructions on how to build the code, please visit [building the code](./BuildingTheCode.md).
+
+For an overview of the solution, please visit the [solution overview](./solution.md).
 
 Once you are ready to make a contribution visit the [Contributions](../Contributing.md) page.
 
@@ -38,7 +42,9 @@ Please visit the [Telemetry](Telemetry.md) page on how to do so.
 ### Q. How do I add a project to the solution?
 Visit [Adding a new project](NewProject.md) for instructions.
 
-### Q. On my pull request, the "license/cla" check does not complete. What should I do?
+For an overview of the solution, please visit the [solution overview](./solution.md).
+
+### q. On my pull request, the "license/cla" check does not complete. What should I do?
 Make sure that you have signed our [CLA agreement](../Contributing.md). If you haven't, please sign the agreement, then close and reopen the PR. This will trigger a new build with the CLA agreement in place.
 
 ### Q. How do I get in contact?

--- a/docs/GitBranchSetup.md
+++ b/docs/GitBranchSetup.md
@@ -20,7 +20,7 @@ repository, start by creating your own [Fork](https://help.github.com/en/article
 -   Create the fork under your account. Your GitHub profile should now show **axe-windows** as one of your repositories.
 -   Create a folder on your device and clone your fork of the **axe-windows** repository. e.g. `https://github.com/ada-cat/axe-windows`. Notice how your GitHub username is in the repository location.
 
-```
+```bash
 git clone https://github.com/ada-cat/axe-windows
 ```
 
@@ -31,7 +31,7 @@ primary **axe-windows** repository.
 
 -   When you run git remote -v, you should see only your fork in the output list
 
-```
+```bash
 git remote -v
 origin  https://github.com/ada-cat/axe-windows (fetch)
 origin  https://github.com/ada-cat/axe-windows (push)
@@ -39,13 +39,13 @@ origin  https://github.com/ada-cat/axe-windows (push)
 
 -   Map the primary **axe-windows** as the upstream remote
 
-```
+```bash
 git remote add upstream https://github.com/Microsoft/axe-windows
 ```
 
 -   Now, running `git remote -v` should show the upstream repository also
 
-```
+```bash
 git remote -v
 origin  https://github.com/ada-cat/axe-windows (fetch)
 origin  https://github.com/ada-cat/axe-windows (push)
@@ -63,7 +63,7 @@ Create a branch from your fork and start making the code changes. Once you are h
 
 From time to time, your fork will get out of sync with the upstream remote. Use the following commands to get the master branch of your fork up to date.
 
-```
+```bash
 git fetch upstream
 git checkout master
 git pull upstream master
@@ -74,7 +74,7 @@ git push
 
 Use these commands instead if you would like to update your current branch in your fork from the upstream remote.
 
-```
+```bash
 git fetch upstream
 git pull upstream master
 git push

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -14,51 +14,6 @@ Windows UI Automation (UIA) is the platform-provided way for accessibility tools
 
 Axe.Windows takes the data provided by UIA and compares it to a set of rules which identify cases where the given data would create issues for users of the assistive technologies which consume UIA data. The results of these rules are then returned to the caller in a selection of formats.
 
-### The code
-The code is organized into the following general areas:
+For information about the code, please visit the [solution overview](./solution.md).
 
-#### Runtime components
-These assemblies provide the interaction with UIA, as well as layers that allow the application to interact with that information in a more structured manner:
-
-Assembly | Responsibility
---- | ---
-Axe.Windows.Actions | Provide a high-level set of Actions that are the primary interface into the Runtime components.
-Axe.Windows.Core | Provide classes, interfaces, and types used by projects throughout the Axe.Windows solution.
-Axe.Windows.Desktop | Provide Windows-specific implementations of the data abstractions found in Axe.Windows.Core. The low-level interactions with UIA occur in this assembly.
-Axe.Windows.Telemetry | Provides an interface which any caller can supply to capture telemetry from Axe.Windows
-Axe.Windows.Win32 | Provide a wrapper around Win32-specific code that is needed by other assemblies.
-
-#### Accessibility rules
-These assemblies contain the automated tests used to evaluate the accessibility of an application. Please visit the [Rules Overview](./RulesOverview.md) for a detailed description of the automated accessibility tests.
-
-Assembly | Responsibility
---- | ---
-Axe.Windows.Rules | Provide a library of rules, each of which scans a given element (or elements) for issues that are likely to be problematic. For example, a button without an accessible label will be flagged as an error.
-Axe.Windows.RuleSelection | Coordinate rule execution in a consistent and reproducible way.
-
-#### Application entry points
-These assemblies allow user interaction with the Runtime components and the Accessibility Rules.
-
-Assembly | Responsibility
---- | ---
-Axe.Windows.Automation | Provide a layer that wraps key actions behind a simplified interface. This layer can be used to run Axe.Windows automated accessibility tests programmatically.
-
-#### Packaging
-The packaging project exists to gather assemblies into their shipping vehicle:
-
-Project | Responsibility
---- | ---
-CI | Builds the NuGet package that will be referenced by code that uses the library.
-
-#### Tests
-Unit tests are built using a combination of Moq and Microsoft Fakes. The folllowing projects exist for testing purposes:
-- Fakes.Prebuild
-- ActionsTests
-- AutomationTests
-- CoreTests
-- DesktopTests
-- RuleSelectionTests
-- RulesTest
-- UnitTestSharedLibrary
-- TelemetryTests
-- Win32Tests 
+For information about the rules used for accessibility testing, please visit the [rules overview](./RulesOverview.md).

--- a/docs/solution.md
+++ b/docs/solution.md
@@ -1,0 +1,53 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved.
+     Licensed under the MIT License. -->
+
+## Solution overview
+
+The code is organized into the following general areas:
+
+#### Runtime components
+These assemblies provide the interaction with UIA, as well as layers that allow the application to interact with that information in a more convenient way:
+
+Assembly | Responsibility
+--- | ---
+Axe.Windows.Actions | Provide a high-level set of Actions that are the primary interface into the Runtime components.
+Axe.Windows.Core | Provide classes, interfaces, and types used by projects throughout the Axe.Windows solution.
+Axe.Windows.Desktop | Provide Windows-specific implementations of the data abstractions found in Axe.Windows.Core. The low-level interactions with UIA occur in this assembly.
+Axe.Windows.Telemetry | Provides an interface which any caller can supply to capture telemetry from Axe.Windows
+Axe.Windows.Win32 | Provide a wrapper around Win32-specific code that is needed by other assemblies.
+
+#### Accessibility rules
+These assemblies contain the automated tests used to evaluate the accessibility of an application. Please visit the [Rules Overview](./RulesOverview.md) for a detailed description of the automated accessibility tests.
+
+Assembly | Responsibility
+--- | ---
+Axe.Windows.Rules | Provide a library of rules, each of which scans a given element (or elements) for issues that are likely to be problematic. For example, a button without an accessible label will be flagged as an error.
+Axe.Windows.RuleSelection | Coordinate rule execution in a consistent and reproducible way.
+
+#### Application entry points
+These assemblies allow user interaction with the Runtime components and the Accessibility Rules.
+
+Assembly | Responsibility
+--- | ---
+Axe.Windows.Automation | Provide a layer that wraps key actions behind a simplified interface. This layer can be used to run Axe.Windows automated accessibility tests programmatically.
+
+#### Packaging
+The packaging project exists to gather assemblies into their shipping vehicle:
+
+Project | Responsibility
+--- | ---
+CI | Builds the NuGet package that will be referenced by code that uses the library.
+
+#### Tests
+
+Unit tests are built using a combination of Moq and Microsoft Fakes. The folllowing projects exist for testing purposes:
+- Fakes.Prebuild
+- ActionsTests
+- AutomationTests
+- CoreTests
+- DesktopTests
+- RuleSelectionTests
+- RulesTest
+- UnitTestSharedLibrary
+- TelemetryTests
+- Win32Tests 


### PR DESCRIPTION
#### Describe the change

- Move the extensive how-to section from automation.md to readme.md
- Rename automation.md to AutomationReference.md
- Extract solution information from overview.md
- add solution overview to solution.md where it can be referenced from multiple places
- Move sections on building the code to their own file where they can be referenced from multiple places
- Add tags to code blocks to get syntax highlighting

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



