### PR TITLE
Remove competing versions of System.Net.Http

### DIFF
--- a/src/ActionsTests/ActionsTests.csproj
+++ b/src/ActionsTests/ActionsTests.csproj
@@ -60,7 +60,7 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Net.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>


### PR DESCRIPTION
#### Describe the change

All Axe.Windows builds (like this [recent PR](https://dev.azure.com/accessibility-insights/axe-windows/_build/results?buildId=4989&view=results)) generate the following error:
```
##[warning]C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2106,5):
Warning MSB3243: No way to resolve conflict between
"System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" and 
"System.Net.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a". Choosing 
"System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" arbitrarily.
```

The current version of System.Net.Http is 4.2.0, but for historical reasons, ActionsTests.csproj is pinned to version 4.0.0. This PR simply removes the pin so that we no longer have the warning about the competing version. As it turns out, System.Net.Http appears to not be used anywhere in Axe.Windows. I'll create a future PR to clean up the leftover boilerplate, but that will be a separate change.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
