### PR TITLE
Remove reference to Fakes which is no longer needed

### DIFF
--- a/src/AutomationTests/AutomationTests.csproj
+++ b/src/AutomationTests/AutomationTests.csproj
@@ -41,9 +41,6 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  <PropertyGroup Condition="$(FAKES_SUPPORTED) == 1">
-    <DefineConstants>$(DefineConstants);FAKES_SUPPORTED</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>


### PR DESCRIPTION
#### Describe the change

This should have been removed when the Automation project was updated. There are no Fakes in AutomationTests.


> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



