### PR TITLE
Add axe-windows-rules.md as a build artifact

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -307,6 +307,12 @@ jobs:
     inputs:
       PathtoPublish: 'src\CI\bin\Release\NuGet'
       ArtifactName: 'NuGet'
+  
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Rules markdown'
+    inputs:
+      PathtoPublish: 'src\RulesMD\bin\Release\axe-windows-rules.md'
+      ArtifactName: 'axe-windows-rules'
 
   - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
     displayName: 'Perform Cleanup Tasks'


### PR DESCRIPTION
#### Describe the change

This will enable us to add the rules documentation as a GitHub asset when new versions of the package are released.

Verified the artifact was created as part of a signed build.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



