### PR TITLE
Explictily Disable signing of .NET Standard assemblies

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Axe.Windows.Core</AssemblyName>
     <RootNamespace>Axe.Windows.Core</RootNamespace>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <Import Project="..\..\build\NetStandardRelease.targets" />

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Rules/Rules.csproj
+++ b/src/Rules/Rules.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Axe.Windows.Rules</AssemblyName>
     <RootNamespace>Axe.Windows.Rules</RootNamespace>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <Import Project="..\..\build\NetStandardRelease.targets" />

--- a/src/RulesTest/RulesTests.csproj
+++ b/src/RulesTest/RulesTests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SystemAbstractions/SystemAbstractions.csproj
+++ b/src/SystemAbstractions/SystemAbstractions.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Axe.Windows.SystemAbstractions</AssemblyName>
     <RootNamespace>Axe.Windows.SystemAbstractions</RootNamespace>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <Import Project="..\..\build\NetStandardRelease.targets" />

--- a/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
+++ b/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Telemetry/Telemetry.csproj
+++ b/src/Telemetry/Telemetry.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Axe.Windows.Telemetry</AssemblyName>
     <RootNamespace>Axe.Windows.Telemetry</RootNamespace>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <Import Project="..\..\build\NetStandardRelease.targets" />

--- a/src/TelemetryTests/TelemetryTests.csproj
+++ b/src/TelemetryTests/TelemetryTests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UnitTestSharedLibrary/UnitTestSharedLibrary.csproj
+++ b/src/UnitTestSharedLibrary/UnitTestSharedLibrary.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Axe.Windows.UnitTestSharedLibrary</AssemblyName>
     <RootNamespace>Axe.Windows.UnitTestSharedLibrary</RootNamespace>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <Import Project="..\..\build\NetStandardTest.targets" />

--- a/src/Win32/Win32.csproj
+++ b/src/Win32/Win32.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Axe.Windows.Win32</AssemblyName>
     <RootNamespace>Axe.Windows.Win32</RootNamespace>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#### Describe the change
Assemblies built with the .NET Core SDK are signed by default in the signed build environment. We explicitly don't want to sign these assemblies, so we need to explicitly add the property to disable signing.

Validation build: https://dev.azure.com/mseng/1ES/_build/results?buildId=11254969&view=results

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
