### PR TITLE
Fix Issue #162 - [Feature Request] Add rules to ensure that an element's clickable point and IsOffscreen property agree. PR (1/2)

### DIFF
--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -16,7 +16,7 @@ namespace Axe.Windows.AutomationTests
     public class AutomationIntegrationTests
     {
         // These values should change only in response to intentional rule modifications
-        const int WildlifeManagerKnownErrorCount = 12;
+        const int WildlifeManagerKnownErrorCount = 13;
         const int Win32ControlSamplerKnownErrorCount = 0;
         const int WindowsFormsControlSamplerKnownErrorCount = 6;
         const int WpfControlSamplerKnownErrorCount = 5;

--- a/src/Core/Enums/RuleId.cs
+++ b/src/Core/Enums/RuleId.cs
@@ -255,5 +255,7 @@ namespace Axe.Windows.Core.Enums
         NameExcludesPrivateUnicodeCharacters,
         HelpTextExcludesPrivateUnicodeCharacters,
         LocalizedControlTypeExcludesPrivateUnicodeCharacters,
+
+        ClickablePointOnScreen,
     }
 }

--- a/src/CurrentFileVersionCompatibilityTests/Program.cs
+++ b/src/CurrentFileVersionCompatibilityTests/Program.cs
@@ -107,7 +107,11 @@ namespace CurrentFileVersionCompatibilityTests
             // element.ProcessName is undefined in Axe.Windows 0.3.1 (fixed in 0.3.2)
             //Assert.AreEqual(string.Empty, element.ProcessName);
             Assert.AreEqual(processId, element.ProcessId);
-            Assert.IsFalse(element.BoundingRectangle.IsEmpty);
+
+            int thumb = 50027;
+            if (element.ControlTypeId != thumb)
+                Assert.IsFalse(element.BoundingRectangle.IsEmpty);
+
             Assert.IsFalse(string.IsNullOrWhiteSpace(element.ClassName));
             Assert.AreNotEqual(0, element.UniqueId);
             Assert.AreNotEqual(0, element.Properties.Count);

--- a/src/Desktop/UIAutomation/DesktopElement.cs
+++ b/src/Desktop/UIAutomation/DesktopElement.cs
@@ -18,10 +18,10 @@ namespace Axe.Windows.Desktop.UIAutomation
     {
         private static readonly List<int> _excludedPropertyIds = new List<int>()
         {
-            PropertyType.UIA_ClickablePointPropertyId // do not remove it since it causes an issue with Edge when this value is there. 
+            // do not remove the following since it causes an issue with Edge when this value is there. 
+            // The clickable point is retrieved later once it can be determined the element does not belong to Edge
+            PropertyType.UIA_ClickablePointPropertyId,
         };
-
-        public static IReadOnlyList<int> ExcludedPropertyIds => _excludedPropertyIds;
 
         /// <summary>
         /// Constructor for DesktopElement

--- a/src/Rules/Extensions/ExtensionMethods.cs
+++ b/src/Rules/Extensions/ExtensionMethods.cs
@@ -8,7 +8,7 @@ using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
-
+using UIAutomationClient;
 using static System.FormattableString;
 
 namespace Axe.Windows.Rules.Extensions
@@ -141,6 +141,14 @@ namespace Axe.Windows.Rules.Extensions
                 && a.Right >= (b.Right + BoundingRectangle.OverlapMargin)
                 && a.Bottom >= (b.Bottom + BoundingRectangle.OverlapMargin)
                 && a.Area() != (b.Area() + (BoundingRectangle.OverlapMargin * 4));
+        }
+
+        public static bool Contains(this tagRECT rect, Point point)
+        {
+            return point.X >= rect.left
+                && point.X <= rect.right
+                && point.Y >= rect.top
+                && point.Y <= rect.bottom;
         }
     } // class
 } // namespace

--- a/src/Rules/Library/ClickablePointOnScreen.cs
+++ b/src/Rules/Library/ClickablePointOnScreen.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Core.Types;
+using Axe.Windows.Rules.PropertyConditions;
+using Axe.Windows.Rules.Resources;
+using System;
+using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
+
+namespace Axe.Windows.Rules.Library
+{
+    [RuleInfo(ID = RuleId.ClickablePointOnScreen)]
+    class ClickablePointOnScreen : Rule
+    {
+        public ClickablePointOnScreen()
+        {
+            this.Info.Description = Descriptions.ClickablePointOnScreen;
+            this.Info.HowToFix = HowToFix.ClickablePointOnScreen;
+            this.Info.Standard = A11yCriteriaId.ObjectInformation;
+            this.Info.PropertyID = PropertyType.UIA_IsOffscreenPropertyId;
+        }
+
+        public override EvaluationCode Evaluate(IA11yElement e)
+        {
+            if (e == null) throw new ArgumentNullException(nameof(e));
+
+            return IsNotOffScreen.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+        }
+
+        protected override Condition CreateCondition()
+        {
+            return ClickablePoint.OnScreen;
+        }
+    } // class
+} // namespace

