### PR TITLE
Create SystemAbstractions project

### DIFF
--- a/build/NetStandardAll.targets
+++ b/build/NetStandardAll.targets
@@ -1,0 +1,8 @@
+﻿<Project>
+
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
+</Project>

--- a/build/NetStandardRelease.targets
+++ b/build/NetStandardRelease.targets
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-  <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 </PropertyGroup>
 
   <ItemGroup>

--- a/build/NetStandardRelease.targets
+++ b/build/NetStandardRelease.targets
@@ -1,0 +1,26 @@
+﻿<Project>
+
+  <PropertyGroup>
+  <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+</PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(TEMP)\AxeWindowsVersionInfo.cs" Link="AxeWindowsVersionInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.3" />
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <DropSignedFile Include="$(TargetPath)" />
+  </ItemGroup>
+  
+  <Import Project="NetStandardAll.targets" />
+  <Import Project="settings.targets" />
+
+</Project>

--- a/build/NetStandardRelease.targets
+++ b/build/NetStandardRelease.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-</PropertyGroup>
+  </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="$(TEMP)\AxeWindowsVersionInfo.cs" Link="AxeWindowsVersionInfo.cs" />

--- a/build/NetStandardTest.targets
+++ b/build/NetStandardTest.targets
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+<PropertyGroup>
+    <NoWarn>1701;1702;CA1707</NoWarn>
+  </PropertyGroup>
+
+<Import Project=".\NetStandardAll.targets" />
+  <Import Project=".\DelaySign.targets" />
+  
+</Project>

--- a/build/NetStandardTest.targets
+++ b/build/NetStandardTest.targets
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-<PropertyGroup>
+  <PropertyGroup>
     <NoWarn>1701;1702;CA1707</NoWarn>
   </PropertyGroup>
 
-<Import Project=".\NetStandardAll.targets" />
+  <Import Project=".\NetStandardAll.targets" />
   <Import Project=".\DelaySign.targets" />
   
 </Project>

--- a/src/Automation/Automation.csproj
+++ b/src/Automation/Automation.csproj
@@ -58,21 +58,13 @@
       <Project>{7FE58829-560E-4142-BF81-291A66D3844B}</Project>
       <Name>Rules</Name>
     </ProjectReference>
+    <ProjectReference Include="..\SystemAbstractions\SystemAbstractions.csproj">
+      <Project>{7e616c64-ead7-458c-92ac-b50643e64d38}</Project>
+      <Name>SystemAbstractions</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(TEMP)\AxeWindowsVersionInfo.cs" />
-    <Compile Include="Abstractions\ISystem.cs" />
-    <Compile Include="Abstractions\ISystemDateTime.cs" />
-    <Compile Include="Abstractions\ISystemFactory.cs" />
-    <Compile Include="Abstractions\ISystemIO.cs" />
-    <Compile Include="Abstractions\ISystemIODirectory.cs" />
-    <Compile Include="Abstractions\ISystemEnvironment.cs" />
-    <Compile Include="Concretions\System.cs" />
-    <Compile Include="Concretions\SystemDateTime.cs" />
-    <Compile Include="Concretions\SystemEnvironment.cs" />
-    <Compile Include="Concretions\SystemFactory.cs" />
-    <Compile Include="Concretions\SystemIO.cs" />
-    <Compile Include="Concretions\SystemIODirectory.cs" />
     <Compile Include="Data\Config.cs" />
     <Compile Include="Data\ElementInfo.cs" />
     <Compile Include="Data\OutputFile.cs" />

--- a/src/Automation/Factory.cs
+++ b/src/Automation/Factory.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Abstractions;
-using Axe.Windows.Concretions;
 using System;
