### PR TITLE
Standardize on int for values returned from GetWindowLong

### DIFF
--- a/src/Core/Bases/A11yElement.cs
+++ b/src/Core/Bases/A11yElement.cs
@@ -409,12 +409,22 @@ namespace Axe.Windows.Core.Bases
         }
 
         /// <summary>
+        /// Gets a specified int property value for the current platform, e.g., Windows.
+        /// </summary>
+        /// <param name="propertyId">the ID of the platform property to retrieve; see <see cref="PlatformPropertyType"/></param>
+        /// <returns>the value of the specified property if it exists; otherwise, default(int)</returns>
+        public int GetPlatformPropertyInt(int propertyId)
+        {
+            return GetPlatformPropertyValue<int>(propertyId);
+        }
+
+        /// <summary>
         /// Gets a specified property value for the current platform, e.g., Windows.
         /// </summary>
         /// <typeparam name="T">the expected type of the property value</typeparam>
         /// <param name="propertyId">the ID of the platform property to retrieve; see <see cref="PlatformPropertyType"/></param>
         /// <returns>the value of the specified property if it exists; otherwise, the default value for the given type</returns>
-        public T GetPlatformPropertyValue<T>(int propertyId)
+        private T GetPlatformPropertyValue<T>(int propertyId)
         {
             var property = this.PlatformProperties?.ById(propertyId);
             if (property == null) return default(T);

--- a/src/Core/Bases/IA11yElement.cs
+++ b/src/Core/Bases/IA11yElement.cs
@@ -42,6 +42,6 @@ namespace Axe.Windows.Core.Bases
 
         bool TryGetPropertyValue<T>(int propertyId, out T value);
         IA11yPattern GetPattern(int patternId);
-        T GetPlatformPropertyValue<T>(int propertyId);
+        int GetPlatformPropertyInt(int propertyId);
     } // class
 } // namespace

--- a/src/Rules/PropertyConditions/ElementGroups.cs
+++ b/src/Rules/PropertyConditions/ElementGroups.cs
@@ -179,9 +179,9 @@ namespace Axe.Windows.Rules.PropertyConditions
 
         private static bool HasStaticEdgeExtendedStyle(IA11yElement e)
         {
-            var platformProperty = e?.GetPlatformPropertyValue<uint>(PlatformPropertyType.Platform_WindowsExtendedStylePropertyId);
+            var platformProperty = e?.GetPlatformPropertyInt(PlatformPropertyType.Platform_WindowsExtendedStylePropertyId);
 
-            const uint WS_EX_STATICEDGE = 0x00020000;
+            const int WS_EX_STATICEDGE = 0x00020000;
 
             return (platformProperty & WS_EX_STATICEDGE) != 0;
         }

--- a/src/Rules/PropertyConditions/PlatformProperties.cs
+++ b/src/Rules/PropertyConditions/PlatformProperties.cs
@@ -14,7 +14,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
             
-            var style = e.GetPlatformPropertyValue<int>(PlatformPropertyType.Platform_WindowsStylePropertyId);
+            var style = e.GetPlatformPropertyInt(PlatformPropertyType.Platform_WindowsStylePropertyId);
 
             const int CBS_SIMPLE = 1;
 

--- a/src/RulesTest/PropertyConditions/NameTest.cs
+++ b/src/RulesTest/PropertyConditions/NameTest.cs
@@ -263,7 +263,7 @@ public void TestElementsWithNoSibblingsOfSameControlType()
         [TestMethod]
         public void TestTextWithDisallowedPlatformProperties()
         {
-            const uint WS_EX_STATICEDGE = 0x00020000;
+            const int WS_EX_STATICEDGE = 0x00020000;
 
             using (var e = new MockA11yElement())
             {

--- a/src/Win32/NativeMethods.cs
+++ b/src/Win32/NativeMethods.cs
@@ -20,6 +20,6 @@ namespace Axe.Windows.Win32
         internal static extern uint VariantClear(ref dynamic pvarg);
 
         [DllImport("user32.dll")]
-        internal static extern uint GetWindowLong(IntPtr hWnd, int nIndex);
+        internal static extern int GetWindowLong(IntPtr hWnd, int nIndex);
     }
 }


### PR DESCRIPTION
#### Describe the change

This fixes issue #244 by forcing int as the type for numeric platform properties. A11yElement.GetPlatformPropertyValue<T> is currently only used for values from GetWindowLong, which we're standardizing as int (instead of always writing as uint, sometimes reading as uint, and sometimes reading as int). I've hidden GetPlatformPropertyValue<T> and exposed GetPlatformPropertyInt in its place--if/when we need to expose other value types, we may wish to add additional wrappers.

This is a breaking change for any code implementing IA11yElement, but that interface isn't publicly documented and we know of nobody trying to implement their own versions.

Tested by successfully running all unit tests, then running all unit tests under the debugger with a breakpoint at the point where we throw on a mismatch. Breakpoint was never hit, so no mismatches remain.