### PR TITLE
Update System.Collections.Immutable to 1.6.0, add the latest versions of its dependencies

### DIFF
--- a/src/CurrentFileVersionCompatibilityTests/App.config
+++ b/src/CurrentFileVersionCompatibilityTests/App.config
@@ -1,6 +1,22 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/src/CurrentFileVersionCompatibilityTests/CurrentFileVersionCompatibilityTests.csproj
+++ b/src/CurrentFileVersionCompatibilityTests/CurrentFileVersionCompatibilityTests.csproj
@@ -64,11 +64,24 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=1.2.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.6.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.6.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/CurrentFileVersionCompatibilityTests/packages.config
+++ b/src/CurrentFileVersionCompatibilityTests/packages.config
@@ -2,5 +2,9 @@
 <packages>
   <package id="Axe.Windows" version="0.3.1-prerelease" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net472" />
-  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net471" />
+  <package id="System.Collections.Immutable" version="1.6.0" targetFramework="net471" />
+  <package id="System.Memory" version="4.5.3" targetFramework="net471" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net471" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
#### Describe the change
Update System.Collections.Immutable to 1.6.0, add the latest versions of its dependencies. We recently (see #195) removed the references to System.Collections.Immutable, but since the file compatibility tests consume an older version of Axe.Windows, and since that older version still references Systems.Colletions.Immutable, the test gets a reference automatically. After consulting with @RobGallo, we felt that it was cleaner to use the updated versions for the test project. It has no impact on shipping bits.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



