### PR TITLE
Change from using FxCop analyzers to RoslynAnalyzers in the pipeline

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -108,7 +108,7 @@ jobs:
       verboseOutput: true
       debugMode: false
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task -roslynanalyzers.RoslynAnalyzers@2
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
     displayName: 'Run Roslyn analyzers'
     inputs:
         userProvideBuildInfo: auto

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -135,7 +135,6 @@ jobs:
     inputs:
       CredScan: true
       RoslynAnalyzers: true
-      RoslynAnalyzersBreakOn: CriticalError
       PoliCheck: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -108,20 +108,10 @@ jobs:
       verboseOutput: true
       debugMode: false
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-fxcop.FxCop@2
-    displayName: 'Run FxCop'
-    inputs:
-      inputType: Basic
-      # Double-quote syntax with trailing backslash on each line concatenates lines without spaces
-      targets: "src\\Actions\\bin\\Debug\\Axe.Windows.*.dll;\
-                src\\Automation\\bin\\Debug\\Axe.Windows.*.dll;\
-                src\\Core\\bin\\Debug\\Axe.Windows.*.dll;\
-                src\\Desktop\\bin\\Debug\\Axe.Windows.*.dll;\
-                src\\Rules\\bin\\Debug\\Axe.Windows.*.dll;\
-                src\\RuleSelection\\bin\\Debug\\Axe.Windows.*.dll;\
-                src\\Telemetry\\bin\\Debug\\Axe.Windows.*.dll;\
-                src\\Win32\\bin\\Debug\\Axe.Windows.*.dll;"
-      ignoreGeneratedCode: true
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task -roslynanalyzers.RoslynAnalyzers@2
+    displayName: 'Run Roslyn analyzers'
+    userProvideBuildInfo: auto
+    rulesetName: recommended
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
     displayName: 'Run PoliCheck'
@@ -130,25 +120,25 @@ jobs:
     continueOnError: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@1
-    displayName: 'Create Security Analysis Report (CredScan, FxCop, and PoliCheck)'
+    displayName: 'Create Security Analysis Report (CredScan, RoslynAnalyzers, and PoliCheck)'
     inputs:
       CredScan: true
-      FxCop: true
+      RoslynAnalyzers: true
       PoliCheck: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
-    displayName: 'Publish Security Analysis Logs (CredScan, FxCop, and PoliCheck)'
+    displayName: 'Publish Security Analysis Logs (CredScan, RoslynAnalyzers, and PoliCheck)'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
-    displayName: 'Post Analysis (CredScan, FxCop, and PoliCheck)'
+    displayName: 'Post Analysis (CredScan, RoslynAnalyzers, and PoliCheck)'
     inputs:
       CredScan: true
-      FxCop: true
-      FxCopBreakOn: CriticalError
+      RoslynAnalyzers: true
+      RoslynAnalyzersBreakOn: CriticalError
       PoliCheck: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
-    displayName: 'TSA upload (CredScan, FxCop, and PoliCheck)'
+    displayName: 'TSA upload (CredScan, RoslynAnalyzers, and PoliCheck)'
     inputs:
       tsaVersion: TsaV2
       codebase: NewOrUpdate

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -110,8 +110,9 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task -roslynanalyzers.RoslynAnalyzers@2
     displayName: 'Run Roslyn analyzers'
-    userProvideBuildInfo: auto
-    rulesetName: recommended
+    inputs:
+        userProvideBuildInfo: auto
+        rulesetName: recommended
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
     displayName: 'Run PoliCheck'


### PR DESCRIPTION
#### Describe the change

This fixes the broken signed build.

FxCop analyzers do not work on .NET Standard and .NET Core assemblies. The recommended fix is to use the RoslynAnalyzers build task instead. And that makes sense given that the analyzers we use while compiling are the Roslyn analyzers (even though the NuGet package name is Microsoft.CodeAnalysis.FxCopAnalyzers because the analyzers therein are based on FxCop).

After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



