### PR TITLE
Re-add SignAppForRelease in SignedRelease job

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -189,6 +189,7 @@ jobs:
   variables:
     PublicRelease: 'true'
     MicroBuild_NuPkgSigningEnabled: 'false'
+    SignAppForRelease: 'true'
   steps:
   - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
     displayName: 'Install Localization Plugin'


### PR DESCRIPTION
#### Describe the change
Test theory that this will re-enable strongname signing

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



