### PR TITLE
Remove authenticode signing

### DIFF
--- a/build/settings.targets
+++ b/build/settings.targets
@@ -10,7 +10,7 @@
     <When Condition=" '$(SignAppForRelease)'=='true' AND '$(Configuration)' == 'Release'">
       <ItemGroup>
         <FilesToSign Include="@(DropSignedFile)">
-          <Authenticode>Microsoft400</Authenticode>
+          <!--Authenticode>Microsoft400</Authenticode-->
           <StrongName>StrongName</StrongName>
         </FilesToSign>
       </ItemGroup>


### PR DESCRIPTION
#### Describe the change

Had previously disabled authenticode signing by removing the SignAppForRelease variable from signed build yml file. But that change also inadvertently disabled strong name signing for the assemblies as well. We have since restored SignAppForRelease in the yml file. This change makes it so assemblies should be strong name signed, but not authenticode signed.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