--- a/src/Rules/Misc/Helpers.cs
+++ b/src/Rules/Misc/Helpers.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Types;
+using System;
+using UIAutomationClient;
+
+namespace Axe.Windows.Rules.Misc
+{
+    static class Helpers
+    {
+        private static readonly Lazy<IUIAutomationElement> _desktop = new Lazy<IUIAutomationElement>(GetDesktopElement);
+        public static IUIAutomationElement Desktop => _desktop.Value;
+
+        private static IUIAutomationElement GetDesktopElement()
+        {
+            IUIAutomation uia = new CUIAutomation();
+
+            var cacheRequest = uia.CreateCacheRequest();
+            cacheRequest.AddProperty(PropertyType.UIA_BoundingRectanglePropertyId);
+
+            return uia.GetRootElementBuildCache(cacheRequest);
+        }
+    } // class
+} // namespace

--- a/src/Rules/PropertyConditions/ClickablePoint.cs
+++ b/src/Rules/PropertyConditions/ClickablePoint.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using Axe.Windows.Rules.Extensions;
+using Axe.Windows.Rules.Resources;
+using System;
+using System.Drawing;
+using static Axe.Windows.Rules.Misc.Helpers;
+
+namespace Axe.Windows.Rules.PropertyConditions
+{
+    /// <summary>
+    /// Provides Conditions related to the ClickablePoint property of an IA11yElement
+    /// </summary>
+    static class ClickablePoint
+    {
+        public static Condition OnScreen = Condition.Create(IsClickablePointOnScreen, ConditionDescriptions.ClickablePointOnScreen);
+
+        private static bool IsClickablePointOnScreen(IA11yElement e)
+        {
+            if (e == null) throw new ArgumentNullException(nameof(e));
+
+            if (!e.TryGetPropertyValue<Point>(PropertyType.UIA_ClickablePointPropertyId, out var clickablePoint)) return false;
+
+            return Desktop.CachedBoundingRectangle.Contains(clickablePoint);
+        }
+    } // class
+} // namespace

