### PR TITLE
Generalize CODEOWNERS to use whole-team instead of windows-specific team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners for everything in the repository.
-*   @Microsoft/accessibility-insights-windows-code-owners
+*   @microsoft/accessibility-insights-code-owners


### PR DESCRIPTION
#### Describe the change

We've started updating all the accessibility insights repos to use a shared CODEOWNERS team, rather than maintaining separate ones per project. This brings axe-windows up to date with this new policy.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



