### PR TITLE
Fix bug #240

### DIFF
--- a/src/Rules/Library/NameIsReasonableLength.cs
+++ b/src/Rules/Library/NameIsReasonableLength.cs
@@ -6,6 +6,7 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.Resources;
+using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.Rules.Library
@@ -35,7 +36,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return Name.NotNullOrEmpty;
+            return Name.NotNullOrEmpty & ~Text;
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/NameIsReasonableLength.cs
+++ b/src/RulesTest/Library/NameIsReasonableLength.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using System.Text;
+using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
@@ -51,6 +52,16 @@ namespace Axe.Windows.RulesTest.Library
                 e.LocalizedControlType = "Button";
                 Action action = () => { Rule.Evaluate(e); };
                 Assert.ThrowsException<ArgumentException>(action);
+            } // using
+        }
+
+        [TestMethod]
+        public void NameIsReasonableLength_TextElement_NotApplicable()
+        {
+            using (var e = new MockA11yElement())
+            {
+                e.ControlTypeId = ControlType.Text;
+                Assert.IsFalse(Rule.Condition.Matches(e));
             } // using
         }
     } // class

--- a/src/RulesTest/MonsterTest.cs
+++ b/src/RulesTest/MonsterTest.cs
@@ -1007,7 +1007,7 @@ namespace Axe.Windows.RulesTest
             Assert.AreEqual(EvaluationCode.Pass, results[RuleId.NameNullButElementNotKeyboardFocusable]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.NameOnCustomWithParentWPFDataItem]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.NameOnOptionalType]);
-            Assert.AreEqual(EvaluationCode.Pass, results[RuleId.NameReasonableLength]);
+            Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.NameReasonableLength]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.NameWithValidBoundingRectangle]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.OrientationPropertyExists]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ProgressBarRangeValue]);


### PR DESCRIPTION
#### Describe the change

Issue #240 [BUG] [false positive] Rule NameIsReasonableLength should not apply to text elements
