### PR TITLE
Set PropertyID in rules relating to support for Grid and Table patterns

### DIFF
--- a/src/Rules/Library/ControlShouldSupportGridPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportGridPattern.cs
@@ -3,6 +3,7 @@
 using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
+using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
@@ -17,6 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldSupportGridPattern;
             this.Info.HowToFix = HowToFix.ControlShouldSupportGridPattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.PropertyID = PropertyType.UIA_IsGridPatternAvailablePropertyId;
         }
 
         public override EvaluationCode Evaluate(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportTablePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTablePattern.cs
@@ -3,6 +3,7 @@
 using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
+using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
@@ -17,6 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldSupportTablePattern;
             this.Info.HowToFix = HowToFix.ControlShouldSupportTablePattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.PropertyID = PropertyType.UIA_IsTablePatternAvailablePropertyId;
         }
 
         public override EvaluationCode Evaluate(IA11yElement e)

--- a/src/RulesTest/Library/ControlShouldSupportGridPattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportGridPattern.cs
@@ -39,12 +39,8 @@ namespace Axe.Windows.RulesTest.Library
             Rule.Evaluate(null);
         }
 
-        /// <summary>
-        /// Pass
-        /// The Grid rule has the UIA Grid PropertyId set.
-        /// </summary>
         [TestMethod]
-        public void GridPropertyExists_Pass()
+        public void CheckPropertyIdIsSet()
         {
             Assert.AreEqual(PropertyType.UIA_IsGridPatternAvailablePropertyId, this.Rule.Info.PropertyID);
         }

--- a/src/RulesTest/Library/ControlShouldSupportGridPattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportGridPattern.cs
@@ -41,39 +41,12 @@ namespace Axe.Windows.RulesTest.Library
 
         /// <summary>
         /// Pass
-        /// A Table supports Grid pattern
+        /// The Grid rule has the UIA Grid PropertyId set.
         /// </summary>
         [TestMethod]
-        public void TableWithGridPattern_Pass()
+        public void GridPropertyExists_Pass()
         {
-            var e = new MockA11yElement();
-
-            e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_TableControlTypeId;
-
-            e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_GridPatternId));
-
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
-
             Assert.AreEqual(PropertyType.UIA_IsGridPatternAvailablePropertyId, this.Rule.Info.PropertyID);
         }
-
-        /// <summary>
-        /// Fail
-        /// A Table does not support Grid pattern
-        /// </summary>
-        [TestMethod]
-        public void TableWithoutGridPattern_Error()
-        {
-            var e = new MockA11yElement();
-
-            e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_TableControlTypeId;
-
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Error, this.Rule.Evaluate(e));
-
-            Assert.AreEqual(PropertyType.UIA_IsGridPatternAvailablePropertyId, this.Rule.Info.PropertyID);
-        }
-
     } // class
 } // namespace

--- a/src/RulesTest/Library/ControlShouldSupportGridPattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportGridPattern.cs
@@ -3,41 +3,33 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Bases;
-using Axe.Windows.Core.Enums;
 using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 using Axe.Windows.Core.Types;
+using System.Diagnostics;
+using UIAutomationClient;
 
 namespace Axe.Windows.RulesTest.Library
 {
     [TestClass]
-    public class ControlShouldSupportTablePattern
+    public class ControlShouldSupportGridPattern
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportTablePattern();
+        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportGridPattern();
 
         [TestMethod]
-        public void HasTablePattern_Pass()
+        public void HasGridPattern_Pass()
         {
             var e = new MockA11yElement();
-            e.Patterns.Add(new A11yPattern(e, PatternType.UIA_TablePatternId));
+            e.Patterns.Add(new A11yPattern(e, PatternType.UIA_GridPatternId));
 
             Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
         }
 
         [TestMethod]
-        public void NoTablePattern_Error()
+        public void NoGridPattern_Error()
         {
             var e = new MockA11yElement();
 
             Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
-        }
-
-        [TestMethod]
-        public void NoTablePatternInEdgeFramework_Error()
-        {
-            var e = new MockA11yElement();
-            e.Framework = Framework.Edge;
-
-            Assert.AreEqual(EvaluationCode.Warning, Rule.Evaluate(e));
         }
 
         [TestMethod]
@@ -49,29 +41,29 @@ namespace Axe.Windows.RulesTest.Library
 
         /// <summary>
         /// Pass
-        /// A Table supports Table pattern
+        /// A Table supports Grid pattern
         /// </summary>
         [TestMethod]
-        public void TableWithTablePattern_Pass()
+        public void TableWithGridPattern_Pass()
         {
             var e = new MockA11yElement();
 
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_TableControlTypeId;
 
-            e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_TablePatternId));
+            e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_GridPatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
             Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
 
