### PR TITLE
Fix specific case where we had a mismatch between int and uint (and its unit test)

### DIFF
--- a/src/Rules/PropertyConditions/PlatformProperties.cs
+++ b/src/Rules/PropertyConditions/PlatformProperties.cs
@@ -14,7 +14,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
             
-            var style = e.GetPlatformPropertyValue<int>(PlatformPropertyType.Platform_WindowsStylePropertyId);
+            var style = e.GetPlatformPropertyValue<uint>(PlatformPropertyType.Platform_WindowsStylePropertyId);
 
             const int CBS_SIMPLE = 1;
 

--- a/src/RulesTest/PropertyConditions/PlatformPropertiesTests.cs
+++ b/src/RulesTest/PropertyConditions/PlatformPropertiesTests.cs
@@ -15,7 +15,7 @@ namespace Axe.Windows.RulesTest.PropertyConditions
         {
             using (var e = new MockA11yElement())
             {
-                var p = new A11yProperty(PlatformPropertyType.Platform_WindowsStylePropertyId, 1);
+                var p = new A11yProperty(PlatformPropertyType.Platform_WindowsStylePropertyId, 1u);
                 e.PlatformProperties.Add(PlatformPropertyType.Platform_WindowsStylePropertyId, p);
 
                 Assert.IsTrue(PlatformProperties.SimpleStyle.Matches(e));


### PR DESCRIPTION
#### Describe the change

Fix specific case where we had a mismatch between int and uint (and its unit test). This is the root cause of #244. This change is sufficient to handle all _current_ usages, but does nothing to prevent _future_ uses. When compared to #245 and #248, this is definitely the smallest and most targeted option.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
