### PR TITLE
Remove remaining Sarif Refefence

### DIFF
--- a/src/ActionsTests/ActionsTests.csproj
+++ b/src/ActionsTests/ActionsTests.csproj
@@ -75,9 +75,6 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sarif.2.0.0.0.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
-      <HintPath>..\Fakes.Prebuild\FakesAssemblies\Sarif.2.0.0.0.Fakes.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>


### PR DESCRIPTION
#### Describe the change
This one apparently got missed in the previous cleanup of Sarif references

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



