### PR TITLE
docs: remove leading whitespace in Contributing header

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,7 +1,7 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved.
      Licensed under the MIT License. -->
      
-     ## Contributing
+## Contributing
 
 ### Code of conduct
 Please review the [Code of Conduct](./CODE_OF_CONDUCT.md) for this project.


### PR DESCRIPTION
#### Describe the change

Extra whitespace made the `Contributing` heading format as a code snippet. Removed leading whitespace to fix this.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



