### PR TITLE
feature: Add a rule to detect characters in the private unicode range

### DIFF
--- a/src/Core/Enums/RuleId.cs
+++ b/src/Core/Enums/RuleId.cs
@@ -252,5 +252,8 @@ namespace Axe.Windows.Core.Enums
         SelectionItemPatternSingleSelection,
 
         ListItemSiblingsUnique,
+        NameExcludesPrivateUnicodeCharacters,
+        HelpTextExcludesPrivateUnicodeCharacters,
+        LocalizedControlTypeExcludesPrivateUnicodeCharacters,
     }
 }

--- a/src/Rules/Library/HelpTextExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/HelpTextExcludesPrivateUnicodeCharacters.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Core.Types;
+using Axe.Windows.Rules.Misc;
+using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
+using static Axe.Windows.Rules.PropertyConditions.StringProperties;
+
+namespace Axe.Windows.Rules.Library
+{
+    [RuleInfo(ID = RuleId.HelpTextExcludesPrivateUnicodeCharacters)]
+    class HelpTextExcludesPrivateUnicodeCharacters : Rule
+    {
+        public HelpTextExcludesPrivateUnicodeCharacters()
+        {
+            this.Info.Description = string.Format(CultureInfo.CurrentCulture, Descriptions.PropertyExcludesPrivateUnicodeCharacters, HelpText.PropertyDescription);
+            this.Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.PropertyExcludesPrivateUnicodeCharacters, HelpText.PropertyDescription);
+            this.Info.Standard = A11yCriteriaId.ObjectInformation;
+            this.Info.PropertyID = PropertyType.UIA_HelpTextPropertyId;
+        }
+
+        public override EvaluationCode Evaluate(IA11yElement e)
+        {
+            if (e == null) throw new ArgumentNullException(nameof(e));
+            if (String.IsNullOrWhiteSpace(e.HelpText)) throw new ArgumentException(ErrorMessages.ElementHelpTextNullOrWhiteSpace, nameof(e));
+
+            return HelpText.ExcludesPrivateUnicodeCharacters.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+        }
+
+        protected override Condition CreateCondition()
+        {
+            return HelpText.NotNullOrWhiteSpace;
+        }
+    } // class
+} // namespace

--- a/src/Rules/Library/LocalizedControlTypeExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/LocalizedControlTypeExcludesPrivateUnicodeCharacters.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Core.Types;
+using Axe.Windows.Rules.Misc;
+using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
+using static Axe.Windows.Rules.PropertyConditions.StringProperties;
+
+namespace Axe.Windows.Rules.Library
+{
+    [RuleInfo(ID = RuleId.LocalizedControlTypeExcludesPrivateUnicodeCharacters)]
+    class LocalizedControlTypeExcludesPrivateUnicodeCharacters : Rule
+    {
+        public LocalizedControlTypeExcludesPrivateUnicodeCharacters()
+        {
+            this.Info.Description = string.Format(CultureInfo.CurrentCulture, Descriptions.PropertyExcludesPrivateUnicodeCharacters, LocalizedControlType.PropertyDescription);
+            this.Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.PropertyExcludesPrivateUnicodeCharacters, LocalizedControlType.PropertyDescription);
+            this.Info.Standard = A11yCriteriaId.ObjectInformation;
+            this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
+        }
+
+        public override EvaluationCode Evaluate(IA11yElement e)
+        {
+            if (e == null) throw new ArgumentNullException(nameof(e));
+            if (String.IsNullOrWhiteSpace(e.LocalizedControlType)) throw new ArgumentException(ErrorMessages.ElementLocalizedControlTypeNullOrWhiteSpace, nameof(e));
+
+            return LocalizedControlType.ExcludesPrivateUnicodeCharacters.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+        }
+
+        protected override Condition CreateCondition()
+        {
+            return LocalizedControlType.NotNullOrWhiteSpace;
+        }
+    } // class
+} // namespace

