### PR TITLE
Remove System.Linq and System.Linq.Expressions from Actions project

### DIFF
--- a/src/Actions/packages.config
+++ b/src/Actions/packages.config
@@ -15,8 +15,6 @@
   <package id="System.Globalization" version="4.3.0" targetFramework="net471" />
   <package id="System.IO" version="4.3.0" targetFramework="net471" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net471" />
-  <package id="System.Linq" version="4.3.0" targetFramework="net471" />
-  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net471" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net471" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net471" />
   <package id="System.Reflection.TypeExtensions" version="4.1.0" targetFramework="net471" />


### PR DESCRIPTION
#### Describe the change
Remove System.Linq and System.Linq.Expressions from Actions project (they aren't used in the code)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