+using SystemAbstractions; 
 
 namespace Axe.Windows.Automation
 {

--- a/src/Automation/Factory.cs
+++ b/src/Automation/Factory.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.SystemAbstractions;
 using System;
-using SystemAbstractions; 
 
 namespace Axe.Windows.Automation
 {

--- a/src/Automation/OutputFileHelper.cs
+++ b/src/Automation/OutputFileHelper.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Abstractions;
 using System;
 using System.Globalization;
+using SystemAbstractions;
 using Path = System.IO.Path;
 
 using static System.FormattableString;

--- a/src/Automation/OutputFileHelper.cs
+++ b/src/Automation/OutputFileHelper.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.SystemAbstractions;
 using System;
 using System.Globalization;
-using SystemAbstractions;
 using Path = System.IO.Path;
 
 using static System.FormattableString;

--- a/src/AutomationTests/AutomationTests.csproj
+++ b/src/AutomationTests/AutomationTests.csproj
@@ -87,7 +87,6 @@
     <Compile Include="ScanResultsAssemblerTests.cs" />
     <Compile Include="ScanToolsBuilderUnitTests.cs" />
     <Compile Include="SnapshotCommandUnitTests.cs" />
-    <Compile Include="SystemUnitTests.cs" />
   </ItemGroup>
   <Import Project="..\..\build\delaysign.targets" />
   <ItemGroup>
@@ -106,6 +105,10 @@
     <ProjectReference Include="..\Rules\Rules.csproj">
       <Project>{7FE58829-560E-4142-BF81-291A66D3844B}</Project>
       <Name>Rules</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SystemAbstractions\SystemAbstractions.csproj">
+      <Project>{7e616c64-ead7-458c-92ac-b50643e64d38}</Project>
+      <Name>SystemAbstractions</Name>
     </ProjectReference>
     <ProjectReference Include="..\UnitTestSharedLibrary\UnitTestSharedLibrary.csproj">
       <Project>{01dc8363-73bc-47fa-bd23-12ac45618e1d}</Project>

--- a/src/AutomationTests/OutputFileHelperUnitTests.cs
+++ b/src/AutomationTests/OutputFileHelperUnitTests.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Abstractions;
 using Axe.Windows.Automation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
+using SystemAbstractions;
 using Path = System.IO.Path;
 
 namespace Axe.Windows.AutomationTests

--- a/src/AutomationTests/OutputFileHelperUnitTests.cs
+++ b/src/AutomationTests/OutputFileHelperUnitTests.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Automation;
+using Axe.Windows.SystemAbstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
-using SystemAbstractions;
 using Path = System.IO.Path;
 
 namespace Axe.Windows.AutomationTests

--- a/src/AxeWindows.sln
+++ b/src/AxeWindows.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2050
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29102.190
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Actions", "Actions\Actions.csproj", "{B2FA5150-470A-4864-A191-7BCAE39DF35A}"
 EndProject
@@ -58,6 +58,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RulesTests", "RulesTest\Rul
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CI", "CI\CI.csproj", "{32273060-8BBE-4BB6-9198-50F9C680BE60}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SystemAbstractions", "SystemAbstractions\SystemAbstractions.csproj", "{7E616C64-EAD7-458C-92AC-B50643E64D38}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SystemAbstractionsTests", "SystemAbstractionsTests\SystemAbstractionsTests.csproj", "{683CBD73-C7B8-4662-A9DE-96E434E167D5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -297,6 +301,30 @@ Global
 		{32273060-8BBE-4BB6-9198-50F9C680BE60}.Release|x64.Build.0 = Release|Any CPU
 		{32273060-8BBE-4BB6-9198-50F9C680BE60}.Release|x86.ActiveCfg = Release|Any CPU
 		{32273060-8BBE-4BB6-9198-50F9C680BE60}.Release|x86.Build.0 = Release|Any CPU
+		{7E616C64-EAD7-458C-92AC-B50643E64D38}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E616C64-EAD7-458C-92AC-B50643E64D38}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E616C64-EAD7-458C-92AC-B50643E64D38}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7E616C64-EAD7-458C-92AC-B50643E64D38}.Debug|x64.Build.0 = Debug|Any CPU
+		{7E616C64-EAD7-458C-92AC-B50643E64D38}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7E616C64-EAD7-458C-92AC-B50643E64D38}.Debug|x86.Build.0 = Debug|Any CPU
+		{7E616C64-EAD7-458C-92AC-B50643E64D38}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E616C64-EAD7-458C-92AC-B50643E64D38}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E616C64-EAD7-458C-92AC-B50643E64D38}.Release|x64.ActiveCfg = Release|Any CPU
+		{7E616C64-EAD7-458C-92AC-B50643E64D38}.Release|x64.Build.0 = Release|Any CPU
+		{7E616C64-EAD7-458C-92AC-B50643E64D38}.Release|x86.ActiveCfg = Release|Any CPU
+		{7E616C64-EAD7-458C-92AC-B50643E64D38}.Release|x86.Build.0 = Release|Any CPU
+		{683CBD73-C7B8-4662-A9DE-96E434E167D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{683CBD73-C7B8-4662-A9DE-96E434E167D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{683CBD73-C7B8-4662-A9DE-96E434E167D5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{683CBD73-C7B8-4662-A9DE-96E434E167D5}.Debug|x64.Build.0 = Debug|Any CPU
+		{683CBD73-C7B8-4662-A9DE-96E434E167D5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{683CBD73-C7B8-4662-A9DE-96E434E167D5}.Debug|x86.Build.0 = Debug|Any CPU
+		{683CBD73-C7B8-4662-A9DE-96E434E167D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{683CBD73-C7B8-4662-A9DE-96E434E167D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{683CBD73-C7B8-4662-A9DE-96E434E167D5}.Release|x64.ActiveCfg = Release|Any CPU
+		{683CBD73-C7B8-4662-A9DE-96E434E167D5}.Release|x64.Build.0 = Release|Any CPU
+		{683CBD73-C7B8-4662-A9DE-96E434E167D5}.Release|x86.ActiveCfg = Release|Any CPU
+		{683CBD73-C7B8-4662-A9DE-96E434E167D5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/SystemAbstractions/Abstractions/ISystem.cs
+++ b/src/SystemAbstractions/Abstractions/ISystem.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
-using System.IO;
 
-namespace Axe.Windows.Abstractions
+namespace SystemAbstractions
 {
-    internal interface ISystemIODirectory
+    public interface ISystem
     {
-        DirectoryInfo CreateDirectory(string path);
-        bool Exists(string path);
+        ISystemDateTime DateTime { get; }
+        ISystemEnvironment Environment { get; }
+        ISystemIO IO { get; }
     } // interface
 } // namespace

--- a/src/SystemAbstractions/Abstractions/ISystem.cs
+++ b/src/SystemAbstractions/Abstractions/ISystem.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 
-namespace SystemAbstractions
+namespace Axe.Windows.SystemAbstractions
 {
     public interface ISystem
     {

--- a/src/SystemAbstractions/Abstractions/ISystemDateTime.cs
+++ b/src/SystemAbstractions/Abstractions/ISystemDateTime.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 
-namespace SystemAbstractions
+namespace Axe.Windows.SystemAbstractions
 {
     public interface ISystemDateTime
     {

--- a/src/SystemAbstractions/Abstractions/ISystemDateTime.cs
+++ b/src/SystemAbstractions/Abstractions/ISystemDateTime.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Abstractions;
 using System;
 
-namespace Axe.Windows.Concretions
+namespace SystemAbstractions
 {
-    internal class SystemDateTime : ISystemDateTime
+    public interface ISystemDateTime
     {
-        public DateTime Now => DateTime.Now;
-    } // class
+        DateTime Now { get; }
+    } // interface
 } // namespace

--- a/src/SystemAbstractions/Abstractions/ISystemEnvironment.cs
+++ b/src/SystemAbstractions/Abstractions/ISystemEnvironment.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 
-namespace SystemAbstractions
+namespace Axe.Windows.SystemAbstractions
 {
     public interface ISystemEnvironment
     {

--- a/src/SystemAbstractions/Abstractions/ISystemEnvironment.cs
+++ b/src/SystemAbstractions/Abstractions/ISystemEnvironment.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 
-namespace Axe.Windows.Abstractions
+namespace SystemAbstractions
 {
-    internal interface ISystemIO
+    public interface ISystemEnvironment
     {
-        ISystemIODirectory Directory { get; }
+        string CurrentDirectory { get; }
     } // interface
 } // namespace

--- a/src/SystemAbstractions/Abstractions/ISystemFactory.cs
+++ b/src/SystemAbstractions/Abstractions/ISystemFactory.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Abstractions;
 
-namespace Axe.Windows.Abstractions
+namespace SystemAbstractions
 {
     internal interface ISystemFactory
     {

--- a/src/SystemAbstractions/Abstractions/ISystemFactory.cs
+++ b/src/SystemAbstractions/Abstractions/ISystemFactory.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace SystemAbstractions
+namespace Axe.Windows.SystemAbstractions
 {
     internal interface ISystemFactory
     {

--- a/src/SystemAbstractions/Abstractions/ISystemIO.cs
+++ b/src/SystemAbstractions/Abstractions/ISystemIO.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 
-namespace SystemAbstractions
+namespace Axe.Windows.SystemAbstractions
 {
     public interface ISystemIO
     {

--- a/src/SystemAbstractions/Abstractions/ISystemIO.cs
+++ b/src/SystemAbstractions/Abstractions/ISystemIO.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 
-namespace Axe.Windows.Abstractions
+namespace SystemAbstractions
 {
-    internal interface ISystemDateTime
+    public interface ISystemIO
     {
-        DateTime Now { get; }
+        ISystemIODirectory Directory { get; }
     } // interface
 } // namespace

--- a/src/SystemAbstractions/Abstractions/ISystemIODirectory.cs
+++ b/src/SystemAbstractions/Abstractions/ISystemIODirectory.cs
@@ -3,7 +3,7 @@
 using System;
 using System.IO;
 
-namespace SystemAbstractions
+namespace Axe.Windows.SystemAbstractions
 {
     public interface ISystemIODirectory
     {

--- a/src/SystemAbstractions/Abstractions/ISystemIODirectory.cs
+++ b/src/SystemAbstractions/Abstractions/ISystemIODirectory.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
+using System.IO;
 
-namespace Axe.Windows.Abstractions
+namespace SystemAbstractions
 {
-    internal interface ISystem
+    public interface ISystemIODirectory
     {
-        ISystemDateTime DateTime { get; }
-        ISystemEnvironment Environment { get; }
-        ISystemIO IO { get; }
+        DirectoryInfo CreateDirectory(string path);
+        bool Exists(string path);
     } // interface
 } // namespace

--- a/src/SystemAbstractions/Concretions/System.cs
+++ b/src/SystemAbstractions/Concretions/System.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace SystemAbstractions
+namespace Axe.Windows.SystemAbstractions
 {
     class System : ISystem
     {

--- a/src/SystemAbstractions/Concretions/System.cs
+++ b/src/SystemAbstractions/Concretions/System.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Abstractions;
 using System;
 using System.Collections.Generic;
 
-namespace Axe.Windows.Concretions
+namespace SystemAbstractions
 {
     class System : ISystem
     {

--- a/src/SystemAbstractions/Concretions/SystemDateTime.cs
+++ b/src/SystemAbstractions/Concretions/SystemDateTime.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 
-namespace SystemAbstractions
+namespace Axe.Windows.SystemAbstractions
 {
     internal class SystemDateTime : ISystemDateTime
     {

--- a/src/SystemAbstractions/Concretions/SystemDateTime.cs
+++ b/src/SystemAbstractions/Concretions/SystemDateTime.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 
-namespace Axe.Windows.Abstractions
+namespace SystemAbstractions
 {
-    internal interface ISystemEnvironment
+    internal class SystemDateTime : ISystemDateTime
     {
-        string CurrentDirectory { get; }
-    } // interface
+        public DateTime Now => DateTime.Now;
+    } // class
 } // namespace

--- a/src/SystemAbstractions/Concretions/SystemEnvironment.cs
+++ b/src/SystemAbstractions/Concretions/SystemEnvironment.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Abstractions;
 using System;
 
-namespace Axe.Windows.Concretions
+namespace SystemAbstractions
 {
     class SystemEnvironment : ISystemEnvironment
     {

--- a/src/SystemAbstractions/Concretions/SystemEnvironment.cs
+++ b/src/SystemAbstractions/Concretions/SystemEnvironment.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 
-namespace SystemAbstractions
+namespace Axe.Windows.SystemAbstractions
 {
     class SystemEnvironment : ISystemEnvironment
     {

--- a/src/SystemAbstractions/Concretions/SystemFactory.cs
+++ b/src/SystemAbstractions/Concretions/SystemFactory.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Abstractions;
 
-namespace Axe.Windows.Concretions
+namespace SystemAbstractions
 {
-    internal class SystemFactory : ISystemFactory
+    public class SystemFactory : ISystemFactory
     {
         private readonly static ISystemFactory SystemFactoryInstance = new SystemFactory();
 

--- a/src/SystemAbstractions/Concretions/SystemFactory.cs
+++ b/src/SystemAbstractions/Concretions/SystemFactory.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace SystemAbstractions
+namespace Axe.Windows.SystemAbstractions
 {
     public class SystemFactory : ISystemFactory
     {

--- a/src/SystemAbstractions/Concretions/SystemIO.cs
+++ b/src/SystemAbstractions/Concretions/SystemIO.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 
-namespace SystemAbstractions
+namespace Axe.Windows.SystemAbstractions
 {
     class SystemIO : ISystemIO
     {

--- a/src/SystemAbstractions/Concretions/SystemIO.cs
+++ b/src/SystemAbstractions/Concretions/SystemIO.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Abstractions;
 using System;
 
-namespace Axe.Windows.Concretions
+namespace SystemAbstractions
 {
     class SystemIO : ISystemIO
     {

--- a/src/SystemAbstractions/Concretions/SystemIODirectory.cs
+++ b/src/SystemAbstractions/Concretions/SystemIODirectory.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Abstractions;
 using System;
 using System.IO;
 
-namespace Axe.Windows.Concretions
+namespace SystemAbstractions
 {
     internal class SystemIODirectory : ISystemIODirectory
     {

--- a/src/SystemAbstractions/Concretions/SystemIODirectory.cs
+++ b/src/SystemAbstractions/Concretions/SystemIODirectory.cs
@@ -3,7 +3,7 @@
 using System;
 using System.IO;
 
-namespace SystemAbstractions
+namespace Axe.Windows.SystemAbstractions
 {
     internal class SystemIODirectory : ISystemIODirectory
     {

--- a/src/SystemAbstractions/SystemAbstractions.csproj
+++ b/src/SystemAbstractions/SystemAbstractions.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Axe.Windows.SystemAbstractions</AssemblyName>
+    <RootNamespace>Axe.Windows.SystemAbstractions</RootNamespace>
   </PropertyGroup>
 
 </Project>

--- a/src/SystemAbstractions/SystemAbstractions.csproj
+++ b/src/SystemAbstractions/SystemAbstractions.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Axe.Windows.SystemAbstractions</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/SystemAbstractions/SystemAbstractions.csproj
+++ b/src/SystemAbstractions/SystemAbstractions.csproj
@@ -6,4 +6,5 @@
     <RootNamespace>Axe.Windows.SystemAbstractions</RootNamespace>
   </PropertyGroup>
 
+  <Import Project="..\..\build\NetStandardRelease.targets" />
 </Project>

--- a/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
+++ b/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
@@ -17,4 +17,6 @@
     <ProjectReference Include="..\SystemAbstractions\SystemAbstractions.csproj" />
   </ItemGroup>
 
+  <Import Project="..\..\build\NetStandardTest.targets" />
+
 </Project>

--- a/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
+++ b/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SystemAbstractions\SystemAbstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SystemAbstractionsTests/SystemUnitTests.cs
+++ b/src/SystemAbstractionsTests/SystemUnitTests.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Abstractions;
-using Axe.Windows.Concretions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using SystemAbstractions;
 
-namespace Axe.Windows.AutomationTests
+namespace SystemAbstractionsTests
 {
     using Path = System.IO.Path;
 

--- a/src/SystemAbstractionsTests/SystemUnitTests.cs
+++ b/src/SystemAbstractionsTests/SystemUnitTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using SystemAbstractions;
+using Axe.Windows.SystemAbstractions;
 
 namespace SystemAbstractionsTests
 {


### PR DESCRIPTION
#### Describe the change

- Enable other projects to use the system abstractions formerly limited to Axe.Windows.Automation
	- Allow System calls to be mocked so Fakes can be replaced
- Use .Net Standard to ensure broadest future compatibility

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



