### PR TITLE
Fix bug #239

### DIFF
--- a/src/Rules/Library/ProgressBarRangeValue.cs
+++ b/src/Rules/Library/ProgressBarRangeValue.cs
@@ -34,8 +34,7 @@ namespace Axe.Windows.Rules.Library
 
             var rangeValue = e.GetPattern(PatternType.UIA_RangeValuePatternId);
 
-            return PropertyValueMatches(rangeValue, "Minimum", 0.0)
-                && PropertyValueMatches(rangeValue, "Maximum", 100.0)
+            return MaxGreaterThanMin(rangeValue)
                 && PropertyValueMatches(rangeValue, "IsReadOnly", true);
         }
 
@@ -48,6 +47,16 @@ namespace Axe.Windows.Rules.Library
             if (equatable == null) return false;
 
             return equatable.Equals(value);
+        }
+
+        private static bool MaxGreaterThanMin(IA11yPattern pattern)
+        {
+            if (pattern == null) throw new ArgumentNullException(nameof(pattern));
+
+            var max = pattern.GetValue<int>("Maximum");
+            var min = pattern.GetValue<int>("Minimum");
+
+            return max > min;
         }
 
         protected override Condition CreateCondition()

--- a/src/RulesTest/Library/ProgressBarRangeValue.cs
+++ b/src/RulesTest/Library/ProgressBarRangeValue.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
+
+namespace Axe.Windows.RulesTest.Library
+{
+    [TestClass]
+    public class ProgressBarRangeValueTests
+    {
+        private readonly Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ProgressBarRangeValue();
+        private Mock<IA11yElement> elementMock = null;
+        private Mock<IA11yPattern> patternMock = null;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            patternMock = new Mock<IA11yPattern>(MockBehavior.Strict);
+            elementMock = new Mock<IA11yElement>(MockBehavior.Strict);
+            elementMock.Setup(e => e.GetPattern(PatternType.UIA_RangeValuePatternId)).Returns(patternMock.Object);
+        }
+
+        private void AddPatternValue<T>(string name, T value)
+        {
+            patternMock.Setup(p => p.GetValue<T>(name)).Returns(value);
+        }
+
+        [TestMethod]
+        public void ProgressBarRangeValue_MaxGreaterMin_Pass()
+        {
+            AddPatternValue("IsReadOnly", true);
+            AddPatternValue("Minimum", 0);
+            AddPatternValue("Maximum", 1);
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(elementMock.Object));
+
+            patternMock.Verify();
+            elementMock.Verify();
+        }
+
+        [TestMethod]
+        public void ProgressBarRangeValue_MaxEqualMin_Fail()
+        {
+            AddPatternValue("IsReadOnly", true);
+            AddPatternValue("Minimum", 1);
+            AddPatternValue("Maximum", 1);
+
+            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(elementMock.Object));
+
+            patternMock.Verify();
+            elementMock.Verify();
+        }
+
+        [TestMethod]
+        public void ProgressBarRangeValue_MaxLessMin_Fail()
+        {
+            AddPatternValue("IsReadOnly", true);
+            AddPatternValue("Minimum", 1);
+            AddPatternValue("Maximum", 0);
+
+            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(elementMock.Object));
+
+            patternMock.Verify();
+            elementMock.Verify();
+        }
+
+        [TestMethod]
+        public void ProgressBarRangeValue_IsReadOnlyFalse_Fail()
+        {
+            AddPatternValue("IsReadOnly", false);
+            AddPatternValue("Minimum", 0);
+            AddPatternValue("Maximum", 1);
+
+            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(elementMock.Object));
+
+            patternMock.Verify();
+            elementMock.Verify();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ProgressBarRangeValue_NullElement_ThrowsException()
+        {
+            Rule.Evaluate(null);
+        }
+
+        [TestMethod]
+        public void ProgressBarRangeValue_NullPattern_ThrowsException()
+        {
+            elementMock.Reset();
+            elementMock.Setup(e => e.GetPattern(PatternType.UIA_RangeValuePatternId)).Returns<IA11yPattern>(null);
+
+            var ex = Assert.ThrowsException<ArgumentNullException>(() => Rule.Evaluate(elementMock.Object));
+            Assert.AreEqual("pattern", ex.ParamName);
+
+            elementMock.Verify();
+        }
+
+        [TestMethod]
+        public void ProgressBarRangeValue_Match()
+        {
+            TestControlTypeMatchesCondition(ControlType.ProgressBar, true);
+        }
+
+        [TestMethod]
+        public void ProgressBarRangeValue_NotProgressBar_NoMatch()
+        {
+            var controlTypesToTest = ControlType.All.Difference(ControlType.ProgressBar);
+            foreach (var controlType in controlTypesToTest)
+                TestControlTypeMatchesCondition(controlType, false);
+        }
+
+        private void TestControlTypeMatchesCondition(int controlType, bool expectedResult)
+        {
+            elementMock.Setup(e => e.ControlTypeId).Returns(controlType);
+
+            Assert.AreEqual(expectedResult, Rule.Condition.Matches(elementMock.Object));
+
+            elementMock.Verify();
+            patternMock.Verify();
+        }
+
+        [TestMethod]
+        public void ProgressBarRangeValue_NoRangeValuePattern_NoMatch()
+        {
+            elementMock.Reset();
+            elementMock.Setup(e => e.ControlTypeId).Returns(ControlType.ProgressBar);
+            elementMock.Setup(e => e.GetPattern(PatternType.UIA_RangeValuePatternId)).Returns<IA11yPattern>(null);
+
+            Assert.IsFalse(Rule.Condition.Matches(elementMock.Object));
+
+            elementMock.Verify();
+        }
+    } // class
+} // namespace

--- a/src/RulesTest/RulesTests.csproj
+++ b/src/RulesTest/RulesTests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Library\HelpTextExcludesPrivateUnicodeCharactersUnitTests.cs" />
     <Compile Include="Library\NameExcludesPrivateUnicodeCharactersUnitTests.cs" />
     <Compile Include="Library\NameExcludesLocalizedControlType.cs" />
+    <Compile Include="Library\ProgressBarRangeValue.cs" />
     <Compile Include="Library\SelectionItemPatternSingleSelection.cs" />
     <Compile Include="Library\SelectionPatternSelectionRequired.cs" />
     <Compile Include="Library\ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs" />


### PR DESCRIPTION
#### Describe the change

#239 [BUG] [false positive] Update ProgressBarRangeValue allowed minimum and maximum values

The only criteria to test for now is that max is greater than min.
