### PR TITLE
Update internal Microsoft Roslyn analyzers to version 2.6.3-beta1

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -113,7 +113,7 @@ jobs:
     inputs:
         userProvideBuildInfo: auto
         rulesetName: recommended
-        internalAnalyzersVersion: 2.6.3
+        internalAnalyzersVersion: 2.6.3-beta1
         microsoftAnalyzersVersion: 2.9.3
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -113,7 +113,7 @@ jobs:
     inputs:
         userProvideBuildInfo: auto
         rulesetName: recommended
-        internalAnalyzersVersion: 2.6.1
+        internalAnalyzersVersion: 2.6.3
         microsoftAnalyzersVersion: 2.9.3
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1


### PR DESCRIPTION
#### Describe the change

Security update

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



