### PR TITLE
Enable Roslyn Analyzers, gather more data in compliance artifacts

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -133,7 +133,7 @@ jobs:
         userProvideBuildInfo: msBuildInfo
         msbuildVersion: 16.0
         msBuildArchitecture: '$(BuildPlatform)'
-        msBuildCommandline: '"$(MSBuildPath)" "$(ProjectFile)" /nologo /nr:false /fl /flp:"logfile=$(ProjectFile).log;verbosity=diagnostic" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="16.0"'
+        msBuildCommandline: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" .\src\Axe.Windows.sln /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="16.0"'
         rulesetName: recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -133,7 +133,7 @@ jobs:
         userProvideBuildInfo: msBuildInfo
         msbuildVersion: 16.0
         msBuildArchitecture: '$(BuildPlatform)'
-        msBuildCommandline: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" .\src\Axe.Windows.sln /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="16.0"'
+        msBuildCommandline: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\Axe.Windows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="16.0"'
         rulesetName: recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -130,7 +130,10 @@ jobs:
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
     displayName: 'Run Roslyn analyzers'
     inputs:
-        userProvideBuildInfo: auto
+        userProvideBuildInfo: msBuildInfo
+        msbuildVersion: 16.0
+        msBuildArchitecture: '$(BuildPlatform)'
+        msBuildCommandline: "$(MSBuildPath)" "$(ProjectFile)" /nologo /nr:false /fl /flp:"logfile=$(ProjectFile).log;verbosity=diagnostic" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="16.0"
         rulesetName: recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -98,6 +98,19 @@ jobs:
     displayName: 'Publish Artifact: Compliance'
     inputs:
       ArtifactName: 'Compliance'
+      
+  - task: VSTest@2
+      displayName: 'Test Assemblies **\debug\*test*.dll;-:**\obj\**'
+      inputs:
+        testAssemblyVer2: |
+          **\*test*.dll
+          !**\obj\**
+        testFiltercriteria: 'TestCategory!=RequiresNetwork'
+        vsTestVersion: 16.0
+        codeCoverageEnabled: false
+        platform: '$(BuildPlatform)'
+        configuration: debug
+      rerunFailedTests: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-autoapplicability.AutoApplicability@1
     displayName: 'Run AutoApplicability'
@@ -108,6 +121,12 @@ jobs:
       verboseOutput: true
       debugMode: false
 
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+    displayName: 'Run PoliCheck'
+    inputs:
+      targetType: F
+    continueOnError: true
+
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
     displayName: 'Run Roslyn analyzers'
     inputs:
@@ -115,12 +134,6 @@ jobs:
         rulesetName: recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest
-
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
-    displayName: 'Run PoliCheck'
-    inputs:
-      targetType: F
-    continueOnError: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@1
     displayName: 'Create Security Analysis Report (CredScan, RoslynAnalyzers, and PoliCheck)'
@@ -158,19 +171,6 @@ jobs:
       uploadPREfast: false
       uploadRoslyn: false
       uploadTSLint: false
-
-  - task: VSTest@2
-    displayName: 'Test Assemblies **\debug\*test*.dll;-:**\obj\**'
-    inputs:
-      testAssemblyVer2: |
-        **\*test*.dll
-        !**\obj\**
-      testFiltercriteria: 'TestCategory!=RequiresNetwork'
-      vsTestVersion: 16.0
-      codeCoverageEnabled: false
-      platform: '$(BuildPlatform)'
-      configuration: debug
-      rerunFailedTests: true
 
 - job: SignedRelease
   dependsOn: 

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -133,7 +133,7 @@ jobs:
         userProvideBuildInfo: msBuildInfo
         msbuildVersion: 16.0
         msBuildArchitecture: '$(BuildPlatform)'
-        msBuildCommandline: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\Axe.Windows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="16.0"'
+        msBuildCommandline: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="16.0"'
         rulesetName: recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -99,6 +99,19 @@ jobs:
     inputs:
       ArtifactName: 'Compliance'
 
+  - task: VSTest@2
+    displayName: 'Test Assemblies **\debug\*test*.dll;-:**\obj\**'
+    inputs:
+      testAssemblyVer2: |
+        **\*test*.dll
+        !**\obj\**
+      testFiltercriteria: 'TestCategory!=RequiresNetwork'
+      vsTestVersion: 16.0
+      codeCoverageEnabled: false
+      platform: '$(BuildPlatform)'
+      configuration: debug
+      rerunFailedTests: true
+
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-autoapplicability.AutoApplicability@1
     displayName: 'Run AutoApplicability'
 
