### PR TITLE
Add a separate publishing artifact dedicated to the NuGet package

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -217,6 +217,12 @@ jobs:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'
 
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: NuGet package'
+    inputs:
+      PathtoPublish: 'src\CI\bin\Release\NuGet'
+      ArtifactName: 'NuGet'
+
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
     displayName: 'Run BinSkim'
     inputs:


### PR DESCRIPTION
#### Describe the change
Create a separate publishing step to publish an artifact with just the NuGet package. This will simplify the effort required to publish the NuGet package (especially if we later automate this part of the process)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