--- a/src/Rules/Library/NameExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/NameExcludesPrivateUnicodeCharacters.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Core.Types;
+using Axe.Windows.Rules.Misc;
+using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
+using static Axe.Windows.Rules.PropertyConditions.StringProperties;
+
+namespace Axe.Windows.Rules.Library
+{
+    [RuleInfo(ID = RuleId.NameExcludesPrivateUnicodeCharacters)]
+    class NameExcludesPrivateUnicodeCharacters : Rule
+    {
+        public NameExcludesPrivateUnicodeCharacters()
+        {
+            this.Info.Description = string.Format(CultureInfo.CurrentCulture, Descriptions.PropertyExcludesPrivateUnicodeCharacters, Name.PropertyDescription);
+            this.Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.PropertyExcludesPrivateUnicodeCharacters, Name.PropertyDescription);
+            this.Info.Standard = A11yCriteriaId.ObjectInformation;
+            this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
+        }
+
+        public override EvaluationCode Evaluate(IA11yElement e)
+        {
+            if (e == null) throw new ArgumentNullException(nameof(e));
+            if (String.IsNullOrWhiteSpace(e.Name)) throw new ArgumentException(ErrorMessages.ElementNameNullOrWhiteSpace, nameof(e));
+
+            return Name.ExcludesPrivateUnicodeCharacters.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+        }
+
+        protected override Condition CreateCondition()
+        {
+            return Name.NotNullOrWhiteSpace;
+        }
+    } // class
+} // namespace

--- a/src/Rules/PropertyConditions/StringProperties.cs
+++ b/src/Rules/PropertyConditions/StringProperties.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Misc;
+using Axe.Windows.Rules.Resources;
 
 namespace Axe.Windows.Rules.PropertyConditions
 {
@@ -9,11 +10,11 @@ namespace Axe.Windows.Rules.PropertyConditions
         public static StringProperty AutomationID = new StringProperty(e => e.AutomationId);
         public static StringProperty ClassName = new StringProperty(e => e.ClassName);
         public static StringProperty Framework = new StringProperty(e => e.GetUIFramework());
-        public static StringProperty HelpText = new StringProperty(e => e.HelpText);
+        public static StringProperty HelpText = new StringProperty(e => e.HelpText, ConditionDescriptions.HelpText);
         public static StringProperty ItemStatus = new StringProperty(e => e.ItemStatus);
-        public static StringProperty LocalizedControlType = new StringProperty(e => e.LocalizedControlType);
+        public static StringProperty LocalizedControlType = new StringProperty(e => e.LocalizedControlType, ConditionDescriptions.LocalizedControlType);
         public static StringProperty LocalizedLandmarkType = new StringProperty(e => e.LocalizedLandmarkType);
-        public static StringProperty Name = new StringProperty(e => e.Name);
+        public static StringProperty Name = new StringProperty(e => e.Name, ConditionDescriptions.Name);
         public static StringProperty ProcessName = new StringProperty(e => e.ProcessName);
     } // class
 } // namespace