@@ -108,6 +121,12 @@ jobs:
       verboseOutput: true
       debugMode: false
 
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+    displayName: 'Run PoliCheck'
+    inputs:
+      targetType: F
+    continueOnError: true
+
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
     displayName: 'Run Roslyn analyzers'
     inputs:
@@ -115,12 +134,6 @@ jobs:
         rulesetName: recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest
-
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
-    displayName: 'Run PoliCheck'
-    inputs:
-      targetType: F
-    continueOnError: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@1
     displayName: 'Create Security Analysis Report (CredScan, RoslynAnalyzers, and PoliCheck)'
@@ -158,19 +171,6 @@ jobs:
       uploadPREfast: false
       uploadRoslyn: false
       uploadTSLint: false
-
-  - task: VSTest@2
-    displayName: 'Test Assemblies **\debug\*test*.dll;-:**\obj\**'
-    inputs:
-      testAssemblyVer2: |
-        **\*test*.dll
-        !**\obj\**
-      testFiltercriteria: 'TestCategory!=RequiresNetwork'
-      vsTestVersion: 16.0
-      codeCoverageEnabled: false
-      platform: '$(BuildPlatform)'
-      configuration: debug
-      rerunFailedTests: true
 
 - job: SignedRelease
   dependsOn: 

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -43,17 +43,6 @@ jobs:
     inputs:
       input: 'src\Axe.Windows\bin\Release'
 
-  - task: CopyFiles@2
-    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
-    inputs:
-      Contents: '**\bin\release\**'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: Compliance'
-    inputs:
-      ArtifactName: 'Compliance'
-
   - task: VSTest@2
     displayName: 'Test Assemblies **\release\*test*.dll;-:**\obj\**'
     inputs:
@@ -68,6 +57,17 @@ jobs:
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
+
+  - task: CopyFiles@2
+    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
+    inputs:
+      Contents: '**\bin\release\**'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Compliance'
+    inputs:
+      ArtifactName: 'Compliance'
 
 - job: ComplianceDebug
   pool:
@@ -87,30 +87,6 @@ jobs:
       vsVersion: 16.0
       platform: '$(BuildPlatform)'
       configuration: debug
-
-  - task: CopyFiles@2
-    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
-    inputs:
-      Contents: '**\bin\debug\**'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: Compliance'
-    inputs:
-      ArtifactName: 'Compliance'
-
-  - task: VSTest@2
-    displayName: 'Test Assemblies **\debug\*test*.dll;-:**\obj\**'
-    inputs:
-      testAssemblyVer2: |
-        **\*test*.dll
-        !**\obj\**
-      testFiltercriteria: 'TestCategory!=RequiresNetwork'
-      vsTestVersion: 16.0
-      codeCoverageEnabled: false
-      platform: '$(BuildPlatform)'
-      configuration: debug
-      rerunFailedTests: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-autoapplicability.AutoApplicability@1
     displayName: 'Run AutoApplicability'
@@ -170,10 +146,34 @@ jobs:
       uploadAPIScan: false
       uploadBinSkim: false
       uploadFortifySCA: false
+      uploadFxCop: false
       uploadModernCop: false
       uploadPREfast: false
-      uploadRoslyn: false
       uploadTSLint: false
+
+  - task: VSTest@2
+    displayName: 'Test Assemblies **\debug\*test*.dll;-:**\obj\**'
+    inputs:
+      testAssemblyVer2: |
+        **\*test*.dll
+        !**\obj\**
+      testFiltercriteria: 'TestCategory!=RequiresNetwork'
+      vsTestVersion: 16.0
+      codeCoverageEnabled: false
+      platform: '$(BuildPlatform)'
+      configuration: debug
+      rerunFailedTests: true
+
+  - task: CopyFiles@2
+    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
+    inputs:
+      Contents: '**\bin\debug\**'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Compliance'
+    inputs:
+      ArtifactName: 'Compliance'
 
 - job: SignedRelease
   dependsOn: 
@@ -210,21 +210,6 @@ jobs:
       vsVersion: 16.0
       platform: '$(BuildPlatform)'
       configuration: release
-
-  - task: CopyFiles@2
-    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
-    inputs:
-      Contents: '**\bin\release\**'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: drop'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: NuGet package'
-    inputs:
-      PathtoPublish: 'src\CI\bin\Release\NuGet'
-      ArtifactName: 'NuGet'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
     displayName: 'Run BinSkim'
@@ -272,15 +257,6 @@ jobs:
       SearchPattern: '**\bin\**\*.pdb'
     continueOnError: true
 
