### PR TITLE
Remove a couple of conditions that don't belong in this test class

### DIFF
--- a/src/OldFileVersionCompatibilityTests/LoadOldFileVersions.cs
+++ b/src/OldFileVersionCompatibilityTests/LoadOldFileVersions.cs
@@ -77,8 +77,6 @@ namespace Axe.Windows.OldFileVersionCompatibilityTests
             Assert.AreEqual(ScanStatus.Fail, result.Status);
             Assert.IsFalse(string.IsNullOrWhiteSpace(result.Description));
             Assert.IsFalse(string.IsNullOrWhiteSpace(result.HelpUrl.Url));
-            Assert.IsNull(result.IssueDisplayText);
-            Assert.IsNull(result.IssueLink);
             Assert.IsNotNull(result.MetaInfo);
             Assert.IsFalse(string.IsNullOrWhiteSpace(result.Source));
             Assert.AreEqual(RuleId.Indecisive, result.Rule);


### PR DESCRIPTION
#### Describe the change
These conditions are true, but since they don't really pin all results, and since they're not directly related to the file format verification, Rob and I have agreed to pull them out.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



