### PR TITLE
Let Roslyn analyzers snap to latest version

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -113,8 +113,8 @@ jobs:
     inputs:
         userProvideBuildInfo: auto
         rulesetName: recommended
-        internalAnalyzersVersion: 2.6.3-beta1
-        microsoftAnalyzersVersion: 2.9.3
+        internalAnalyzersVersion: Latest
+        microsoftAnalyzersVersion: Latest
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
     displayName: 'Run PoliCheck'


### PR DESCRIPTION
#### Describe the change
Now that we're receiving early warning about the Roslyn analyzers, we should be able to let the system pick the latest version automatically instead of trying to manage it manually. If/when we have a version that causes trouble, we can always re-pin to a "known good" version. By keeping the 2 settings, we also have an obvious record of what changed when.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



