### PR TITLE
Add .Net Standard-related content to documentation

### DIFF
--- a/docs/NewProject.md
+++ b/docs/NewProject.md
@@ -12,8 +12,7 @@
 ### For all .Net Framework projects
 
 1. Right-click on the project and select Properties.
-2. In the Application tab, configure "Target Framework" to use the same .NET Framework version used by the `axe.windows.core` project.
-   - Currently .NET Framework 4.7.1
+2. In the Application tab, configure "Target Framework" to use the same .NET Framework version used by the `axe.windows.core` project, currently .NET Framework 4.7.1.
 3. In the build tab, set the following for both Debug and Release configurations:
    1. "Warning level" to 4.
    2. "Treat warnings as errors" to "All".

--- a/docs/NewProject.md
+++ b/docs/NewProject.md
@@ -25,7 +25,7 @@
    Microsoft.CodeAnalysis.FxCopAnalyzers
    ```
 2. Close the solution and use your text editor to make the following changes to your `.csproj` file to properly configure the version and signing options:
-   1. Add the following line along side the existing `<Compile>` statements:<br>
+   1. Add the following line alongside the existing `<Compile>` statements:<br>
    `<Compile Include="$(TEMP)\AxeWindowsVersionInfo.cs" />`
    2. Add the following below the last ItemGroup:<br>
    ```

--- a/docs/NewProject.md
+++ b/docs/NewProject.md
@@ -2,43 +2,60 @@
      Licensed under the MIT License. -->
      
 ## Adding a new project
-Do the following when adding a new project:
 
-### For all projects
-1. Add a project to the Axe.Windows Solution (`src\axe.windows.sln`).
-2. Right-click on the project and select Properties.
+### All project types
+
+1. Add your new project to the Axe.Windows Solution (`src\AxeWindows.sln`).
+2. Before creating a pull request, verify that Visual Studio can successfully load and build the entire solution in both Debug and Release.
+3. If your project requires NuGet dependencies which need to be installed along side it, update the <dependencies> section of `./src/ci/axe.windows.nuspec`.
+
+### For all .Net Framework projects
+
+1. Right-click on the project and select Properties.
 2. In the Application tab, configure "Target Framework" to use the same .NET Framework version used by the `axe.windows.core` project.
-   - Currently .NET Framework 4.7.1 is the target. 
+   - Currently .NET Framework 4.7.1
 3. In the build tab, set the following for both Debug and Release configurations:
    1. "Warning level" to 4.
    2. "Treat warnings as errors" to "All".
 
-### For *non-test* projects only
-1. Add the following NuGet packages in Visual Studio to enable signing and code analysis:
+#### For *production (not test)* .Net Framework projects
+
+1. Add the following NuGet packages in Visual Studio to enable signing and code analysis:<br>
    ```
    Microsoft.VisualStudioEng.MicroBuild.Core
    Microsoft.CodeAnalysis.FxCopAnalyzers
    ```
 2. Close the solution and use your text editor to make the following changes to your `.csproj` file to properly configure the version and signing options:
-   1. Add the following line with the other `.cs` files):<br>
+   1. Add the following line along side the existing `<Compile>` statements:<br>
    `<Compile Include="$(TEMP)\AxeWindowsVersionInfo.cs" />`
    2. Add the following below the last ItemGroup:<br>
    ```
    <ItemGroup>
-      <DropSignedFile Include="$(OutDir)\[your project name].dll" />
+      <DropSignedFile Include="$(TargetPath)" />
    </ItemGroup>
    <Import Project="..\..\build\settings.targets" />
    ```
 3. Use your text editor to make the following changes to your project's `Properties\AssemblyInfo` file to set the correct version:
-   1. Remove the following lines from the following lines, as well as the commented lines above them: <br>
+   1. Remove the following lines, as well as the commented lines above them: <br>
       ```
       [assembly: AssemblyVersion("1.0.*")]
       [assembly: AssemblyFileVersion("1.0.0.0")]
       ```
-4. Verify that Visual Studio can successfully load and build the entire solution in both Debug and Release.
-5. If your project requires NuGet dependencies which need to be installed along side it, update the <dependencies> section of `./src/ci/axe.windows.nuspec`.
 
-### For *test* projects only
+#### For *test* .Net Framework projects
+
 1. Close the solution and use your text editor to add the following line to your `.csproj` file to properly configure [Strong Naming](https://docs.microsoft.com/en-us/dotnet/framework/app-domains/strong-named-assemblies) for your assembly:<br>
    `<Import Project="..\..\build\delaysign.targets" />`
-2. Verify that Visual Studio can successfully load and build the entire solution in both Debug and Release. Ensure that the tests are appropriately discovered in the test explorer, and that they all run successfully.
+2. Build the entire solution in both Debug and Release. Ensure that the tests are appropriately discovered in the test explorer, and that they all run successfully.
+
+### .Net Standard and .Net Core projects
+
+#### For *production (not test)* .Net Standard/Core projects
+
+In a text editor, add the following line:<br>
+`<Import Project="..\..\build\NetStandardRelease.targets" />`
+
+#### For *test* .Net Standard/Core projects
+
+In a text editor, add the following line:<br>
+`<Import Project="..\..\build\NetStandardTest.targets" />`

--- a/docs/solution.md
+++ b/docs/solution.md
@@ -13,6 +13,7 @@ Assembly | Responsibility
 Axe.Windows.Actions | Provide a high-level set of Actions that are the primary interface into the Runtime components.
 Axe.Windows.Core | Provide classes, interfaces, and types used by projects throughout the Axe.Windows solution.
 Axe.Windows.Desktop | Provide Windows-specific implementations of the data abstractions found in Axe.Windows.Core. The low-level interactions with UIA occur in this assembly.
+Axe.Windows.SystemAbstractions | Provides abstract classes for accessing system components, making it possible to unit test code that consumes the abstractions by using mocks
 Axe.Windows.Telemetry | Provides an interface which any caller can supply to capture telemetry from Axe.Windows
 Axe.Windows.Win32 | Provide a wrapper around Win32-specific code that is needed by other assemblies.
 
@@ -48,6 +49,7 @@ Unit tests are built using a combination of Moq and Microsoft Fakes. The folllow
 - DesktopTests
 - RuleSelectionTests
 - RulesTest
+- SystemAbstractionsTests
 - UnitTestSharedLibrary
 - TelemetryTests
 - Win32Tests 


### PR DESCRIPTION
#### Describe the change

Relevant after the creation of the SystemAbstractions .Net Standard project and the SystemAbstractionsTests .Net Core project

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



