### PR TITLE
Rework Config.Builder.Build to return new each time

### DIFF
--- a/src/Automation/Data/Config.cs
+++ b/src/Automation/Data/Config.cs
@@ -91,7 +91,12 @@ namespace Axe.Windows.Automation
             /// <returns></returns>
             public Config Build()
             {
-                return _config;
+                return new Config
+                {
+                    ProcessId = _config.ProcessId,
+                    OutputFileFormat = _config.OutputFileFormat,
+                    OutputDirectory = _config.OutputDirectory,
+                };
             }
         } // Builder
     } // class


### PR DESCRIPTION
#### Describe the change

The expectation for a builder pattern seems to be that a new object should be created each time Build() is called. This change fixes the issue where Config.Builder.Build() would have returned the same object if Build() had been called multiple times.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



