### PR TITLE
Fix Issue #162 - [Feature Request] Add rules to ensure that an element's clickable point and IsOffscreen property agree. PR (2/2)

### DIFF
--- a/src/Core/Enums/RuleId.cs
+++ b/src/Core/Enums/RuleId.cs
@@ -257,5 +257,6 @@ namespace Axe.Windows.Core.Enums
         LocalizedControlTypeExcludesPrivateUnicodeCharacters,
 
         ClickablePointOnScreen,
+        ClickablePointOffScreen,
     }
 }

--- a/src/Rules/Library/ClickablePointOffScreen.cs
+++ b/src/Rules/Library/ClickablePointOffScreen.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Core.Types;
+using Axe.Windows.Rules.PropertyConditions;
+using Axe.Windows.Rules.Resources;
+using System;
+using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
+
+namespace Axe.Windows.Rules.Library
+{
+    [RuleInfo(ID = RuleId.ClickablePointOffScreen)]
+    class ClickablePointOffScreen : Rule
+    {
+        public ClickablePointOffScreen()
+        {
+            this.Info.Description = Descriptions.ClickablePointOffScreen;
+            this.Info.HowToFix = HowToFix.ClickablePointOffScreen;
+            this.Info.Standard = A11yCriteriaId.ObjectInformation;
+            this.Info.PropertyID = PropertyType.UIA_IsOffscreenPropertyId;
+        }
+
+        public override EvaluationCode Evaluate(IA11yElement e)
+        {
+            if (e == null) throw new ArgumentNullException(nameof(e));
+
+            return IsOffScreen.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Warning;
+        }
+
+        protected override Condition CreateCondition()
+        {
+            return ClickablePoint.OffScreen;
+        }
+    } // class
+} // namespace

--- a/src/Rules/PropertyConditions/ClickablePoint.cs
+++ b/src/Rules/PropertyConditions/ClickablePoint.cs
@@ -16,6 +16,7 @@ namespace Axe.Windows.Rules.PropertyConditions
     static class ClickablePoint
     {
         public static Condition OnScreen = Condition.Create(IsClickablePointOnScreen, ConditionDescriptions.ClickablePointOnScreen);
+        public static Condition OffScreen = Condition.Create(IsClickablePointOffScreen, ConditionDescriptions.ClickablePointOffScreen);
 
         private static bool IsClickablePointOnScreen(IA11yElement e)
         {
@@ -24,6 +25,15 @@ namespace Axe.Windows.Rules.PropertyConditions
             if (!e.TryGetPropertyValue<Point>(PropertyType.UIA_ClickablePointPropertyId, out var clickablePoint)) return false;
 
             return Desktop.CachedBoundingRectangle.Contains(clickablePoint);
+        }
+
+        private static bool IsClickablePointOffScreen(IA11yElement e)
+        {
+            if (e == null) throw new ArgumentNullException(nameof(e));
+
+            if (!e.TryGetPropertyValue<Point>(PropertyType.UIA_ClickablePointPropertyId, out var clickablePoint)) return false;
+
+            return !Desktop.CachedBoundingRectangle.Contains(clickablePoint);
         }
     } // class
 } // namespace

