### PR TITLE
Update to System.Drawing.Common 4.6.0, update dependency

### DIFF
--- a/src/CI/Axe.Windows.nuspec
+++ b/src/CI/Axe.Windows.nuspec
@@ -18,7 +18,7 @@
       <dependency id="Newtonsoft.Json" version="9.0.1" />
       <dependency id="Microsoft.Win32.Registry" version="4.5.0" />
       <dependency id="System.Collections.Immutable" version="1.5.0" />
-      <dependency id="System.Drawing.Common" version="4.5.1" />
+      <dependency id="System.Drawing.Common" version="4.6.0" />
     </dependencies>
     <releaseNotes>https://github.com/microsoft/axe-windows/releases</releaseNotes>
   </metadata>

--- a/src/Win32/Win32.csproj
+++ b/src/Win32/Win32.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
+    <PackageReference Include="System.Drawing.Common" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#### Describe the change
Update to System.Drawing.Common 4.6.0, update dependency. Replaces #183 

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



