### PR TITLE
Embed Interop types in Rules and RulesTest assemblies

### DIFF
--- a/src/Rules/Rules.csproj
+++ b/src/Rules/Rules.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <Reference Include="Interop.UIAutomationClient">
       <HintPath>..\UIAAssemblies\Win10.17713\Interop.UIAutomationClient.dll</HintPath>
+      <EmbedInteropTypes>true</EmbedInteropTypes>
     </Reference>
   </ItemGroup>
 

--- a/src/RulesTest/RulesTests.csproj
+++ b/src/RulesTest/RulesTests.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <Reference Include="Interop.UIAutomationClient">
       <HintPath>..\UIAAssemblies\Win10.17713\Interop.UIAutomationClient.dll</HintPath>
+      <EmbedInteropTypes>true</EmbedInteropTypes>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
#### Describe the change
Interop types need to be embedded in the rules assembly (this was missed during the port)

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
