### PR TITLE
Update Screenshot unit test to "shim" Graphics

### DIFF
--- a/src/Actions/Actions/ScreenShotAction.cs
+++ b/src/Actions/Actions/ScreenShotAction.cs
@@ -19,6 +19,8 @@ namespace Axe.Windows.Actions
         // unit test hooks
         internal static Func<DataManager> GetDataManager = () => DataManager.GetDefaultInstance();
         internal static Func<int, int, Bitmap> CreateBitmap = (width, height) => new Bitmap(width, height);
+        internal static readonly Action<Graphics, int, int, Size> DefaultCopyFromScreen = (g, x, y, s) => g.CopyFromScreen(x, y, 0, 0, s);
+        internal static Action<Graphics, int, int, Size> CopyFromScreen = DefaultCopyFromScreen;
 
         /// <summary>
         /// Take a screenshot of the given element's parent window, if it has one
@@ -43,7 +45,8 @@ namespace Axe.Windows.Actions
                 Bitmap bmp = CreateBitmap(rect.Width, rect.Height);
                 Graphics g = Graphics.FromImage(bmp);
 
-                g.CopyFromScreen(rect.X, rect.Y, 0, 0, rect.Size);
+                CopyFromScreen(g, rect.X, rect.Y, rect.Size);
+
                 ec.DataContext.Screenshot = bmp;
                 ec.DataContext.ScreenshotElementId = el.UniqueId;
             }

--- a/src/ActionsTests/Actions/ScreenShotActionUnitTests.cs
+++ b/src/ActionsTests/Actions/ScreenShotActionUnitTests.cs
@@ -34,6 +34,7 @@ namespace Axe.Windows.ActionsTests.Actions
         {
             ScreenShotAction.GetDataManager = () => DataManager.GetDefaultInstance();
             ScreenShotAction.CreateBitmap = (w, h) => new Bitmap(w, h);
+            ScreenShotAction.CopyFromScreen = ScreenShotAction.DefaultCopyFromScreen;
         }
 
         [TestMethod]
@@ -89,6 +90,7 @@ namespace Axe.Windows.ActionsTests.Actions
                 dm.AddElementContext(elementContext);
 
                 ScreenShotAction.GetDataManager = () => dm;
+                ScreenShotAction.CopyFromScreen = (g, x, y, s) => { };
 
                 ScreenShotAction.CaptureScreenShot(elementContext.Id);
 


### PR DESCRIPTION
#### Describe the change

The call to CopyFromScreen fails in the microbuild pool on release builds.

This solution is decidedly unpretty, but it will help us move forward with eliminating Fakes and getting the builds to work for now.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
