### PR TITLE
Remove System.Reflection.TypeExtensions from Actions (it's not needed)

### DIFF
--- a/src/Actions/Actions.csproj
+++ b/src/Actions/Actions.csproj
@@ -63,9 +63,6 @@
       <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.TypeExtensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.TypeExtensions.4.1.0\lib\net462\System.Reflection.TypeExtensions.dll</HintPath>
-    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Actions/packages.config
+++ b/src/Actions/packages.config
@@ -19,7 +19,6 @@
   <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net471" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net471" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net471" />
-  <package id="System.Reflection.TypeExtensions" version="4.1.0" targetFramework="net471" />
   <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net471" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net471" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net471" />


### PR DESCRIPTION
#### Describe the change
Remove System.Reflection.TypeExtensions from Actions (it's not needed)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



