### PR TITLE
Allow uint property values to be read as ints; framework can be made generic

### DIFF
--- a/src/Core/Bases/A11yElement.cs
+++ b/src/Core/Bases/A11yElement.cs
@@ -418,9 +418,22 @@ namespace Axe.Windows.Core.Bases
         {
             var property = this.PlatformProperties?.ById(propertyId);
             if (property == null) return default(T);
-            if (!(property.Value is T)) throw new Exception(Invariant($"Expected property.Value, which is type {property.Value.GetType().Name}, to be type {typeof(T).Name}"));
+            Type propertyType = property.Value.GetType();
+            Type requestedType = typeof(T);
 
-            return property.Value;
+            ThrowIfTypesAreIncompatible(propertyType, requestedType);
+
+            return (T)(property.Value);
+        }
+
+        private void ThrowIfTypesAreIncompatible(Type propertyType, Type requestedType)
+        {
+            if (propertyType == requestedType) return;
+
+            // Explicitly allow specific type pairings
+            if (propertyType == typeof(uint) && requestedType == typeof(int)) return;
+
+            throw new InvalidCastException(Invariant($"Expected property.Value, which is type {propertyType.Name}, to be type {requestedType.Name}"));
         }
 
         /// <summary>

--- a/src/CoreTests/Bases/A11yElementTests.cs
+++ b/src/CoreTests/Bases/A11yElementTests.cs
@@ -3,6 +3,7 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.UnitTestSharedLibrary;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 
@@ -97,6 +98,7 @@ namespace Axe.Windows.CoreTests.Bases
         /// Test various getters which use GetPropertySafely
         /// </summary>
         [TestMethod()]
+        [Timeout(2000)]
         public void GetPropertySafelyTest()
         {
             A11yElement ke = Utility.LoadA11yElementsFromJSON("Resources/A11yElementTest.hier");
@@ -118,6 +120,63 @@ namespace Axe.Windows.CoreTests.Bases
             Assert.IsTrue(ke.IsContentElement);
             Assert.IsTrue(ke.IsControlElement);
             Assert.IsTrue(ke.IsKeyboardFocusable);
+        }
+
+        [TestMethod]
+        [Timeout(2000)]
+        public void GetPlatformProperty_DataIsUint_ReadsAsUint_Succeeds()
+        {
+            const uint expectedValue = 12345;
+            const int propertyId = 5;
+
+            A11yElement e = new A11yElement
+            {
+                PlatformProperties = new Dictionary<int, A11yProperty>
+                {
+                    { propertyId, new A11yProperty(propertyId, expectedValue) },
+                }
+            };
+
+            uint actualData = e.GetPlatformPropertyValue<uint>(propertyId);
+            Assert.AreEqual(actualData, expectedValue);
+        }
+
+        [TestMethod]
+        [Timeout(2000)]
+        public void GetPlatformProperty_DataIsUint_ReadsAsInt_Succeeds()
+        {
+            const uint expectedValue = 12345;
+            const int propertyId = 5;
+
+            A11yElement e = new A11yElement
+            {
+                PlatformProperties = new Dictionary<int, A11yProperty>
+                {
+                    { propertyId, new A11yProperty(propertyId, expectedValue) },
+                }
+            };
+
+            int actualData = e.GetPlatformPropertyValue<int>(propertyId);
+            Assert.AreEqual(actualData, (int)expectedValue);
+        }
+
+        [TestMethod]
+        [Timeout(2000)]
+        [ExpectedException(typeof(InvalidCastException))]
+        public void GetPlatformProperty_DataIsUint_ReadsAsLong_ThrowsInvalidCastException()
+        {
+            const uint expectedValue = 12345;
+            const int propertyId = 5;
+
+            A11yElement e = new A11yElement
+            {
+                PlatformProperties = new Dictionary<int, A11yProperty>
+                {
+                    { propertyId, new A11yProperty(propertyId, expectedValue) },
+                }
+            };
+
+            long actualData = e.GetPlatformPropertyValue<long>(propertyId);
         }
     }
 }


### PR DESCRIPTION
#### Describe the change

Allow uint property values to be read as ints; framework can be made generic. This fixes #244 by allowing for specific type mappings. This change does not attempt to handle all mappings (for example, a uint can appropriately fit into a long), but only covers the cases that we know occur. 

It also throws an `InvalidCastException` instead of throwing a generic `Exception`, since it's generally discouraged to throw the basic `Exception` type.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