--- a/src/Rules/Resources/ConditionDescriptions.Designer.cs
+++ b/src/Rules/Resources/ConditionDescriptions.Designer.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.Rules.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ConditionDescriptions {
@@ -129,6 +129,15 @@ namespace Axe.Windows.Rules.Resources {
         internal static string ChildrenExist {
             get {
                 return ResourceManager.GetString("ChildrenExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ClickablePointOnScreen.
+        /// </summary>
+        internal static string ClickablePointOnScreen {
+            get {
+                return ResourceManager.GetString("ClickablePointOnScreen", resourceCulture);
             }
         }
         

--- a/src/Rules/Resources/ConditionDescriptions.resx
+++ b/src/Rules/Resources/ConditionDescriptions.resx
@@ -236,4 +236,7 @@
   <data name="IncludesPrivateUnicodeCharacters" xml:space="preserve">
     <value>{0}.IncludesPrivateUnicodeCharacters</value>
   </data>
+  <data name="ClickablePointOnScreen" xml:space="preserve">
+    <value>ClickablePointOnScreen</value>
+  </data>
 </root>

--- a/src/Rules/Resources/Descriptions.Designer.cs
+++ b/src/Rules/Resources/Descriptions.Designer.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.Rules.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Descriptions {
@@ -435,6 +435,15 @@ namespace Axe.Windows.Rules.Resources {
         internal static string HyperlinkNameShouldBeUnique {
             get {
                 return ResourceManager.GetString("HyperlinkNameShouldBeUnique", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An element&apos;s IsOffScreen property must be false when its clickable point is on screen..
+        /// </summary>
+        internal static string ClickablePointOnScreen {
+            get {
+                return ResourceManager.GetString("ClickablePointOnScreen", resourceCulture);
             }
         }
         

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -426,4 +426,7 @@
   <data name="PropertyExcludesPrivateUnicodeCharacters" xml:space="preserve">
     <value>The {0} property must not contain any characters in the private Unicode range.</value>
   </data>
+  <data name="ClickablePointOnScreen" xml:space="preserve">
+    <value>An element's IsOffScreen property must be false when its clickable point is on screen.</value>
+  </data>
 </root>

--- a/src/Rules/Resources/HowToFix.Designer.cs
+++ b/src/Rules/Resources/HowToFix.Designer.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.Rules.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class HowToFix {
@@ -469,6 +469,16 @@ namespace Axe.Windows.Rules.Resources {
         internal static string HyperlinkNameShouldBeUnique {
             get {
                 return ResourceManager.GetString("HyperlinkNameShouldBeUnique", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If the element&apos;s ClickablePoint property is correct, set the element&apos;s IsOffScreen property to false.
+        ///If the element&apos;s ClickablePoint property is incorrect, please ensure it returns the correct value..
+        /// </summary>
+        internal static string ClickablePointOnScreen {
+            get {
+                return ResourceManager.GetString("ClickablePointOnScreen", resourceCulture);
             }
         }
         

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -546,4 +546,8 @@ If possible, use a predefined (non-custom) control type and the default localize
   <data name="PropertyExcludesPrivateUnicodeCharacters" xml:space="preserve">
     <value>Modify the {0} property, removing all characters in the range U+E000 to U+F8FF and replace them with meaninful, standard text content.</value>
   </data>
+  <data name="ClickablePointOnScreen" xml:space="preserve">
+    <value>If the element's ClickablePoint property is correct, set the element's IsOffScreen property to false.
+If the element's ClickablePoint property is incorrect, please ensure it returns the correct value.</value>
+  </data>
 </root>

--- a/src/Rules/Rules.csproj
+++ b/src/Rules/Rules.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Library\ComboBoxShouldNotSupportScrollPattern.cs" />
     <Compile Include="Library\HyperlinkNameShouldBeUnique.cs" />
     <Compile Include="Library\HelpTextExcludesPrivateUnicodeCharacters.cs" />
+    <Compile Include="Library\ClickablePointOnScreen.cs" />
     <Compile Include="Library\LocalizedControlTypeExcludesPrivateUnicodeCharacters.cs" />
     <Compile Include="Library\NameExcludesPrivateUnicodeCharacters.cs" />
     <Compile Include="Library\ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs" />
@@ -207,7 +208,9 @@
     <Compile Include="Library\Structure\ControlView\Tree.cs" />
     <Compile Include="Library\Structure\ControlView\TreeItem.cs" />
     <Compile Include="Library\SelectionPatternSingleSelection.cs" />
+    <Compile Include="Misc\Helpers.cs" />
     <Compile Include="PropertyConditions\BoolProperties.cs" />
+    <Compile Include="PropertyConditions\ClickablePoint.cs" />
     <Compile Include="PropertyConditions\ContentView.cs" />
     <Compile Include="PropertyConditions\Context.cs" />
     <Compile Include="PropertyConditions\ControlType.cs" />

--- a/src/RulesTest/Library/ClickablePointOnScreen.cs
+++ b/src/RulesTest/Library/ClickablePointOnScreen.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Drawing;
+using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
+
+namespace Axe.Windows.RulesTest.Library
+{
+    [TestClass]
+    public class ClickablePointOnScreenTests
+    {
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ClickablePointOnScreen();
+        private Mock<IA11yElement> mockElement = new Mock<IA11yElement>(MockBehavior.Strict);
+        private delegate void TryGetDelegate(int propertyId, out Point value);
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            mockElement.Reset();
+        }
+
+        private void SetupTryGetProperty(Point outVal)
+        {
+            mockElement.Setup(m => m.TryGetPropertyValue<Point>(PropertyType.UIA_ClickablePointPropertyId, out It.Ref<Point>.IsAny))
+                .Callback(new TryGetDelegate((int _, out Point p) =>
+                {
+                    p = outVal;
+                }))
+                .Returns(true);
+        }
+
+        [TestMethod]
+        public void ClickablePointOnScreen_OffScreen_Error()
+        {
+            mockElement.Setup(m => m.IsOffScreen).Returns(true);
+            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePointOnScreen_OnScreen_Pass()
+        {
+            mockElement.Setup(m => m.IsOffScreen).Returns(false);
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePointOnScreen_IsClickable_Matches()
+        {
+            SetupTryGetProperty(new Point(100, 100));
+            Assert.IsTrue(Rule.Condition.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePointOnScreen_IsNotClickable_NoMatch()
+        {
+            SetupTryGetProperty(new Point(-100, -100));
+            Assert.IsFalse(Rule.Condition.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+    } // class
+} // namespace

--- a/src/RulesTest/PropertyConditions/ClickablePointTests.cs
+++ b/src/RulesTest/PropertyConditions/ClickablePointTests.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Drawing;
+
+namespace Axe.Windows.RulesTest.Library
+{
+    [TestClass]
+    public class ClickablePointTests
+    {
+        private Mock<IA11yElement> mockElement = new Mock<IA11yElement>(MockBehavior.Strict);
+        private delegate void TryGetDelegate(int propertyId, out Point value);
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            mockElement.Reset();
+        }
+
+        private void SetupTryGetProperty(Point outVal, bool retVal = true)
+        {
+            mockElement.Setup(m => m.TryGetPropertyValue<Point>(PropertyType.UIA_ClickablePointPropertyId, out It.Ref<Point>.IsAny))
+                .Callback(new TryGetDelegate((int _, out Point p) =>
+                {
+                    p = outVal;
+                }))
+                .Returns(retVal);
+        }
+
+        [TestMethod]
+        public void ClickablePoint_OnScreen_True()
+        {
+            SetupTryGetProperty(new Point(100, 100));
+            Assert.IsTrue(ClickablePoint.OnScreen.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePoint_OnScreen_OffLeft_False()
+        {
+            SetupTryGetProperty(new Point(-100, 100));
+            Assert.IsFalse(ClickablePoint.OnScreen.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePoint_OnScreen_OffRightt_False()
+        {
+            SetupTryGetProperty(new Point(10000, 100));
+            Assert.IsFalse(ClickablePoint.OnScreen.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePoint_OnScreen_OffTop_False()
+        {
+            SetupTryGetProperty(new Point(100, -100));
+            Assert.IsFalse(ClickablePoint.OnScreen.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePoint_OnScreen_OffBottom_False()
+        {
+            SetupTryGetProperty(new Point(100, 10000));
+            Assert.IsFalse(ClickablePoint.OnScreen.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePoint_OnScreen_NoProperty_False()
+        {
+            SetupTryGetProperty(new Point(100, 100), false);
+            Assert.IsFalse(ClickablePoint.OnScreen.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePoint_OnScreen_NullElement_Throws()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => ClickablePoint.OnScreen.Matches(null));
+        }
+    } // class
+} // namespace

--- a/src/RulesTest/RulesTests.csproj
+++ b/src/RulesTest/RulesTests.csproj
@@ -48,6 +48,7 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
       <HintPath>..\UIAAssemblies\Win10.17713\Interop.UIAutomationClient.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
@@ -94,6 +95,7 @@
     <Compile Include="Library\ControlShouldSupportTablePattern.cs" />
     <Compile Include="Library\ControlShouldSupportTextPatternUnitTests.cs" />
     <Compile Include="Library\HyperlinkNameShouldBeUniqueTest.cs" />
+    <Compile Include="Library\ClickablePointOnScreen.cs" />
     <Compile Include="Library\IsKeyboardFocusableTopLevelTextPattern.cs" />
     <Compile Include="Library\IsKeyboardFocusableOnEmptyContainer.cs" />
     <Compile Include="Library\LandmarkIsTopLevel.cs" />
@@ -130,6 +132,7 @@
     <Compile Include="PatternIDs.cs" />
     <Compile Include="PropertyConditions\BoolPropertiesTest.cs" />
     <Compile Include="PropertyConditions\IntPropertiesTests.cs" />
+    <Compile Include="PropertyConditions\ClickablePointTests.cs" />
     <Compile Include="PropertyConditions\NameTest.cs" />
     <Compile Include="PropertyConditions\BoundingRectangleTest.cs" />
     <Compile Include="PropertyConditions\RelationshipsTest.cs" />


### PR DESCRIPTION
#### Describe the change

- Add a new rule, ClicablePointOnScreen, to test that when the clickable point for an element is within the desktop's bounding rectangle, the element's IsOffScreen property is set to false.
- Add a new property condition ClickablePoint.OnScreen -- tests if an element's clickable point both exists and is within the desktop's bounding rectangle.
- Remove DesktopElement.ExcludedPropertyIds because it is not used by axe windows or ai-win.
- Add code to add the ClickablePoint property to element's which are not inside Edge. According to the existing comments, querying for the ClickablePoint property causes a crash in Edge.
- Add an if condition to CurrentFileVersionCompatibilityTests to ignore element's of type thumb when ensuring bounding rectangles are not empty. This is necessary because the new rule, ClickablePointOnScreen, adds an additional error on a thumb element with an empty bounding rectangle to the a11ytest file.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