-            Assert.AreEqual(PropertyType.UIA_IsTablePatternAvailablePropertyId, this.Rule.Info.PropertyID);
+            Assert.AreEqual(PropertyType.UIA_IsGridPatternAvailablePropertyId, this.Rule.Info.PropertyID);
         }
 
         /// <summary>
         /// Fail
-        /// A Table does not support Table pattern
+        /// A Table does not support Grid pattern
         /// </summary>
         [TestMethod]
-        public void TableWithoutTablePattern_Error()
+        public void TableWithoutGridPattern_Error()
         {
             var e = new MockA11yElement();
 
@@ -80,7 +72,8 @@ namespace Axe.Windows.RulesTest.Library
             Assert.IsTrue(this.Rule.Condition.Matches(e));
             Assert.AreEqual(EvaluationCode.Error, this.Rule.Evaluate(e));
 
-            Assert.AreEqual(PropertyType.UIA_IsTablePatternAvailablePropertyId, this.Rule.Info.PropertyID);
+            Assert.AreEqual(PropertyType.UIA_IsGridPatternAvailablePropertyId, this.Rule.Info.PropertyID);
         }
+
     } // class
 } // namespace

--- a/src/RulesTest/Library/ControlShouldSupportTablePattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTablePattern.cs
@@ -47,12 +47,8 @@ namespace Axe.Windows.RulesTest.Library
             Rule.Evaluate(null);
         }
 
-        /// <summary>
-        /// Pass
-        /// The Table rule has the UIA Table PropertyId set.
-        /// </summary>
         [TestMethod]
-        public void TablePropertyExists_Pass()
+        public void CheckPropertyIdIsSet()
         {
             Assert.AreEqual(PropertyType.UIA_IsTablePatternAvailablePropertyId, this.Rule.Info.PropertyID);
         }

--- a/src/RulesTest/Library/ControlShouldSupportTablePattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTablePattern.cs
@@ -49,37 +49,11 @@ namespace Axe.Windows.RulesTest.Library
 
         /// <summary>
         /// Pass
-        /// A Table supports Table pattern
+        /// The Table rule has the UIA Table PropertyId set.
         /// </summary>
         [TestMethod]
-        public void TableWithTablePattern_Pass()
+        public void TablePropertyExists_Pass()
         {
-            var e = new MockA11yElement();
-
-            e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_TableControlTypeId;
-
-            e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_TablePatternId));
-
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
-
-            Assert.AreEqual(PropertyType.UIA_IsTablePatternAvailablePropertyId, this.Rule.Info.PropertyID);
-        }
-
-        /// <summary>
-        /// Fail
-        /// A Table does not support Table pattern
-        /// </summary>
-        [TestMethod]
-        public void TableWithoutTablePattern_Error()
-        {
-            var e = new MockA11yElement();
-
-            e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_TableControlTypeId;
-
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Error, this.Rule.Evaluate(e));
-
             Assert.AreEqual(PropertyType.UIA_IsTablePatternAvailablePropertyId, this.Rule.Info.PropertyID);
         }
     } // class

--- a/src/RulesTest/RulesTests.csproj
+++ b/src/RulesTest/RulesTests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Library\ComboBoxShouldNotSupportScrollPatternTests.cs" />
     <Compile Include="Library\ControlShouldNotSupportInvokePattern.cs" />
     <Compile Include="Library\ControlShouldNotSupportScrollPatternTests.cs" />
+    <Compile Include="Library\ControlShouldSupportGridPattern.cs" />
     <Compile Include="Library\ControlShouldSupportSetInfoTest.cs" />
     <Compile Include="Library\ControlShouldSupportTablePattern.cs" />
     <Compile Include="Library\ControlShouldSupportTextPatternUnitTests.cs" />


### PR DESCRIPTION
Adding PropertyIDs to enable snippet link to be shown in AIWin when a Table is found not to support the required UIA Grid and Table patterns. Update the related TablePattern unit tests, and create new GridPattern unit tests.