### PR TITLE
Fix two bugs in BoundingRectangleNotNull rule

### DIFF
--- a/src/Rules/Library/BoundingRectangleNotNull.cs
+++ b/src/Rules/Library/BoundingRectangleNotNull.cs
@@ -30,6 +30,9 @@ namespace Axe.Windows.Rules.Library
             var sysmenubar = ControlType.MenuBar & StringProperties.AutomationID.Is("SystemMenuBar") & StringProperties.Name.Is("System");
             var sysmenuitem = ControlType.MenuItem & Relationships.Parent(sysmenubar) & StringProperties.Name.Is("System");
 
+            // This exception is meant to apply to the non-Chromium version of Edge
+            var edgeGroups = ControlType.Group & StringProperties.Framework.Is(Framework.Edge);
+
             // the Bounding rectangle property might be empty due to
             // a non-existent property, or an invalid data format.
             // If the Bounding rectangle property is not empty, it means all the above criteria were met successfully
@@ -41,6 +44,8 @@ namespace Axe.Windows.Rules.Library
             // legitimately be null or all zeros when the thumb control is at the maximum or minimum value.
             return IsNotOffScreen
                 & ~WPFScrollBarPageButtons
+                & ~NonFocusableSliderButtons
+                & ~edgeGroups
                 & ~sysmenubar
                 & ~sysmenuitem;
         }

--- a/src/Rules/PropertyConditions/ElementGroups.cs
+++ b/src/Rules/PropertyConditions/ElementGroups.cs
@@ -29,6 +29,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         public static Condition ExpectedToBeFocusable = CreateExpectedToBeFocusableCondition();
         public static Condition ParentWPFDataItem = CreateParentWPFDataItemCondition();
         public static Condition WPFScrollBarPageButtons = CreateWPFScrollBarPageButtons();
+        public static Condition NonFocusableSliderButtons = CreateNonFocusableSliderButtonsCondition();
         public static Condition NameRequired = CreateNameRequiredCondition();
         public static Condition NameOptional = CreateNameOptionalCondition();
         public static Condition IsControlElementTrueRequired = CreateIsControlRequiredCondition();
@@ -154,6 +155,13 @@ namespace Axe.Windows.Rules.PropertyConditions
                 | AutomationID.Is("PageDown")
                 | AutomationID.Is("PageLeft")
                 | AutomationID.Is("PageRight"));
+        }
+
+        private static Condition CreateNonFocusableSliderButtonsCondition()
+        {
+            return Button
+                & Parent(Slider)
+                & IsNotKeyboardFocusable;
         }
 
         private static bool IsParentWPFDataItem(IA11yElement e)

--- a/src/RulesTest/Library/BoundingRectangleNotNullTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotNullTest.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Enums;
 using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
@@ -85,16 +86,30 @@ namespace Axe.Windows.RulesTest.Library
         }
 
         [TestMethod]
-        public void BoundingRectangleNotNull_WPFScrollbarPageRightButton_NotApplicable()
+        public void BoundingRectangleNotNull_NonFocusableSliderButton_NotApplicable()
         {
             using (var e = new MockA11yElement())
             using (var parent = new MockA11yElement())
             {
-                parent.ControlTypeId = ControlType.ScrollBar;
-                e.IsOffScreen = false;
+                parent.ControlTypeId = ControlType.Slider;
+                e.IsKeyboardFocusable = false;
                 e.ControlTypeId = ControlType.Button;
-                e.Framework = "WPF";
-                e.AutomationId = "PageRight";
+                parent.Children.Add(e);
+                e.Parent = parent;
+
+                Assert.IsFalse(Rule.Condition.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void BoundingRectangleNotNull_EdgeGroup_NotApplicable()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                parent.ControlTypeId = ControlType.Slider;
+                e.Framework = Framework.Edge;
+                e.ControlTypeId = ControlType.Group;
                 parent.Children.Add(e);
                 e.Parent = parent;
 


### PR DESCRIPTION
#### Describe the change

- [BUG] BoundingRectangleNotNull rule should exclude non-focusable buttons that are children of sliders · Issue #139
- [BUG] False positive for BoundingRectangleNotNull for group elements in Edge · Issue #142

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



