### PR TITLE
Remove System.Compositions from Actions (it's not needed)

### DIFF
--- a/src/Actions/Actions.csproj
+++ b/src/Actions/Actions.csproj
@@ -57,21 +57,6 @@
       <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Composition.AttributedModel, Version=1.0.32.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Composition.AttributedModel.1.1.0\lib\netstandard2.0\System.Composition.AttributedModel.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Composition.Convention, Version=1.0.32.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Composition.Convention.1.1.0\lib\netstandard2.0\System.Composition.Convention.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Composition.Hosting, Version=1.0.32.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Composition.Hosting.1.1.0\lib\netstandard2.0\System.Composition.Hosting.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Composition.Runtime, Version=1.0.32.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Composition.Runtime.1.1.0\lib\netstandard2.0\System.Composition.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Composition.TypedParts, Version=1.0.32.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Composition.TypedParts.1.1.0\lib\netstandard2.0\System.Composition.TypedParts.dll</HintPath>
-    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">

--- a/src/Actions/packages.config
+++ b/src/Actions/packages.config
@@ -10,12 +10,6 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net471" />
   <package id="System.Collections" version="4.3.0" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
-  <package id="System.Composition" version="1.1.0" targetFramework="net471" />
-  <package id="System.Composition.AttributedModel" version="1.1.0" targetFramework="net471" />
-  <package id="System.Composition.Convention" version="1.1.0" targetFramework="net471" />
-  <package id="System.Composition.Hosting" version="1.1.0" targetFramework="net471" />
-  <package id="System.Composition.Runtime" version="1.1.0" targetFramework="net471" />
-  <package id="System.Composition.TypedParts" version="1.1.0" targetFramework="net471" />
   <package id="System.Console" version="4.0.0" targetFramework="net471" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net471" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net471" />


### PR DESCRIPTION
#### Describe the change
System.Compositions.* is referenced in `Actions.csproj`, but is never referenced in the code. Removing it as unnecessary

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



