### PR TITLE
Rewrite CaptureActionUnitTests to avoid requiring Fakes

### DIFF
--- a/src/Actions/Actions/CaptureAction.cs
+++ b/src/Actions/Actions/CaptureAction.cs
@@ -160,12 +160,6 @@ namespace Axe.Windows.Actions
             }
         }
 
-        /// <summary>
-        /// check whether it needs new DataContext
-        /// </summary>
-        /// <param name="sm"></param>
-        /// <param name="tm"></param>
-        /// <returns></returns>
         private static bool NeedNewDataContext(ElementDataContext dc, DataContextMode sm, TreeViewMode tm)
         {
             return dc == null || (dc.Mode != DataContextMode.Load && (dc.Mode != sm || dc.TreeMode != tm));

--- a/src/Actions/Actions/CaptureAction.cs
+++ b/src/Actions/Actions/CaptureAction.cs
@@ -48,7 +48,7 @@ namespace Axe.Windows.Actions
         {
             var ec = GetDataManager().GetElementContext(ecId);
 
-            if (ec.DataContext == null || ec.DataContext.NeedNewDataContext(DataContextMode.Live, mode) || force)
+            if (NeedNewDataContext(ec.DataContext, DataContextMode.Live, mode) || force)
             {
                 var dc = new ElementDataContext(ec.Element, MaxElements);
                 PopulateDataContextForLiveMode(dc, mode);
@@ -93,7 +93,7 @@ namespace Axe.Windows.Actions
                 ec.DataContext = null;
             }
 
-            if (ec.DataContext == null || ec.DataContext.NeedNewDataContext(dm, tvm) || force)
+            if (NeedNewDataContext(ec.DataContext, dm, tvm) || force)
             {
                 ec.DataContext = new ElementDataContext(ec.Element, MaxElements);
                 PopulateData(ec.DataContext, dm, tvm);
@@ -159,6 +159,17 @@ namespace Axe.Windows.Actions
                     AddElementAndChildrenIntoList(c, dic, elementCounter);
                 }
             }
+        }
+
+        /// <summary>
+        /// check whether it needs new DataContext
+        /// </summary>
+        /// <param name="sm"></param>
+        /// <param name="tm"></param>
+        /// <returns></returns>
+        public static bool NeedNewDataContext(ElementDataContext dc, DataContextMode sm, TreeViewMode tm)
+        {
+            return dc == null || (dc.Mode != DataContextMode.Load && (dc.Mode != sm || dc.TreeMode != tm));
         }
         #endregion
     }