--- a/src/Rules/Resources/ConditionDescriptions.Designer.cs
+++ b/src/Rules/Resources/ConditionDescriptions.Designer.cs
@@ -133,6 +133,15 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ClickablePointOffScreen.
+        /// </summary>
+        internal static string ClickablePointOffScreen {
+            get {
+                return ResourceManager.GetString("ClickablePointOffScreen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ClickablePointOnScreen.
         /// </summary>
         internal static string ClickablePointOnScreen {

--- a/src/Rules/Resources/ConditionDescriptions.resx
+++ b/src/Rules/Resources/ConditionDescriptions.resx
@@ -239,4 +239,7 @@
   <data name="ClickablePointOnScreen" xml:space="preserve">
     <value>ClickablePointOnScreen</value>
   </data>
+  <data name="ClickablePointOffScreen" xml:space="preserve">
+    <value>ClickablePointOffScreen</value>
+  </data>
 </root>

--- a/src/Rules/Resources/Descriptions.Designer.cs
+++ b/src/Rules/Resources/Descriptions.Designer.cs
@@ -205,6 +205,24 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An element&apos;s IsOffScreen property must be true when its clickable point is off screen..
+        /// </summary>
+        internal static string ClickablePointOffScreen {
+            get {
+                return ResourceManager.GetString("ClickablePointOffScreen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An element&apos;s IsOffScreen property must be false when its clickable point is on screen..
+        /// </summary>
+        internal static string ClickablePointOnScreen {
+            get {
+                return ResourceManager.GetString("ClickablePointOnScreen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes support the scroll pattern by default, which app developers can&apos;t easily fix..
         /// </summary>
         internal static string ComboBoxShouldNotSupportScrollPattern {
@@ -435,15 +453,6 @@ namespace Axe.Windows.Rules.Resources {
         internal static string HyperlinkNameShouldBeUnique {
             get {
                 return ResourceManager.GetString("HyperlinkNameShouldBeUnique", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to An element&apos;s IsOffScreen property must be false when its clickable point is on screen..
-        /// </summary>
-        internal static string ClickablePointOnScreen {
-            get {
-                return ResourceManager.GetString("ClickablePointOnScreen", resourceCulture);
             }
         }
         

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -429,4 +429,7 @@
   <data name="ClickablePointOnScreen" xml:space="preserve">
     <value>An element's IsOffScreen property must be false when its clickable point is on screen.</value>
   </data>
+  <data name="ClickablePointOffScreen" xml:space="preserve">
+    <value>An element's IsOffScreen property must be true when its clickable point is off screen.</value>
+  </data>
 </root>

--- a/src/Rules/Resources/HowToFix.Designer.cs
+++ b/src/Rules/Resources/HowToFix.Designer.cs
@@ -225,6 +225,26 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to If the element&apos;s ClickablePoint property is correct, set the element&apos;s IsOffScreen property to true.
+        ///If the element&apos;s ClickablePoint property is incorrect, please ensure it returns the correct value..
+        /// </summary>
+        internal static string ClickablePointOffScreen {
+            get {
+                return ResourceManager.GetString("ClickablePointOffScreen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If the element&apos;s ClickablePoint property is correct, set the element&apos;s IsOffScreen property to false.
+        ///If the element&apos;s ClickablePoint property is incorrect, please ensure it returns the correct value..
+        /// </summary>
+        internal static string ClickablePointOnScreen {
+            get {
+                return ResourceManager.GetString("ClickablePointOnScreen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes support the scroll pattern by default, which app developers can&apos;t easily fix..
         /// </summary>
         internal static string ComboBoxShouldNotSupportScrollPattern {
@@ -469,16 +489,6 @@ namespace Axe.Windows.Rules.Resources {
         internal static string HyperlinkNameShouldBeUnique {
             get {
                 return ResourceManager.GetString("HyperlinkNameShouldBeUnique", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to If the element&apos;s ClickablePoint property is correct, set the element&apos;s IsOffScreen property to false.
-        ///If the element&apos;s ClickablePoint property is incorrect, please ensure it returns the correct value..
-        /// </summary>
-        internal static string ClickablePointOnScreen {
-            get {
-                return ResourceManager.GetString("ClickablePointOnScreen", resourceCulture);
             }
         }
         

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -550,4 +550,8 @@ If possible, use a predefined (non-custom) control type and the default localize
     <value>If the element's ClickablePoint property is correct, set the element's IsOffScreen property to false.
 If the element's ClickablePoint property is incorrect, please ensure it returns the correct value.</value>
   </data>
+  <data name="ClickablePointOffScreen" xml:space="preserve">
+    <value>If the element's ClickablePoint property is correct, set the element's IsOffScreen property to true.
+If the element's ClickablePoint property is incorrect, please ensure it returns the correct value.</value>
+  </data>
 </root>

--- a/src/Rules/Rules.csproj
+++ b/src/Rules/Rules.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Library\ButtonToggleAndExpandeCollapsePatterns.cs" />
     <Compile Include="Library\ButtonInvokeAndExpandeCollapsePatterns.cs" />
     <Compile Include="Library\ButtonInvokeAndTogglePatterns.cs" />
+    <Compile Include="Library\ClickablePointOffScreen.cs" />
     <Compile Include="Library\ComboBoxShouldNotSupportScrollPattern.cs" />
     <Compile Include="Library\HyperlinkNameShouldBeUnique.cs" />
     <Compile Include="Library\HelpTextExcludesPrivateUnicodeCharacters.cs" />

--- a/src/RulesTest/Library/ClickablePointOffScreen.cs
+++ b/src/RulesTest/Library/ClickablePointOffScreen.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Drawing;
+using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
+
+namespace Axe.Windows.RulesTest.Library
+{
+    [TestClass]
+    public class ClickablePointOffScreenTests
+    {
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ClickablePointOffScreen();
+        private Mock<IA11yElement> mockElement = new Mock<IA11yElement>(MockBehavior.Strict);
+        private delegate void TryGetDelegate(int propertyId, out Point value);
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            mockElement.Reset();
+        }
+
+        private void SetupTryGetProperty(Point outVal)
+        {
+            mockElement.Setup(m => m.TryGetPropertyValue<Point>(PropertyType.UIA_ClickablePointPropertyId, out It.Ref<Point>.IsAny))
+                .Callback(new TryGetDelegate((int _, out Point p) =>
+                {
+                    p = outVal;
+                }))
+                .Returns(true);
+        }
+
+        [TestMethod]
+        public void ClickablePointOffScreen_OnScreen_Warning()
+        {
+            mockElement.Setup(m => m.IsOffScreen).Returns(false);
+            Assert.AreEqual(EvaluationCode.Warning, Rule.Evaluate(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePointOffScreen_OffScreen_Pass()
+        {
+            mockElement.Setup(m => m.IsOffScreen).Returns(true);
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePointOffScreen_IsNotClickable_Matches()
+        {
+            SetupTryGetProperty(new Point(-100, -100));
+            Assert.IsTrue(Rule.Condition.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePointOffScreen_IsClickable_NoMatch()
+        {
+            SetupTryGetProperty(new Point(100, 100));
+            Assert.IsFalse(Rule.Condition.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+    } // class
+} // namespace

--- a/src/RulesTest/PropertyConditions/ClickablePointTests.cs
+++ b/src/RulesTest/PropertyConditions/ClickablePointTests.cs
@@ -85,5 +85,59 @@ namespace Axe.Windows.RulesTest.Library
         {
             Assert.ThrowsException<ArgumentNullException>(() => ClickablePoint.OnScreen.Matches(null));
         }
+
+        [TestMethod]
+        public void ClickablePoint_OffScreen_False()
+        {
+            SetupTryGetProperty(new Point(100, 100));
+            Assert.IsFalse(ClickablePoint.OffScreen.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePoint_OffScreen_OffLeft_True()
+        {
+            SetupTryGetProperty(new Point(-100, 100));
+            Assert.IsTrue(ClickablePoint.OffScreen.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePoint_OffScreen_OffRightt_True()
+        {
+            SetupTryGetProperty(new Point(10000, 100));
+            Assert.IsTrue(ClickablePoint.OffScreen.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePoint_OffScreen_OffTop_True()
+        {
+            SetupTryGetProperty(new Point(100, -100));
+            Assert.IsTrue(ClickablePoint.OffScreen.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePoint_OffScreen_OffBottom_True()
+        {
+            SetupTryGetProperty(new Point(100, 10000));
+            Assert.IsTrue(ClickablePoint.OffScreen.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePoint_OffScreen_NoProperty_False()
+        {
+            SetupTryGetProperty(new Point(100, 100), false);
+            Assert.IsFalse(ClickablePoint.OffScreen.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePoint_OffScreen_NullElement_Throws()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => ClickablePoint.OffScreen.Matches(null));
+        }
     } // class
 } // namespace

--- a/src/RulesTest/RulesTests.csproj
+++ b/src/RulesTest/RulesTests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Library\ButtonInvokeAndExpandCollapsePatterns.cs" />
     <Compile Include="Library\ButtonInvokeAndTogglePatterns.cs" />
     <Compile Include="Library\ButtonPatterns.cs" />
+    <Compile Include="Library\ClickablePointOffScreen.cs" />
     <Compile Include="Library\ComboBoxShouldNotSupportScrollPatternTests.cs" />
     <Compile Include="Library\ControlShouldNotSupportInvokePattern.cs" />
     <Compile Include="Library\ControlShouldNotSupportScrollPatternTests.cs" />


### PR DESCRIPTION
#### Describe the change

- Add a new rule, ClicablePointOffScreen, to test that when the clickable point for an element is outside the desktop's bounding rectangle, the element's IsOffScreen property is set to true.
    - Add a new property condition ClickablePoint.OffScreen -- tests if an element's clickable point both exists and is outside the desktop's bounding rectangle.

The new rule generates a warning instead of an error because

- When Axe.Windows is run from a CLI, The desktop bounding rectangle is probably wrong because DPI awareness is probably not set for the CLI app (this will be addressed in an upcoming change)
- The resulting errors will likely create noise which only platform developers can fix (keeping this rule as a warning will allow it to become an assessment eventually, which will make it easier to ignore in automation)

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
