### PR TITLE
Add null check to TreeTracker to avoid exception

### DIFF
--- a/src/Actions/Trackers/TreeTracker.cs
+++ b/src/Actions/Trackers/TreeTracker.cs
@@ -150,6 +150,12 @@ namespace Axe.Windows.Actions.Trackers
 
             var retVal = getNextElement?.Invoke(treeWalker, currentElement);
 
+            if (retVal == null)
+            {
+                Marshal.ReleaseComObject(treeWalker);
+                return null;
+            }
+
             // make sure that we skip an element from current process while walking tree.
             // this code should be hit only at App level. but for sure. 
             if(DesktopElement.IsFromCurrentProcess(retVal))

--- a/src/Actions/Trackers/TreeTracker.cs
+++ b/src/Actions/Trackers/TreeTracker.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Runtime.InteropServices;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Exceptions;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Desktop.UIAutomation;
+using System;
+using System.Runtime.InteropServices;
 using UIAutomationClient;
 
 namespace Axe.Windows.Actions.Trackers
@@ -123,9 +123,9 @@ namespace Axe.Windows.Actions.Trackers
             var element = GetNearbyElement(getElementMethod);
             if (element == null) throw new TreeNavigationFailedException();
 
-            #pragma warning disable CA2000 // Call IDisposable.Dispose()
+#pragma warning disable CA2000 // Call IDisposable.Dispose()
             var desktopElement = new DesktopElement(element, true, false);
-            #pragma warning restore CA2000
+#pragma warning restore CA2000
 
             desktopElement.PopulateMinimumPropertiesForSelection();
             if (desktopElement.IsRootElement() == false)
@@ -148,9 +148,9 @@ namespace Axe.Windows.Actions.Trackers
 
             var treeWalker = A11yAutomation.GetTreeWalker(this.TreeViewMode);
 
-            var retVal = getNextElement?.Invoke(treeWalker, currentElement);
+            var nextElement = getNextElement?.Invoke(treeWalker, currentElement);
 
-            if (retVal == null)
+            if (nextElement == null)
             {
                 Marshal.ReleaseComObject(treeWalker);
                 return null;
@@ -158,11 +158,11 @@ namespace Axe.Windows.Actions.Trackers
 
             // make sure that we skip an element from current process while walking tree.
             // this code should be hit only at App level. but for sure. 
-            if(DesktopElement.IsFromCurrentProcess(retVal))
+            if (DesktopElement.IsFromCurrentProcess(nextElement))
             {
-                var tmp = retVal;
+                var tmp = nextElement;
 
-                retVal = getNextElement?.Invoke(treeWalker, retVal);
+                nextElement = getNextElement?.Invoke(treeWalker, nextElement);
 
                 // since element is not in use, release. 
                 Marshal.ReleaseComObject(tmp);
@@ -170,7 +170,7 @@ namespace Axe.Windows.Actions.Trackers
 
             Marshal.ReleaseComObject(treeWalker);
 
-            return retVal;
+            return nextElement;
         }
 
         private IUIAutomationElement GetCurrentElement()


### PR DESCRIPTION
#### Describe the change
This addresses [an issue in ai-win](https://github.com/microsoft/accessibility-insights-windows/issues/619) related to crashes during hotkey tree navigation. A previous axe-windows PR added null checks to certain methods' parameters. One of these methods was consistently passed a null parameter in the circumstance outlined in the aforementioned ai-win issue. Rather than remove the null check, this PR prevents the method from being passed a null parameter in the first place, thus avoiding the exception.

Some minor formatting improvements were made to the file.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
