### PR TITLE
Remove Fakes used in ScreenShotAction unit tests

### DIFF
--- a/src/Actions/Actions/ScreenShotAction.cs
+++ b/src/Actions/Actions/ScreenShotAction.cs
@@ -16,6 +16,10 @@ namespace Axe.Windows.Actions
     [InteractionLevel(UxInteractionLevel.NoUxInteraction)]
     public static class ScreenShotAction
     {
+        // unit test hooks
+        internal static Func<DataManager> GetDataManager = () => DataManager.GetDefaultInstance();
+        internal static Func<int, int, Bitmap> CreateBitmap = (width, height) => new Bitmap(width, height);
+
         /// <summary>
         /// Take a screenshot of the given element's parent window, if it has one
         ///     returns null if the bounding rectangle is 0-sized
@@ -25,7 +29,7 @@ namespace Axe.Windows.Actions
         {
             try
             {
-                var ec = DataManager.GetDefaultInstance().GetElementContext(ecId);
+                var ec = GetDataManager().GetElementContext(ecId);
                 var el = ec.Element;
 
                 var win = el.GetParentWindow();
@@ -35,7 +39,8 @@ namespace Axe.Windows.Actions
                 {
                     return; // no capture. 
                 }
-                Bitmap bmp = new Bitmap(rect.Width, rect.Height);
+
+                Bitmap bmp = CreateBitmap(rect.Width, rect.Height);
                 Graphics g = Graphics.FromImage(bmp);
 
                 g.CopyFromScreen(rect.X, rect.Y, 0, 0, rect.Size);

--- a/src/Actions/Contexts/ElementContext.cs
+++ b/src/Actions/Contexts/ElementContext.cs
@@ -71,7 +71,7 @@ namespace Axe.Windows.Actions.Contexts
                 return _dataContext;
             }
 
-            set
+            internal set
             {
                 _dataContext?.Dispose();
                 _dataContext = value;

--- a/src/Actions/Contexts/ElementContext.cs
+++ b/src/Actions/Contexts/ElementContext.cs
@@ -71,7 +71,7 @@ namespace Axe.Windows.Actions.Contexts
                 return _dataContext;
             }
 
-            internal set
+            set
             {
                 _dataContext?.Dispose();
                 _dataContext = value;

--- a/src/ActionsTests/Actions/ScreenShotActionUnitTests.cs
+++ b/src/ActionsTests/Actions/ScreenShotActionUnitTests.cs
@@ -29,42 +29,40 @@ namespace Axe.Windows.ActionsTests.Actions
             element.Properties.Add(typeId, new A11yProperty(typeId, data));
         }
 
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            ScreenShotAction.GetDataManager = () => DataManager.GetDefaultInstance();
+            ScreenShotAction.CreateBitmap = (w, h) => new Bitmap(w, h);
+        }
+
         [TestMethod]
         [Timeout(2000)]
         public void CaptureScreenShot_ElementWithoutBoundingRectangle_NoScreenShot()
         {
-            using (ShimsContext.Create())
+            using (var dm = new DataManager())
             {
-                bool bitmapsetcalled = false;
-
                 // no bounding rectangle.
                 A11yElement element = new A11yElement
                 {
-                    Parent = null,
+                    UniqueId = 42,
                 };
 
-                ElementDataContext dc = new ShimElementDataContext()
+                var dc = new ElementDataContext(element, 1);
+
+                var elementContext = new ElementContext(element)
                 {
-                    ScreenshotSetBitmap = (_) => bitmapsetcalled = true,
+                    DataContext = dc,
                 };
 
-                ElementContext elementContext = new ShimElementContext
-                {
-                    ElementGet = () => element,
-                    DataContextGet = () => dc,
-                };
+                dm.AddElementContext(elementContext);
 
-                ShimDataManager.GetDefaultInstance = () => new ShimDataManager
-                {
-                    GetElementContextGuid = (_) => elementContext,
-                };
+                ScreenShotAction.GetDataManager = () => dm;
+                
+                ScreenShotAction.CaptureScreenShot(elementContext.Id);
 
-                ScreenShotAction.CaptureScreenShot(Guid.NewGuid());
-
-                // screenshot is not set(null)
                 Assert.IsNull(dc.Screenshot);
-                // ScreenShotSet was not called.
-                Assert.IsFalse(bitmapsetcalled);
+                Assert.AreEqual(default(int), dc.ScreenshotElementId);
             }
         }
 
@@ -72,84 +70,62 @@ namespace Axe.Windows.ActionsTests.Actions
         [Timeout(2000)]
         public void CaptureScreenShot_ElementWithBoundingRectangle_ScreenShotCreated()
         {
-            using (ShimsContext.Create())
+            using (var dm = new DataManager())
             {
-                bool bitmapsetcalled = false;
-
-                //  bounding rectangle exists.
                 A11yElement element = new A11yElement
                 {
-                    UniqueId = 1,
+                    UniqueId = 42,
                 };
+
                 SetBoundingRectangle(element, new Rectangle(0, 0, 10, 10));
 
-                ElementDataContext dc = new ShimElementDataContext()
+                var dc = new ElementDataContext(element, 1);
+
+                var elementContext = new ElementContext(element)
                 {
-                    ScreenshotSetBitmap = (_) => bitmapsetcalled = true,
+                    DataContext = dc,
                 };
 
-                ElementContext elementContext = new ShimElementContext
-                {
-                    ElementGet = () => element,
-                    DataContextGet = () => dc,
-                };
+                dm.AddElementContext(elementContext);
 
-                ShimDataManager.GetDefaultInstance = () => new ShimDataManager
-                {
-                    GetElementContextGuid = (_) => elementContext,
-                };
+                ScreenShotAction.GetDataManager = () => dm;
 
-                Graphics g = new ShimGraphics();
+                ScreenShotAction.CaptureScreenShot(elementContext.Id);
 
-                ShimGraphics.FromImageImage = (_) => g;
-
-                ScreenShotAction.CaptureScreenShot(Guid.NewGuid());
-
-                // bitmap is set
-                Assert.IsTrue(bitmapsetcalled);
+                Assert.IsNotNull(dc.Screenshot);
+                Assert.AreEqual(element.UniqueId, dc.ScreenshotElementId);
             }
         }
 
-        [TestMethod]
+            [TestMethod]
         [Timeout(2000)]
         public void CaptureScreenShotOnWCOS_ElementWithBoundingRectangle_NoScreenShot()
         {
-            using (ShimsContext.Create())
+            using (var dm = new DataManager())
             {
-                bool bitmapsetcalled = false;
-
-                //  bounding rectangle exists.
                 A11yElement element = new A11yElement
                 {
-                    UniqueId = 1,
+                    UniqueId = 42,
                 };
+
                 SetBoundingRectangle(element, new Rectangle(0, 0, 10, 10));
 
-                ElementDataContext dc = new ShimElementDataContext()
+                var dc = new ElementDataContext(element, 1);
+
+                var elementContext = new ElementContext(element)
                 {
-                    ScreenshotSetBitmap = (_) => bitmapsetcalled = true,
+                    DataContext = dc,
                 };
 
-                ElementContext elementContext = new ShimElementContext
-                {
-                    ElementGet = () => element,
-                    DataContextGet = () => dc,
-                };
+                dm.AddElementContext(elementContext);
 
-                ShimDataManager.GetDefaultInstance = () => new ShimDataManager
-                {
-                    GetElementContextGuid = (_) => elementContext,
-                };
+                ScreenShotAction.GetDataManager = () => dm;
+                ScreenShotAction.CreateBitmap = (w, h) => throw new TypeInitializationException("Bitmap", null);
 
-                ShimBitmap.ConstructorInt32Int32 = (_, w, h) => throw new TypeInitializationException("Bitmap", null);
+                ScreenShotAction.CaptureScreenShot(elementContext.Id);
 
-                ScreenShotAction.CaptureScreenShot(Guid.NewGuid());
-
-                // screenshot is not set(null)
                 Assert.IsNull(dc.Screenshot);
-                // ScreenShotSet was not called.
-                Assert.IsFalse(bitmapsetcalled);
-
+                Assert.AreEqual(default(int), dc.ScreenshotElementId);
             }
         }
     }

--- a/src/ActionsTests/Actions/ScreenShotActionUnitTests.cs
+++ b/src/ActionsTests/Actions/ScreenShotActionUnitTests.cs
@@ -29,8 +29,8 @@ namespace Axe.Windows.ActionsTests.Actions
             element.Properties.Add(typeId, new A11yProperty(typeId, data));
         }
 
-        [TestInitialize]
-        public void TestInitialize()
+        [TestCleanup]
+        public void TestCleanup()
         {
             ScreenShotAction.GetDataManager = () => DataManager.GetDefaultInstance();
             ScreenShotAction.CreateBitmap = (w, h) => new Bitmap(w, h);


### PR DESCRIPTION
#### Describe the change

Using static property injection as a light-weight way to avoid using Fakes for getting the Datamanager and creating Bitmaps.

The original tests ensured the ElementDataContext.Screenshot property setter was called. But since that would involve a larger change including creating an interface which could be mocked to replace ElementDataContext, that idea was abandoned in favor of simply checking the resulting data.

I will remove all remaining vestiges of Fakes in another PR. I thought it would be good to keep this PR as minimal as practical.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
