### PR TITLE
Remove Axe.Windows methods that aren't used by Axe.Windows

### DIFF
--- a/src/Desktop/Utility/ExtensionMethods.cs
+++ b/src/Desktop/Utility/ExtensionMethods.cs
@@ -4,16 +4,12 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.UIAutomation;
-using Axe.Windows.Win32;
 using Axe.Windows.Telemetry;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
-using System.Windows.Interop;
-using System.Windows.Media.Imaging;
-using System.Windows;
 using System;
 using UIAutomationClient;
 
@@ -112,21 +108,6 @@ namespace Axe.Windows.Desktop.Utility
         }
 
         /// <summary>
-        /// Gets source for bitmap
-        /// </summary>
-        /// <param name="bitmap"></param>
-        /// <returns></returns>
-        public static BitmapSource ConvertToSource(this Bitmap bitmap)
-        {
-            if (bitmap == null) throw new ArgumentNullException(nameof(bitmap));
-
-            var hbmp = bitmap.GetHbitmap();
-            var result = Imaging.CreateBitmapSourceFromHBitmap(hbmp, IntPtr.Zero, Int32Rect.Empty, BitmapSizeOptions.FromEmptyOptions());
-            NativeMethods.DeleteObject(hbmp);
-            return result;
-        }
-
-        /// <summary>
         /// Check whether p is fully visible based on current screen size
         /// </summary>
         /// <param name="p"></param>
@@ -173,51 +154,6 @@ namespace Axe.Windows.Desktop.Utility
                 }
             }
             return curr;
-        }
-
-        /// <summary>
-        /// Get DPI
-        /// </summary>
-        /// <param name="rc"></param>
-        /// <returns></returns>
-        public static double GetDPI(this Rectangle rc)
-        {
-            return GetDPI(rc.Left, rc.Top);
-        }
-
-        /// <summary>
-        /// Get DPI with left/top
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="top"></param>
-        /// <returns></returns>
-        public static double GetDPI(int left, int top)
-        {
-            var win32Helper = new Win32Helper();
-            win32Helper.GetDpi(new System.Drawing.Point(left, top), DpiType.Effective, out uint dpiX, out uint dpiY);
-
-            return GetDPIRate(dpiX);
-        }
-
-        /// <summary>
-        /// Gets the DPI that WPF seems to use internally
-        /// when positioning windows; scale by this DPI 
-        /// when setting Window.Left / Window.Top before calling show()
-        /// </summary>
-        /// <returns></returns>
-        public static double GetWPFWindowPositioningDPI()
-        {
-            return new Rectangle().GetDPI();
-        }
-
-        /// <summary>
-        /// turn raw DPI value to DPI rate
-        /// </summary>
-        /// <param name="dpiX"></param>
-        /// <returns></returns>
-        private static double GetDPIRate(uint dpi)
-        {
-            return dpi / 96.0; // 96 is 100% scale. 
         }
 
         /// <summary>

--- a/src/Win32/NativeMethods.cs
+++ b/src/Win32/NativeMethods.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
-using System.Drawing;
 using System.Runtime.InteropServices;
 
 namespace Axe.Windows.Win32
@@ -12,17 +11,6 @@ namespace Axe.Windows.Win32
     /// </summary>
     internal static partial class NativeMethods
     {
-        [DllImport("gdi32.dll", CharSet = CharSet.Auto, SetLastError = true, ExactSpelling = true)]
-        internal static extern uint GetDeviceCaps(IntPtr hDC, int nIndex);
-
-        //https://msdn.microsoft.com/en-us/library/windows/desktop/dd145062(v=vs.85).aspx
-        [DllImport("User32.dll")]
-        internal static extern IntPtr MonitorFromPoint([In]Point pt, [In]uint dwFlags);
-
-        //https://msdn.microsoft.com/en-us/library/windows/desktop/dn280510(v=vs.85).aspx
-        [DllImport("Shcore.dll")]
-        internal static extern IntPtr GetDpiForMonitor([In]IntPtr hmonitor, [In]DpiType dpiType, [Out]out uint dpiX, [Out]out uint dpiY);
-
         /// <summary>
         /// Clean up Variant
         /// </summary>
@@ -33,9 +21,5 @@ namespace Axe.Windows.Win32
 
         [DllImport("user32.dll")]
         internal static extern uint GetWindowLong(IntPtr hWnd, int nIndex);
-
-        [DllImport("gdi32.dll", EntryPoint = "DeleteObject")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool DeleteObject(IntPtr hObject);
     }
 }

--- a/src/Win32/Win32Enums.cs
+++ b/src/Win32/Win32Enums.cs
@@ -4,32 +4,6 @@
 namespace Axe.Windows.Win32
 {
     /// <summary>
-    /// Device Cap
-    /// https://docs.microsoft.com/en-us/windows/desktop/api/wingdi/nf-wingdi-getdevicecaps
-    /// </summary>
-    public enum DeviceCap
-    {
-        /// <summary>
-        /// Logical pixels inch in X
-        /// </summary>
-        LOGPIXELSX = 88,
-        /// <summary>
-        /// Logical pixels inch in Y
-        /// </summary>
-        LOGPIXELSY = 90
-    }
-
-    /// <summary>
-    /// https://msdn.microsoft.com/en-us/library/windows/desktop/dn280511(v=vs.85).aspx
-    /// </summary>
-    public enum DpiType
-    {
-        Effective = 0,
-        Angular = 1,
-        Raw = 2,
-    }
-
-    /// <summary>
     /// https://msdn.microsoft.com/en-us/library/windows/desktop/ms646309(v=vs.85).aspx
     /// </summary>
     public enum HotkeyModifier : int

--- a/src/Win32/Win32Helper.cs
+++ b/src/Win32/Win32Helper.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.SystemAbstractions;
 using System;
-using System.Drawing;
 
 namespace Axe.Windows.Win32
 {
@@ -38,30 +37,6 @@ namespace Axe.Windows.Win32
         internal static bool IsWindows7()
         {
             return Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor == 1;
-        }
-
-        /// <summary>
-        /// Get DPI value from pointer
-        /// </summary>
-        /// <param name="point"></param>
-        /// <param name="dpiType"></param>
-        /// <param name="dpiX"></param>
-        /// <param name="dpiY"></param>
-        internal void GetDpi(Point point, DpiType dpiType, out uint dpiX, out uint dpiY)
-        {
-            var mon = NativeMethods.MonitorFromPoint(point, 2/*MONITOR_DEFAULTTONEAREST*/);
-            if (IsWindows7())
-            {
-                Graphics g = Graphics.FromHwnd(IntPtr.Zero);
-                IntPtr desktop = g.GetHdc();
-
-                dpiX = NativeMethods.GetDeviceCaps(desktop, (int)DeviceCap.LOGPIXELSX);
-                dpiY = NativeMethods.GetDeviceCaps(desktop, (int)DeviceCap.LOGPIXELSY);
-            }
-            else
-            {
-                NativeMethods.GetDpiForMonitor(mon, dpiType, out dpiX, out dpiY);
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
#### Describe the change
We identified some Axe.Windows methods that are used only in AIWin. We're adding these methods to AIWin and removing them from Axe.Windows. This is the complement of https://github.com/microsoft/accessibility-insights-windows/pull/630

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



