### PR TITLE
Update RoslynAnalyzers build task to use fixed analyzers version

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -113,6 +113,8 @@ jobs:
     inputs:
         userProvideBuildInfo: auto
         rulesetName: recommended
+        internalAnalyzersVersion: 2.6.1
+        microsoftAnalyzersVersion: 2.9.3
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
     displayName: 'Run PoliCheck'


### PR DESCRIPTION
#### Describe the change

The values of both sets of analyzers are the latest versions provided by https://www.1eswiki.com/wiki/Roslyn_Analyzers_Build_Task.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