--- a/src/Rules/Resources/ConditionDescriptions.Designer.cs
+++ b/src/Rules/Resources/ConditionDescriptions.Designer.cs
@@ -187,6 +187,24 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to HelpText.
+        /// </summary>
+        internal static string HelpText {
+            get {
+                return ResourceManager.GetString("HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}.IncludesPrivateUnicodeCharacters.
+        /// </summary>
+        internal static string IncludesPrivateUnicodeCharacters {
+            get {
+                return ResourceManager.GetString("IncludesPrivateUnicodeCharacters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [IntProperty not set].
         /// </summary>
         internal static string IntPropertyNotSet {
@@ -214,6 +232,15 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to LocalizedControlType.
+        /// </summary>
+        internal static string LocalizedControlType {
+            get {
+                return ResourceManager.GetString("LocalizedControlType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to main landmark.
         /// </summary>
         internal static string MainLandmark {
@@ -237,6 +264,15 @@ namespace Axe.Windows.Rules.Resources {
         internal static string MatchesRegExWithOptions {
             get {
                 return ResourceManager.GetString("MatchesRegExWithOptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name.
+        /// </summary>
+        internal static string Name {
+            get {
+                return ResourceManager.GetString("Name", resourceCulture);
             }
         }
         

--- a/src/Rules/Resources/ConditionDescriptions.resx
+++ b/src/Rules/Resources/ConditionDescriptions.resx
@@ -222,4 +222,18 @@
   <data name="StringPropertyNotSet" xml:space="preserve">
     <value>[StringProperty not set]</value>
   </data>
+  <data name="Name" xml:space="preserve">
+    <value>Name</value>
+    <comment>Name</comment>
+  </data>
+  <data name="LocalizedControlType" xml:space="preserve">
+    <value>LocalizedControlType</value>
+    <comment>LocalizedControlType</comment>
+  </data>
+  <data name="HelpText" xml:space="preserve">
+    <value>HelpText</value>
+  </data>
+  <data name="IncludesPrivateUnicodeCharacters" xml:space="preserve">
+    <value>{0}.IncludesPrivateUnicodeCharacters</value>
+  </data>
 </root>

--- a/src/Rules/Resources/Descriptions.Designer.cs
+++ b/src/Rules/Resources/Descriptions.Designer.cs
@@ -916,6 +916,15 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The {0} property must not contain any characters in the private Unicode range..
+        /// </summary>
+        internal static string PropertyExcludesPrivateUnicodeCharacters {
+            get {
+                return ResourceManager.GetString("PropertyExcludesPrivateUnicodeCharacters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An element whose parent supports single selection must not have selected siblings..
         /// </summary>
         internal static string SelectionItemPatternSingleSelection {

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -423,4 +423,7 @@
   <data name="HyperlinkNameShouldBeUnique" xml:space="preserve">
     <value>Links with different purposes and destinations should have different names.</value>
   </data>
+  <data name="PropertyExcludesPrivateUnicodeCharacters" xml:space="preserve">
+    <value>The {0} property must not contain any characters in the private Unicode range.</value>
+  </data>
 </root>

--- a/src/Rules/Resources/ErrorMessages.Designer.cs
+++ b/src/Rules/Resources/ErrorMessages.Designer.cs
@@ -61,7 +61,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The element&apos;s BoundingRectangle property should not be null.
+        ///   Looks up a localized string similar to The element&apos;s BoundingRectangle property must not be null.
         /// </summary>
         internal static string ElementBoundingRectangleNull {
             get {
@@ -70,7 +70,16 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The element&apos;s LocalizedControlType property should not be null or white space.
+        ///   Looks up a localized string similar to The element&apos;s HelpText property must not be null or white space.
+        /// </summary>
+        internal static string ElementHelpTextNullOrWhiteSpace {
+            get {
+                return ResourceManager.GetString("ElementHelpTextNullOrWhiteSpace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The element&apos;s LocalizedControlType property must not be null or white space.
         /// </summary>
         internal static string ElementLocalizedControlTypeNullOrWhiteSpace {
             get {
@@ -79,7 +88,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The element&apos;s Name property should not be null or white space.
+        ///   Looks up a localized string similar to The element&apos;s Name property must not be null or white space.
         /// </summary>
         internal static string ElementNameNullOrWhiteSpace {
             get {
@@ -88,7 +97,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The element&apos;s Parent property should not be null.
+        ///   Looks up a localized string similar to The element&apos;s Parent property must not be null.
         /// </summary>
         internal static string ElementParentNull {
             get {
@@ -124,7 +133,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The given int parameter should not be zero.
+        ///   Looks up a localized string similar to The given int parameter must not be zero.
         /// </summary>
         internal static string IntParameterEqualsZero {
             get {
@@ -133,7 +142,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Int parameter should not be less than zero.
+        ///   Looks up a localized string similar to Int parameter must not be less than zero.
         /// </summary>
         internal static string IntParameterLessThanZero {
             get {
@@ -156,6 +165,15 @@ namespace Axe.Windows.Rules.Resources {
         internal static string NoLocalizedControlTypeStringFound {
             get {
                 return ResourceManager.GetString("NoLocalizedControlTypeStringFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expected the given string not to be null and not to be white space.
+        /// </summary>
+        internal static string StringNullOrWhiteSpace {
+            get {
+                return ResourceManager.GetString("StringNullOrWhiteSpace", resourceCulture);
             }
         }
     }

--- a/src/Rules/Resources/ErrorMessages.resx
+++ b/src/Rules/Resources/ErrorMessages.resx
@@ -120,6 +120,9 @@
   <data name="ElementBoundingRectangleNull" xml:space="preserve">
     <value>The element's BoundingRectangle property must not be null</value>
   </data>
+  <data name="ElementHelpTextNullOrWhiteSpace" xml:space="preserve">
+    <value>The element's HelpText property must not be null or white space</value>
+  </data>
   <data name="ElementLocalizedControlTypeNullOrWhiteSpace" xml:space="preserve">
     <value>The element's LocalizedControlType property must not be null or white space</value>
   </data>
@@ -149,5 +152,8 @@
   </data>
   <data name="NoLocalizedControlTypeStringFound" xml:space="preserve">
     <value>Could not find potential LocalizedControlType string(s) for the given control type</value>
+  </data>
+  <data name="StringNullOrWhiteSpace" xml:space="preserve">
+    <value>Expected the given string not to be null and not to be white space</value>
   </data>
 </root>

--- a/src/Rules/Resources/HowToFix.Designer.cs
+++ b/src/Rules/Resources/HowToFix.Designer.cs
@@ -1006,6 +1006,15 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Modify the {0} property, removing all characters in the range U+E000 to U+F8FF and replace them with meaninful, standard text content..
+        /// </summary>
+        internal static string PropertyExcludesPrivateUnicodeCharacters {
+            get {
+                return ResourceManager.GetString("PropertyExcludesPrivateUnicodeCharacters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Do one of the following:
         /// 1. Modify the element and/or its siblings so that only one of them is selected at any given time, OR
         /// 2. Modify the parent element so its CanSelectMultiple property is TRUE..

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -543,4 +543,7 @@ If possible, use a predefined (non-custom) control type and the default localize
   <data name="HyperlinkNameShouldBeUnique" xml:space="preserve">
     <value>If the sibling hyperlink with the same Name navigates to a different destination, change the Name of either hyperlink.</value>
   </data>
+  <data name="PropertyExcludesPrivateUnicodeCharacters" xml:space="preserve">
+    <value>Modify the {0} property, removing all characters in the range U+E000 to U+F8FF and replace them with meaninful, standard text content.</value>
+  </data>
 </root>

--- a/src/Rules/Rules.csproj
+++ b/src/Rules/Rules.csproj
@@ -73,6 +73,9 @@
     <Compile Include="Library\ButtonInvokeAndTogglePatterns.cs" />
     <Compile Include="Library\ComboBoxShouldNotSupportScrollPattern.cs" />
     <Compile Include="Library\HyperlinkNameShouldBeUnique.cs" />
+    <Compile Include="Library\HelpTextExcludesPrivateUnicodeCharacters.cs" />
+    <Compile Include="Library\LocalizedControlTypeExcludesPrivateUnicodeCharacters.cs" />
+    <Compile Include="Library\NameExcludesPrivateUnicodeCharacters.cs" />
     <Compile Include="Library\ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs" />
     <Compile Include="Library\SelectionItemPatternSingleSelection.cs" />
     <Compile Include="Library\ListItemSiblingsUnique.cs" />

--- a/src/RulesTest/Library/HelpTextExcludesPrivateUnicodeCharactersUnitTests.cs
+++ b/src/RulesTest/Library/HelpTextExcludesPrivateUnicodeCharactersUnitTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Axe.Windows.RulesTest.ControlType;
+using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
+
+namespace Axe.Windows.RulesTest.Library
+{
+    [TestClass]
+    public class HelpTextExcludesPrivateUnicodeCharactersUnitTests
+    {
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.HelpTextExcludesPrivateUnicodeCharacters();
+
+        [TestMethod]
+        public void HelpTextExcludesPrivateUnicodeCharacters_Pass()
+        {
+            var e = new MockA11yElement();
+            e.HelpText = "Hello";
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+        }
+
+        [TestMethod]
+        public void HelpTextExcludesPrivateUnicodeCharacters_Faile()
+        {
+            var e = new MockA11yElement();
+            e.HelpText = "Hello \uE000";
+
+            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void HelpTextExcludesPrivateUnicodeCharacters_NullElement_ThrowsArgumentNullException()
+        {
+            Rule.Evaluate(null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void HelpTextExcludesPrivateUnicodeCharacters_HelpTextNull_ThrowsArgumentException()
+        {
+            var e = new MockA11yElement();
+
+            Rule.Evaluate(e);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void HelpTextExcludesPrivateUnicodeCharacters_HelpTextEmpty_ThrowsArgumentException()
+        {
+            var e = new MockA11yElement();
+            e.HelpText = string.Empty;
+
+            Rule.Evaluate(e);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void HelpTextExcludesPrivateUnicodeCharacters_HelpTextWhiteSpace_ThrowsArgumentException()
+        {
+            var e = new MockA11yElement();
+            e.HelpText = " ";
+
+            Rule.Evaluate(e);
+        }
+    } // class
+} // namespace

--- a/src/RulesTest/Library/LocalizedControlTypeExcludesPrivateUnicodeCharactersUnitTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeExcludesPrivateUnicodeCharactersUnitTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Axe.Windows.RulesTest.ControlType;
+using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
+
+namespace Axe.Windows.RulesTest.Library
+{
+    [TestClass]
+    public class LocalizedControlTypeExcludesPrivateUnicodeCharactersUnitTests
+    {
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.LocalizedControlTypeExcludesPrivateUnicodeCharacters();
+
+        [TestMethod]
+        public void LocalizedControlTypeExcludesPrivateUnicodeCharacters_Pass()
+        {
+            var e = new MockA11yElement();
+            e.LocalizedControlType = "Hello";
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+        }
+
+        [TestMethod]
+        public void LocalizedControlTypeExcludesPrivateUnicodeCharacters_Faile()
+        {
+            var e = new MockA11yElement();
+            e.LocalizedControlType = "Hello \uE000";
+
+            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void LocalizedControlTypeExcludesPrivateUnicodeCharacters_NullElement_ThrowsArgumentNullException()
+        {
+            Rule.Evaluate(null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void LocalizedControlTypeExcludesPrivateUnicodeCharacters_LocalizedControlTypeNull_ThrowsArgumentException()
+        {
+            var e = new MockA11yElement();
+
+            Rule.Evaluate(e);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void LocalizedControlTypeExcludesPrivateUnicodeCharacters_LocalizedControlTypeEmpty_ThrowsArgumentException()
+        {
+            var e = new MockA11yElement();
+            e.LocalizedControlType = string.Empty;
+
+            Rule.Evaluate(e);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void LocalizedControlTypeExcludesPrivateUnicodeCharacters_LocalizedControlTypeWhiteSpace_ThrowsArgumentException()
+        {
+            var e = new MockA11yElement();
+            e.LocalizedControlType = " ";
+
+            Rule.Evaluate(e);
+        }
+    } // class
+} // namespace

--- a/src/RulesTest/Library/NameExcludesPrivateUnicodeCharactersUnitTests.cs
+++ b/src/RulesTest/Library/NameExcludesPrivateUnicodeCharactersUnitTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Axe.Windows.RulesTest.ControlType;
+using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
+
+namespace Axe.Windows.RulesTest.Library
+{
+    [TestClass]
+    public class NameExcludesPrivateUnicodeCharactersUnitTests
+    {
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.NameExcludesPrivateUnicodeCharacters();
+
+        [TestMethod]
+        public void NameExcludesPrivateUnicodeCharacters_Pass()
+        {
+            var e = new MockA11yElement();
+            e.Name = "Hello";
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+        }
+
+        [TestMethod]
+        public void NameExcludesPrivateUnicodeCharacters_Faile()
+        {
+            var e = new MockA11yElement();
+            e.Name = "Hello \uE000";
+
+            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void NameExcludesPrivateUnicodeCharacters_NullElement_ThrowsArgumentNullException()
+        {
+            Rule.Evaluate(null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void NameExcludesPrivateUnicodeCharacters_NameNull_ThrowsArgumentException()
+        {
+            var e = new MockA11yElement();
+
+            Rule.Evaluate(e);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void NameExcludesPrivateUnicodeCharacters_NameEmpty_ThrowsArgumentException()
+        {
+            var e = new MockA11yElement();
+            e.Name = string.Empty;
+
+            Rule.Evaluate(e);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void NameExcludesPrivateUnicodeCharacters_NameWhiteSpace_ThrowsArgumentException()
+        {
+            var e = new MockA11yElement();
+            e.Name = " ";
+
+            Rule.Evaluate(e);
+        }
+    } // class
+} // namespace

--- a/src/RulesTest/PropertyConditions/StringPropertiesTest.cs
+++ b/src/RulesTest/PropertyConditions/StringPropertiesTest.cs
@@ -178,6 +178,94 @@ namespace Axe.Windows.RulesTest.PropertyConditions
         }
 
         [TestMethod]
+        public void NullOrWhiteSpace_Null_True()
+        {
+            using (var e = new MockA11yElement())
+            {
+                e.Name = null;
+                Assert.IsTrue(Property.NullOrWhiteSpace.Matches(e));
+                Assert.IsFalse(Property.NotNullOrWhiteSpace.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void NullOrWhiteSpace_Empty_True()
+        {
+            using (var e = new MockA11yElement())
+            {
+                e.Name = string.Empty;
+                Assert.IsTrue(Property.NullOrWhiteSpace.Matches(e));
+                Assert.IsFalse(Property.NotNullOrWhiteSpace.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void NullOrWhiteSpace_WhiteSpace_True()
+        {
+            using (var e = new MockA11yElement())
+            {
+                e.Name = " \t";
+                Assert.IsTrue(Property.NullOrWhiteSpace.Matches(e));
+                Assert.IsFalse(Property.NotNullOrWhiteSpace.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void NullOrWhiteSpace_False()
+        {
+            using (var e = new MockA11yElement())
+            {
+                e.Name = "Hello";
+                Assert.IsFalse(Property.NullOrWhiteSpace.Matches(e));
+                Assert.IsTrue(Property.NotNullOrWhiteSpace.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void IncludesPrivateUnicodeCharacters_LowerBound_True()
+        {
+            using (var e = new MockA11yElement())
+            {
+                e.Name = "\uE000";
+                Assert.IsTrue(Property.IncludesPrivateUnicodeCharacters.Matches(e));
+                Assert.IsFalse(Property.ExcludesPrivateUnicodeCharacters.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void IncludesPrivateUnicodeCharacters_LowerBound_False()
+        {
+            using (var e = new MockA11yElement())
+            {
+                e.Name = "\uDFFF";
+                Assert.IsFalse(Property.IncludesPrivateUnicodeCharacters.Matches(e));
+                Assert.IsTrue(Property.ExcludesPrivateUnicodeCharacters.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void IncludesPrivateUnicodeCharacters_UpperBound_True()
+        {
+            using (var e = new MockA11yElement())
+            {
+                e.Name = "\uF8FF";
+                Assert.IsTrue(Property.IncludesPrivateUnicodeCharacters.Matches(e));
+                Assert.IsFalse(Property.ExcludesPrivateUnicodeCharacters.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void IncludesPrivateUnicodeCharacters_UpperBound_False()
+        {
+            using (var e = new MockA11yElement())
+            {
+                e.Name = "\uF900";
+                Assert.IsFalse(Property.IncludesPrivateUnicodeCharacters.Matches(e));
+                Assert.IsTrue(Property.ExcludesPrivateUnicodeCharacters.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
         public void TestStringPropertyIsTrue()
         {
             using (var e = new MockA11yElement())

--- a/src/RulesTest/RulesTests.csproj
+++ b/src/RulesTest/RulesTests.csproj
@@ -96,6 +96,9 @@
     <Compile Include="Library\IsKeyboardFocusableTopLevelTextPattern.cs" />
     <Compile Include="Library\IsKeyboardFocusableOnEmptyContainer.cs" />
     <Compile Include="Library\LandmarkIsTopLevel.cs" />
+    <Compile Include="Library\LocalizedControlTypeExcludesPrivateUnicodeCharactersUnitTests.cs" />
+    <Compile Include="Library\HelpTextExcludesPrivateUnicodeCharactersUnitTests.cs" />
+    <Compile Include="Library\NameExcludesPrivateUnicodeCharactersUnitTests.cs" />
     <Compile Include="Library\NameExcludesLocalizedControlType.cs" />
     <Compile Include="Library\SelectionItemPatternSingleSelection.cs" />
     <Compile Include="Library\SelectionPatternSelectionRequired.cs" />


### PR DESCRIPTION
#### Describe the change

Created three rules for Name, HelpText, and LocalizedControlType because rules are not meant to test the same issue for multiple properties.

Issue #129

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