--- a/src/Actions/Actions/CaptureAction.cs
+++ b/src/Actions/Actions/CaptureAction.cs
@@ -22,6 +22,13 @@ namespace Axe.Windows.Actions
     [InteractionLevel(UxInteractionLevel.NoUxInteraction)]
     public static class CaptureAction
     {
+        // Test hooks; making this non-static and enabling constructor injection
+        // would be nicer, but this was the minimal set of changes to remove the
+        // need to use Fakes to test this class.
+        internal static Func<DataManager> GetDataManager = () => DataManager.GetDefaultInstance();
+        internal static Func<ITreeWalkerForLive> NewTreeWalkerForLive = () => new TreeWalkerForLive();
+        internal static Func<A11yElement, BoundedCounter, ITreeWalkerForTest> NewTreeWalkerForTest = (A11yElement e, BoundedCounter bc) => new TreeWalkerForTest(e, bc);
+
         // This defines the maximum number of elements that we will support in a file.
         // We added this at the suggestion of the security team as a defense against
         // malicious files. Since we never want to write a file that we can't open,
@@ -39,7 +46,7 @@ namespace Axe.Windows.Actions
         /// <returns></returns>
         public static void SetLiveModeDataContext(Guid ecId, TreeViewMode mode, bool force = false)
         {
-            var ec = DataManager.GetDefaultInstance().GetElementContext(ecId);
+            var ec = GetDataManager().GetElementContext(ecId);
 
             if (ec.DataContext == null || ec.DataContext.NeedNewDataContext(DataContextMode.Live, mode) || force)
             {
@@ -59,7 +66,7 @@ namespace Axe.Windows.Actions
         {
             dc.TreeMode = mode;
             dc.Mode = DataContextMode.Live;
-            var ltw = new TreeWalkerForLive();
+            var ltw = NewTreeWalkerForLive();
             ltw.GetTreeHierarchy(dc.Element, mode);
             dc.RootElment = ltw.RootElement;
             dc.Elements = ltw.Elements.ToDictionary(i => i.UniqueId);
@@ -79,7 +86,7 @@ namespace Axe.Windows.Actions
         /// <returns>boolean</returns>
         public static bool SetTestModeDataContext(Guid ecId, DataContextMode dm, TreeViewMode tvm, bool force = false)
         {
-            var ec = DataManager.GetDefaultInstance().GetElementContext(ecId);
+            var ec = GetDataManager().GetElementContext(ecId);
             // if Data context is set via Live Mode, set it to null.
             if (ec.DataContext != null && ec.DataContext.Mode == DataContextMode.Live)
             {
@@ -111,7 +118,7 @@ namespace Axe.Windows.Actions
             switch (dcMode)
             {
                 case DataContextMode.Test:
-                    var stw = new TreeWalkerForTest(dc.Element, dc.ElementCounter);
+                    var stw = NewTreeWalkerForTest(dc.Element, dc.ElementCounter);
                     stw.RefreshTreeData(tm);
                     dc.Elements = stw.Elements.ToDictionary(l => l.UniqueId);
                     dc.RootElment = stw.TopMostElement;

--- a/src/Actions/Actions/CaptureAction.cs
+++ b/src/Actions/Actions/CaptureAction.cs
@@ -3,7 +3,6 @@
 using Axe.Windows.Actions.Attributes;
 using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Actions.Enums;
-using Axe.Windows.Actions.Misc;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Actions/Actions/CaptureAction.cs
+++ b/src/Actions/Actions/CaptureAction.cs
@@ -167,7 +167,7 @@ namespace Axe.Windows.Actions
         /// <param name="sm"></param>
         /// <param name="tm"></param>
         /// <returns></returns>
-        public static bool NeedNewDataContext(ElementDataContext dc, DataContextMode sm, TreeViewMode tm)
+        private static bool NeedNewDataContext(ElementDataContext dc, DataContextMode sm, TreeViewMode tm)
         {
             return dc == null || (dc.Mode != DataContextMode.Load && (dc.Mode != sm || dc.TreeMode != tm));
         }

--- a/src/Actions/Misc/ExtensionMethods.cs
+++ b/src/Actions/Misc/ExtensionMethods.cs
@@ -20,19 +20,6 @@ namespace Axe.Windows.Actions.Misc
     public static class ExtensionMethods
     {
         /// <summary>
-        /// check whether it needs new DataContext
-        /// </summary>
-        /// <param name="sm"></param>
-        /// <param name="tm"></param>
-        /// <returns></returns>
-        public static bool NeedNewDataContext(this ElementDataContext dc, DataContextMode sm, TreeViewMode tm)
-        {
-            if (dc == null) throw new ArgumentNullException(nameof(dc));
-
-            return dc.Mode != DataContextMode.Load && ( dc.Mode != sm  || dc.TreeMode != tm);
-        }
-
-        /// <summary>
         /// Identifies elements whose bounding rectangles contain the given position
         /// and returns the element with the smallest bounding rectangle (by area)
         /// 

--- a/src/ActionsTests/Actions/CaptureActionUnitTests.cs
+++ b/src/ActionsTests/Actions/CaptureActionUnitTests.cs
@@ -6,11 +6,11 @@ using Axe.Windows.Actions.Enums;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;
-using System;
-using System.Collections.Generic;
+using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
+using System;
+using System.Collections.Generic;
 
 namespace Axe.Windows.ActionsTests.Actions
 {

--- a/src/ActionsTests/ActionsTests.csproj
+++ b/src/ActionsTests/ActionsTests.csproj
@@ -100,7 +100,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Actions\ScreenShotActionUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1" />
-    <Compile Include="Actions\CaptureActionUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1" />
+    <Compile Include="Actions\CaptureActionUnitTests.cs" />
     <Compile Include="Misc\ExtensionMethodsTests.cs" Condition="$(FAKES_SUPPORTED) == 1" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
@@ -11,11 +11,18 @@ using System.Runtime.InteropServices;
 
 namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 {
+    public interface ITreeWalkerForLive
+    {
+        List<A11yElement> Elements { get; }
+        A11yElement RootElement { get; }
+        void GetTreeHierarchy(A11yElement e, TreeViewMode mode);
+    }
+
     /// <summary>
     /// Wrapper for UIAutomation Tree Walker for Live mode. 
     /// it is based on 2nd edition of TreeWalker
     /// </summary>
-    public class TreeWalkerForLive
+    public class TreeWalkerForLive : ITreeWalkerForLive
     {
         /// <summary>
         /// List to keep all elements in tree walking(Ancestors, self and children)

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -13,11 +13,18 @@ using Axe.Windows.Core.Misc;
 
 namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 {
+    public interface ITreeWalkerForTest
+    {
+        List<A11yElement> Elements { get; }
+        A11yElement TopMostElement { get; }
+        void RefreshTreeData(TreeViewMode mode);
+    }
+
     /// <summary>
     /// Wrapper for UIAutomation Tree Walker 2nd edition
     /// Do tree walking by retrieving all children at once. 
     /// </summary>
-    public class TreeWalkerForTest
+    public class TreeWalkerForTest : ITreeWalkerForTest
     {
         private readonly BoundedCounter _elementCounter;
 
@@ -30,6 +37,13 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// Last walk time spane
         /// </summary>
         public TimeSpan LastWalkTime { get; private set; }
+
+
+        public TreeViewMode WalkerMode { get; private set; }
+
+        public A11yElement SelectedElement { get; private set; }
+
+        public A11yElement TopMostElement { get; private set; }
 
         /// <summary>
         /// Constructor
@@ -92,11 +106,6 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
                 RuleRunner.Run(e);
             });
         }
-
-        public TreeViewMode WalkerMode { get; private set; }
-
-        public A11yElement SelectedElement { get; private set; }
-        public A11yElement TopMostElement { get; private set; }
 
         /// <summary>
         /// Populate tree by retrieving all children at once.

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -33,12 +33,8 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// </summary>
         public List<A11yElement> Elements { get; }
 
-        /// <summary>
-        /// Last walk time spane
-        /// </summary>
         public TimeSpan LastWalkTime { get; private set; }
-
-
+        
         public TreeViewMode WalkerMode { get; private set; }
 
         public A11yElement SelectedElement { get; private set; }


### PR DESCRIPTION
#### Describe the change

Our use of Fakes was the only blocker I found to migrating to the newer form of .csproj, so I decided to start removing the few remaining places where axe-windows uses them.

This PR rewrites 1 of the 3 unit test files that currently use Fakes to instead, not. I felt that the original tests were doing too much of testing implementation details, anyway; the ones that used fakes verified that the public `CaptureActions` methods called various internal `CaptureActions` methods, but the caller doesn't care about that, they care about the observable effects. So I rewrote the tests essentially from scratch to pin the caller-visible behavior of the public methods, and avoid testing the interactions between the different internal methods.

To achieve this, I added 3 `internal` test hooks to the `CaptureActions` class, to enable the test to inject replacements for the class's dependencies. I used static property injection for this because it seemed like the lowest-impact/lowest-risk option, given that I didn't want to change the signatures of the CaptureActions APIs.

Besides these 3 cases, the other significant external dependencies were a `ElementDataContext.NeedNewDataContext` extension method and a `A11yElement.GetOriginAncestor`. The former was only used as a helper within CaptureActions (I checked both axe-windows and all github searches), so I moved it to be a private helper of CaptureActions and tested the relevant behavior as it applied to the CaptureActions public APIs. The latter was used in several places in AIWin, so I left it where it was, but it was simple enough that I didn't bother mocking it for the sake of the test and just allowed the tests to use the real implementation.