### PR TITLE
chore: update issue templates to use headings and comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,32 +8,38 @@ assignees: ''
 ---
 Please check whether the bug has [already been filed](https://github.com/Microsoft/axe-windows/issues).
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Describe the bug
+
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+## Expected behavior
 
-**Actual behavior**
-What actually happened.
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Screenshots or .GIF**
-If applicable, add screenshots to help explain your problem.
+## Actual behavior
 
-**Desktop (please complete the following information):**
+<!-- What actually happened. -->
+
+## Screenshots or .GIF
+
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## Desktop (please complete the following information):
+
  - OS: [e.g. Windows 10 1809] (Get the version by running `winver` from the command line)
  - Accessibility Insights for Windows Version:
  - Target Application: [e.g. Chrome, Wildlife Manager]
  - Target Application Version: [e.g. 22]
 
+## Additional context
 
-**Additional context**
 Priority requested -
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,14 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Is your feature request related to a problem? Please describe.
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+## Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+## Describe alternatives you've considered
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+## Additional context
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/general-question.md
+++ b/.github/ISSUE_TEMPLATE/general-question.md
@@ -7,6 +7,9 @@ assignees: ''
 
 ---
 
-**Your question here**
+## Your question here
+
+<!--
 Make sure to provide enough context. If you have spoken to a team member please mention them here.
 Add any items (screenshots etc) that will help.
+-->


### PR DESCRIPTION
#### Describe the change

Use comments for help text in issue templates so they don't show up when the issue creator doesn't delete them. The commented help text will still show up during issue creation.

Also changed from emphasis (**) to headings (##) to match templates in other Accessibility Insights repos.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



