### PR TITLE
Correct spelling of "Sibling", which only has 1 'b'. 

### DIFF
--- a/src/Actions/Trackers/TreeTracker.cs
+++ b/src/Actions/Trackers/TreeTracker.cs
@@ -73,24 +73,24 @@ namespace Axe.Windows.Actions.Trackers
             return treeWalker?.GetLastChildElement(element);
         }
 
-        public void MoveToNextSibbling()
+        public void MoveToNextSibling()
         {
-            MoveTo(this.GetNexSibbling);
+            MoveTo(this.GetNexSibling);
         }
 
-        private IUIAutomationElement GetNexSibbling(IUIAutomationTreeWalker treeWalker, IUIAutomationElement element)
+        private IUIAutomationElement GetNexSibling(IUIAutomationTreeWalker treeWalker, IUIAutomationElement element)
         {
             if (element == null) return null;
 
             return treeWalker?.GetNextSiblingElement(element);
         }
 
-        public void MoveToPreviousSibbling()
+        public void MoveToPreviousSibling()
         {
-            MoveTo(this.GetPreviousSibbling);
+            MoveTo(this.GetPreviousSibling);
         }
 
-        private IUIAutomationElement GetPreviousSibbling(IUIAutomationTreeWalker treeWalker, IUIAutomationElement element)
+        private IUIAutomationElement GetPreviousSibling(IUIAutomationTreeWalker treeWalker, IUIAutomationElement element)
         {
             if (element == null) return null;
 

--- a/src/Actions/Trackers/TreeTracker.cs
+++ b/src/Actions/Trackers/TreeTracker.cs
@@ -75,10 +75,10 @@ namespace Axe.Windows.Actions.Trackers
 
         public void MoveToNextSibling()
         {
-            MoveTo(this.GetNexSibling);
+            MoveTo(this.GetNextSibling);
         }
 
-        private IUIAutomationElement GetNexSibling(IUIAutomationTreeWalker treeWalker, IUIAutomationElement element)
+        private IUIAutomationElement GetNextSibling(IUIAutomationTreeWalker treeWalker, IUIAutomationElement element)
         {
             if (element == null) return null;
 

--- a/src/RulesTest/PropertyConditions/NameTest.cs
+++ b/src/RulesTest/PropertyConditions/NameTest.cs
@@ -169,7 +169,7 @@ public void TestCustomWithDisallowedParents()
 }
 
 [TestMethod]
-public void TestElementsWithSibblingsOfSameControlType()
+public void TestElementsWithSiblingsOfSameControlType()
 {
     // this only applies to headers and status bars at the moment
     int[] controlTypes = { Header, StatusBar };
@@ -192,7 +192,7 @@ public void TestElementsWithSibblingsOfSameControlType()
 }
 
 [TestMethod]
-public void TestElementsWithNoSibblingsOfSameControlType()
+public void TestElementsWithNoSiblingsOfSameControlType()
 {
     // this only applies to headers and status bars at the moment
     int[] controlTypes = { Header, StatusBar };

--- a/src/RulesTest/PropertyConditions/RelationshipsTest.cs
+++ b/src/RulesTest/PropertyConditions/RelationshipsTest.cs
@@ -13,7 +13,7 @@ namespace Axe.Windows.RulesTest.PropertyConditions
     public class RelationshipsTest
     {
         [TestMethod]
-        public void TestSibblingsWithSameTypeTrue()
+        public void TestSiblingsWithSameTypeTrue()
         {
             using (var e = new MockA11yElement())
             using (var sibbling = new MockA11yElement())
@@ -31,7 +31,7 @@ namespace Axe.Windows.RulesTest.PropertyConditions
         }
 
         [TestMethod]
-        public void TestSibblingsWithSameTypeFalse()
+        public void TestSiblingsWithSameTypeFalse()
         {
             using (var e = new MockA11yElement())
             using (var sibbling = new MockA11yElement())
@@ -49,7 +49,7 @@ namespace Axe.Windows.RulesTest.PropertyConditions
         }
 
         [TestMethod]
-        public void TestNoSibblingsWithSameTypeTrue()
+        public void TestNoSiblingsWithSameTypeTrue()
         {
             using (var e = new MockA11yElement())
             using (var sibbling = new MockA11yElement())
@@ -67,7 +67,7 @@ namespace Axe.Windows.RulesTest.PropertyConditions
         }
 
         [TestMethod]
-        public void TestNoSibblingsWithSameTypeFalse()
+        public void TestNoSiblingsWithSameTypeFalse()
         {
             using (var e = new MockA11yElement())
             using (var sibbling = new MockA11yElement())


### PR DESCRIPTION
#### Describe the change

Correct spelling of "Sibling", which only has 1 'b'. This will require some minor changes in AIWin when we integrate it there, but has no impact on automation consumers.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
