### PR TITLE
Bump CommandLineParser from 2.6.0 to 2.7.82

### DIFF
--- a/src/RulesMD/RulesMD.csproj
+++ b/src/RulesMD/RulesMD.csproj
@@ -43,8 +43,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.6.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommandLineParser.2.6.0\lib\net461\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.7.82.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.7.82\lib\net461\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/RulesMD/packages.config
+++ b/src/RulesMD/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.6.0" targetFramework="net471" />
+  <package id="CommandLineParser" version="2.7.82" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
#### Describe the change

Manually making a change that dependabot is unable to make on older project types.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