-  - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
-    displayName: 'Publish Symbols'
-    inputs:
-      symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
-      requestName: 'CollectionId/$(System.CollectionId)/ProjectId/$(System.TeamProjectId)/BuildId/$(Build.BuildId)'
-      sourcePath: '$(Build.ArtifactStagingDirectory)'
-      detailedLog: true
-      usePat: false
-
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
 
@@ -305,6 +281,30 @@ jobs:
       uploadPREfast: false
       uploadRoslyn: false
       uploadTSLint: false
+
+  - task: CopyFiles@2
+    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
+    inputs:
+      Contents: '**\bin\release\**'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: drop'
+
+  - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
+    displayName: 'Publish Symbols'
+    inputs:
+      symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
+      requestName: 'CollectionId/$(System.CollectionId)/ProjectId/$(System.TeamProjectId)/BuildId/$(Build.BuildId)'
+      sourcePath: '$(Build.ArtifactStagingDirectory)'
+      detailedLog: true
+      usePat: false
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: NuGet package'
+    inputs:
+      PathtoPublish: 'src\CI\bin\Release\NuGet'
+      ArtifactName: 'NuGet'
 
   - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
     displayName: 'Perform Cleanup Tasks'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -98,19 +98,6 @@ jobs:
     displayName: 'Publish Artifact: Compliance'
     inputs:
       ArtifactName: 'Compliance'
-      
-  - task: VSTest@2
-      displayName: 'Test Assemblies **\debug\*test*.dll;-:**\obj\**'
-      inputs:
-        testAssemblyVer2: |
-          **\*test*.dll
-          !**\obj\**
-        testFiltercriteria: 'TestCategory!=RequiresNetwork'
-        vsTestVersion: 16.0
-        codeCoverageEnabled: false
-        platform: '$(BuildPlatform)'
-        configuration: debug
-      rerunFailedTests: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-autoapplicability.AutoApplicability@1
     displayName: 'Run AutoApplicability'
@@ -121,12 +108,6 @@ jobs:
       verboseOutput: true
       debugMode: false
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
-    displayName: 'Run PoliCheck'
-    inputs:
-      targetType: F
-    continueOnError: true
-
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
     displayName: 'Run Roslyn analyzers'
     inputs:
@@ -134,6 +115,12 @@ jobs:
         rulesetName: recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest
+
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+    displayName: 'Run PoliCheck'
+    inputs:
+      targetType: F
+    continueOnError: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@1
     displayName: 'Create Security Analysis Report (CredScan, RoslynAnalyzers, and PoliCheck)'
@@ -171,6 +158,19 @@ jobs:
       uploadPREfast: false
       uploadRoslyn: false
       uploadTSLint: false
+
+  - task: VSTest@2
+    displayName: 'Test Assemblies **\debug\*test*.dll;-:**\obj\**'
+    inputs:
+      testAssemblyVer2: |
+        **\*test*.dll
+        !**\obj\**
+      testFiltercriteria: 'TestCategory!=RequiresNetwork'
+      vsTestVersion: 16.0
+      codeCoverageEnabled: false
+      platform: '$(BuildPlatform)'
+      configuration: debug
+      rerunFailedTests: true
 
 - job: SignedRelease
   dependsOn: 

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -133,7 +133,7 @@ jobs:
         userProvideBuildInfo: msBuildInfo
         msbuildVersion: 16.0
         msBuildArchitecture: '$(BuildPlatform)'
-        msBuildCommandline: "$(MSBuildPath)" "$(ProjectFile)" /nologo /nr:false /fl /flp:"logfile=$(ProjectFile).log;verbosity=diagnostic" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="16.0"
+        msBuildCommandline: '"$(MSBuildPath)" "$(ProjectFile)" /nologo /nr:false /fl /flp:"logfile=$(ProjectFile).log;verbosity=diagnostic" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="16.0"'
         rulesetName: recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest


### PR DESCRIPTION
#### Describe the change
Fix #152. The Roslyn build task is unable to obtain any information about what it needs to scan. This change does 3 things:
1. Uses alternate arguments to launch the Roslyn pass. The argument uses a hardcoded path to the default location of VS2019. I don't like this at all, but it seems to be a necessary evil for the short term. Long-term, we may be able to revert to using the default arguments (this will require as-yet-unknown changes in the build definition)
2. Fixes a small error that was causing us to attempt to upload FxCop results instead of Roslyn results
3. Moves the file copy and artifact publishing as late as possible, so that we can capture more files (especially log files) in the published artifacts.

Unless marked otherwise with a comment, changes are all cut/paste within a job

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



