### PR TITLE
Fix [BUG] False positives created by change to ControlShouldSupportTextPattern ruleIssue #140

### DIFF
--- a/src/Core/Enums/Framework.cs
+++ b/src/Core/Enums/Framework.cs
@@ -4,6 +4,7 @@ namespace Axe.Windows.Core.Enums
 {
     public static class Framework
     {
+        public const string DirectUI = "DirectUI";
         public const string Edge = "MicrosoftEdge";
         public const string InternetExplorer = "InternetExplorer";
         public const string WPF = "WPF";

--- a/src/Rules/Library/ControlShouldSupportTextPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTextPattern.cs
@@ -5,6 +5,7 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library
@@ -28,7 +29,13 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return Document | Edit;
+            var win32Edit = Edit & StringProperties.Framework.Is(Framework.Win32);
+            var nonfocusableDirectUIEdit = Edit & ~IsKeyboardFocusable & StringProperties.Framework.Is(Framework.DirectUI);
+
+            return Document
+                | (Edit
+                & ~win32Edit
+                & ~nonfocusableDirectUIEdit);
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/ControlShouldSupportTextPatternUnitTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTextPatternUnitTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
+using Axe.Windows.Core.Types;
+
+namespace Axe.Windows.RulesTest.Library
+{
+    [TestClass]
+    public class ControlShouldSupportTextPatternUnitTests
+    {
+        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportTextPattern();
+
+        [TestMethod]
+        public void HasTextPattern_Pass()
+        {
+            var e = new MockA11yElement();
+            e.Patterns.Add(new A11yPattern(e, PatternType.UIA_TextPatternId));
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+        }
+
+        [TestMethod]
+        public void NoTextPattern_Error()
+        {
+            var e = new MockA11yElement();
+
+            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+        }
+
+        [TestMethod]
+        public void Document_IsApplicable()
+        {
+            var e = new MockA11yElement();
+            e.ControlTypeId = ControlType.Document;
+
+            Assert.IsTrue(Rule.Condition.Matches(e));
+        }
+
+        [TestMethod]
+        public void Edit_IsApplicable()
+        {
+            var e = new MockA11yElement();
+            e.ControlTypeId = ControlType.Edit;
+
+            Assert.IsTrue(Rule.Condition.Matches(e));
+        }
+
+        [TestMethod]
+        public void Win32Edit_NotApplicable()
+        {
+            var e = new MockA11yElement();
+            e.ControlTypeId = ControlType.Edit;
+            e.Framework = Framework.Win32;
+
+            Assert.IsFalse(Rule.Condition.Matches(e));
+        }
+
+        [TestMethod]
+        public void DirectUIEdit_NotApplicable()
+        {
+            var e = new MockA11yElement();
+            e.ControlTypeId = ControlType.Edit;
+            e.Framework = Framework.Win32;
+            e.IsKeyboardFocusable = false;
+
+            Assert.IsFalse(Rule.Condition.Matches(e));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ArgumentNull_Exception()
+        {
+            Rule.Evaluate(null);
+        }
+    } // class
+} // namespace

--- a/src/RulesTest/Library/ControlShouldSupportTextPatternUnitTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTextPatternUnitTests.cs
@@ -64,7 +64,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.ControlTypeId = ControlType.Edit;
-            e.Framework = Framework.Win32;
+            e.Framework = Framework.DirectUI;
             e.IsKeyboardFocusable = false;
 
             Assert.IsFalse(Rule.Condition.Matches(e));

--- a/src/RulesTest/RulesTests.csproj
+++ b/src/RulesTest/RulesTests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Library\ControlShouldNotSupportScrollPatternTests.cs" />
     <Compile Include="Library\ControlShouldSupportSetInfoTest.cs" />
     <Compile Include="Library\ControlShouldSupportTablePattern.cs" />
+    <Compile Include="Library\ControlShouldSupportTextPatternUnitTests.cs" />
     <Compile Include="Library\HyperlinkNameShouldBeUniqueTest.cs" />
     <Compile Include="Library\IsKeyboardFocusableTopLevelTextPattern.cs" />
     <Compile Include="Library\IsKeyboardFocusableOnEmptyContainer.cs" />


### PR DESCRIPTION
#### Describe the change

Please see the bug description for details on the fix.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



