### PR TITLE
Move default language specification outside of ENABLE_SIGNING block

### DIFF
--- a/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Core/Properties/AssemblyInfo.cs
@@ -17,6 +17,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
+[assembly: NeutralResourcesLanguage("en-US")]
+
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
@@ -35,5 +37,4 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Axe.Windows.ActionsTests")]
 [assembly: InternalsVisibleTo("Axe.Windows.CoreTests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
-[assembly: NeutralResourcesLanguage("en-US")]
 #endif


### PR DESCRIPTION
#### Describe the change
Signed build broke because it can't find the default language specification

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



