### PR TITLE
Restore Assembly Metadata to projects built with .NET Core SDK

### DIFF
--- a/src/Core/AssemblyInfo.cs
+++ b/src/Core/AssemblyInfo.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+
+[assembly: AssemblyProduct("Axe.Windows.Core")]
+[assembly: AssemblyTitle("Axe.Windows.Core")]
+[assembly: AssemblyCopyright("Copyright © 2020")]
 
 #if ENABLE_SIGNING
 [assembly: InternalsVisibleTo("Axe.Windows.Actions,PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]

--- a/src/Rules/AssemblyInfo.cs
+++ b/src/Rules/AssemblyInfo.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+
+[assembly: AssemblyProduct("Axe.Windows.Rules")]
+[assembly: AssemblyTitle("Axe.Windows.Rules")]
+[assembly: AssemblyCopyright("Copyright © 2020")]
 
 #if ENABLE_SIGNING
 [assembly: InternalsVisibleTo("RulesTests,PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]

--- a/src/SystemAbstractions/AssemblyInfo.cs
+++ b/src/SystemAbstractions/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Reflection;
+
+[assembly: AssemblyProduct("Axe.Windows.SystemAbstractions")]
+[assembly: AssemblyTitle("Axe.Windows.SystemAbstractions")]
+[assembly: AssemblyCopyright("Copyright © 2020")]

--- a/src/Telemetry/AssemblyInfo.cs
+++ b/src/Telemetry/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Reflection;
+
+[assembly: AssemblyProduct("Axe.Windows.Telemetry")]
+[assembly: AssemblyTitle("Axe.Windows.Telemetry")]
+[assembly: AssemblyCopyright("Copyright © 2020")]

--- a/src/Win32/AssemblyInfo.cs
+++ b/src/Win32/AssemblyInfo.cs
@@ -1,8 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+
+[assembly: AssemblyProduct("Axe.Windows.Telemetry")]
+[assembly: AssemblyTitle("Axe.Windows.Telemetry")]
+[assembly: AssemblyCopyright("Copyright © 2020")]
 
 // Limit P/Invoke to assemblies located in the System32 folder
 [assembly: DefaultDllImportSearchPaths(DllImportSearchPath.System32)]

--- a/src/Win32/AssemblyInfo.cs
+++ b/src/Win32/AssemblyInfo.cs
@@ -5,8 +5,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyProduct("Axe.Windows.Telemetry")]
-[assembly: AssemblyTitle("Axe.Windows.Telemetry")]
+[assembly: AssemblyProduct("Axe.Windows.Win32")]
+[assembly: AssemblyTitle("Axe.Windows.Win32")]
 [assembly: AssemblyCopyright("Copyright © 2020")]
 
 // Limit P/Invoke to assemblies located in the System32 folder


### PR DESCRIPTION
#### Describe the change
In porting from .NET Framework to .NET Core, we stopped setting the following assembly metadata fields that we used to set:
AssemblyTitle (becomes the "FileDescription" property)
AssemblyProduct (becomes the "ProductName" property)
AssemblyCopyright (becomes the "LegalCopyright" property)

This PR sets the AssemblyTitle and AssemblyProduct values to their pre-port values, and sets the Copyright to 2020 so it's up-to-date. Future changes could potentially use a common value for AssemblyProduct (instead of using the assembly name) and/or centralize these values in a .props file, but the objective here is to achieve parity (modulo the updated copyright).

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
