### PR TITLE
Remove unused assembly references

### DIFF
--- a/src/Actions/Actions.csproj
+++ b/src/Actions/Actions.csproj
@@ -53,9 +53,6 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
-    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/src/Actions/packages.config
+++ b/src/Actions/packages.config
@@ -9,7 +9,6 @@
   <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="0.4.1" targetFramework="net471" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net471" />
   <package id="System.Collections" version="4.3.0" targetFramework="net471" />
-  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net471" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net471" />
   <package id="System.IO" version="4.3.0" targetFramework="net471" />

--- a/src/Actions/packages.config
+++ b/src/Actions/packages.config
@@ -10,14 +10,11 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net471" />
   <package id="System.Collections" version="4.3.0" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
-  <package id="System.Console" version="4.0.0" targetFramework="net471" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net471" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net471" />
   <package id="System.IO" version="4.3.0" targetFramework="net471" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net471" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net471" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net471" />
-  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net471" />
-  <package id="System.Runtime" version="4.3.0" targetFramework="net471" />
   <package id="Text.Analyzers" version="2.6.2" targetFramework="net471" developmentDependency="true" />
 </packages>

--- a/src/ActionsTests/ActionsTests.csproj
+++ b/src/ActionsTests/ActionsTests.csproj
@@ -73,9 +73,6 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
-    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Drawing.4.0.0.0.Fakes" Condition="$(FAKES_SUPPORTED) == 1">

--- a/src/ActionsTests/packages.config
+++ b/src/ActionsTests/packages.config
@@ -5,7 +5,6 @@
   <package id="MSTest.TestAdapter" version="2.0.0" targetFramework="net471" />
   <package id="MSTest.TestFramework" version="2.0.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net471" />
-  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
   <package id="System.IO" version="4.3.0" targetFramework="net471" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" targetFramework="net471" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net471" />

--- a/src/Automation/packages.config
+++ b/src/Automation/packages.config
@@ -8,8 +8,6 @@
   <package id="Microsoft.NetFramework.Analyzers" version="2.9.6" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="0.4.1" targetFramework="net471" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net471" />
-  <package id="System.CodeDom" version="4.4.0" targetFramework="net471" />
   <package id="System.IO" version="4.3.0" targetFramework="net471" />
   <package id="System.Management.Automation.dll" version="10.0.10586.0" targetFramework="net471" />
-  <package id="System.Runtime" version="4.3.0" targetFramework="net471" />
 </packages>

--- a/src/CI/Axe.Windows.nuspec
+++ b/src/CI/Axe.Windows.nuspec
@@ -17,7 +17,6 @@
     <dependencies>
       <dependency id="Newtonsoft.Json" version="9.0.1" />
       <dependency id="Microsoft.Win32.Registry" version="4.5.0" />
-      <dependency id="System.Collections.Immutable" version="1.5.0" />
       <dependency id="System.Drawing.Common" version="4.6.0" />
     </dependencies>
     <releaseNotes>https://github.com/microsoft/axe-windows/releases</releaseNotes>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -48,9 +48,6 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
-    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Core/packages.config
+++ b/src/Core/packages.config
@@ -8,6 +8,5 @@
   <package id="Microsoft.NetFramework.Analyzers" version="2.9.6" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="0.4.1" targetFramework="net471" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net471" />
-  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
   <package id="Text.Analyzers" version="2.6.2" targetFramework="net471" developmentDependency="true" />
 </packages>

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -57,9 +57,6 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
-    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/CoreTests/packages.config
+++ b/src/CoreTests/packages.config
@@ -5,7 +5,6 @@
   <package id="MSTest.TestAdapter" version="2.0.0" targetFramework="net471" />
   <package id="MSTest.TestFramework" version="2.0.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net471" />
-  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" targetFramework="net471" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net471" />
 </packages>

--- a/src/Fakes.Prebuild/Fakes.Prebuild.csproj
+++ b/src/Fakes.Prebuild/Fakes.Prebuild.csproj
@@ -32,9 +32,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
-    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Fakes.Prebuild/packages.config
+++ b/src/Fakes.Prebuild/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net471" />
-  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>

--- a/src/UnitTestSharedLibrary/UnitTestSharedLibrary.csproj
+++ b/src/UnitTestSharedLibrary/UnitTestSharedLibrary.csproj
@@ -5,7 +5,6 @@
   <Import Project="..\packages\Microsoft.NetCore.Analyzers.2.9.6\build\Microsoft.NetCore.Analyzers.props" Condition="Exists('..\packages\Microsoft.NetCore.Analyzers.2.9.6\build\Microsoft.NetCore.Analyzers.props')" />
   <Import Project="..\packages\Microsoft.CodeQuality.Analyzers.2.9.6\build\Microsoft.CodeQuality.Analyzers.props" Condition="Exists('..\packages\Microsoft.CodeQuality.Analyzers.2.9.6\build\Microsoft.CodeQuality.Analyzers.props')" />
   <Import Project="..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.6\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.6\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" />
-  <Import Project="..\packages\Text.Analyzers.2.6.2\build\Text.Analyzers.props" Condition="Exists('..\packages\Text.Analyzers.2.6.2\build\Text.Analyzers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -99,15 +98,12 @@
     <Analyzer Include="..\packages\Microsoft.NetCore.Analyzers.2.9.6\analyzers\dotnet\cs\Microsoft.NetCore.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.6\analyzers\dotnet\cs\Microsoft.NetFramework.Analyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.6\analyzers\dotnet\cs\Microsoft.NetFramework.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Text.Analyzers.2.6.2\analyzers\dotnet\cs\Text.Analyzers.dll" />
-    <Analyzer Include="..\packages\Text.Analyzers.2.6.2\analyzers\dotnet\cs\Text.CSharp.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Text.Analyzers.2.6.2\build\Text.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Text.Analyzers.2.6.2\build\Text.Analyzers.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.6\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.6\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.CodeQuality.Analyzers.2.9.6\build\Microsoft.CodeQuality.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeQuality.Analyzers.2.9.6\build\Microsoft.CodeQuality.Analyzers.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.NetCore.Analyzers.2.9.6\build\Microsoft.NetCore.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NetCore.Analyzers.2.9.6\build\Microsoft.NetCore.Analyzers.props'))" />

--- a/src/UnitTestSharedLibrary/packages.config
+++ b/src/UnitTestSharedLibrary/packages.config
@@ -6,5 +6,4 @@
   <package id="Microsoft.NetCore.Analyzers" version="2.9.6" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="2.9.6" targetFramework="net471" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net471" />
-  <package id="Text.Analyzers" version="2.6.2" targetFramework="net471" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
#### Describe the change
Remove multiple assembly references that are not needed:
 - System.Collections.Immutable (still needed only because old versions of Axe.Windows say it's used, when it really isn't)
 - System.Console
 - System.Resources.ResourceManager
 - System.Runtime
 - System.CodeDom
 - Text.Analyzers (removed from UnitTestSharedLibrary so it's only in production projects)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



