### PR TITLE
Let IScanner.Scan caller specify scan ID (intended for CLI usage)

### DIFF
--- a/src/Automation/Interfaces/IOutputFileHelper.cs
+++ b/src/Automation/Interfaces/IOutputFileHelper.cs
@@ -7,5 +7,6 @@ namespace Axe.Windows.Automation
     internal interface IOutputFileHelper
     {
         string GetNewA11yTestFilePath();
+        void SetOutputFileNameWithoutExtension(string outputFileNameWithoutExtension);
     } // interface
 } // namespace

--- a/src/Automation/Interfaces/IOutputFileHelper.cs
+++ b/src/Automation/Interfaces/IOutputFileHelper.cs
@@ -7,6 +7,6 @@ namespace Axe.Windows.Automation
     internal interface IOutputFileHelper
     {
         string GetNewA11yTestFilePath();
-        void SetOutputFileNameWithoutExtension(string outputFileNameWithoutExtension);
+        void SetScanId(string scanId);
     } // interface
 } // namespace

--- a/src/Automation/Interfaces/IScanner.cs
+++ b/src/Automation/Interfaces/IScanner.cs
@@ -29,7 +29,7 @@ namespace Axe.Windows.Automation
         /// <summary>
         /// Run AxeWindows automated tests
         /// </summary>
-        /// <param name="outputFileNameWithoutExtension">The base file name (no path or extension) of the output file.</param>
+        /// <param name="scanId">The ID of this scan. Must be null or comply with file name requirements.</param>
         /// <remarks>
         /// If a value was provided in <see cref="Config.OutputDirectory"/>,
         /// output files may be written to the specified directory.
@@ -42,7 +42,7 @@ namespace Axe.Windows.Automation
         /// </remarks>
         /// <returns>Information about the scan and any issues detected</returns>
         /// <exception cref="AxeWindowsAutomationException"/>
-        ScanResults Scan(string outputFileNameWithoutExtension);
+        ScanResults Scan(string scanId);
 
     } // interface
 } // namespace

--- a/src/Automation/Interfaces/IScanner.cs
+++ b/src/Automation/Interfaces/IScanner.cs
@@ -25,5 +25,24 @@ namespace Axe.Windows.Automation
         /// <returns>Information about the scan and any issues detected</returns>
         /// <exception cref="AxeWindowsAutomationException"/>
         ScanResults Scan();
+
+        /// <summary>
+        /// Run AxeWindows automated tests
+        /// </summary>
+        /// <param name="outputFileNameWithoutExtension">The base file name (no path or extension) of the output file.</param>
+        /// <remarks>
+        /// If a value was provided in <see cref="Config.OutputDirectory"/>,
+        /// output files may be written to the specified directory.
+        /// (Note: no output files will be written if no errors were found.)
+        /// An exception may be thrown if the value of <see cref="Config.ProcessId"/> is invalid
+        /// or if the directory provided in <see cref="Config.OutputDirectory"/> cannot be created or accessed.
+        /// All exceptions are wrapped in <see cref="AxeWindowsAutomationException"/>.
+        /// If the exception was not thrown by AxeWindows automation, the <see cref="Exception.InnerException"/> property
+        /// will contain the exception.
+        /// </remarks>
+        /// <returns>Information about the scan and any issues detected</returns>
+        /// <exception cref="AxeWindowsAutomationException"/>
+        ScanResults Scan(string outputFileNameWithoutExtension);
+
     } // interface
 } // namespace

--- a/src/Automation/Interfaces/IScanner.cs
+++ b/src/Automation/Interfaces/IScanner.cs
@@ -29,7 +29,7 @@ namespace Axe.Windows.Automation
         /// <summary>
         /// Run AxeWindows automated tests
         /// </summary>
-        /// <param name="scanId">The ID of this scan. Must be null or comply with file name requirements.</param>
+        /// <param name="scanId">The ID of this scan. Must meet the requirements for a file name.</param>
         /// <remarks>
         /// If a value was provided in <see cref="Config.OutputDirectory"/>,
         /// output files may be written to the specified directory.

--- a/src/Automation/OutputFileHelper.cs
+++ b/src/Automation/OutputFileHelper.cs
@@ -70,10 +70,10 @@ namespace Axe.Windows.Automation
         public string GetNewA11yTestFilePath()
         {
             return Path.Combine(_outputDirectory,
-                GetEffectiveScanId() + ".a11ytest");
+                GetBaseFileName() + ".a11ytest");
         }
 
-        private string GetEffectiveScanId()
+        private string GetBaseFileName()
         {
             if (!string.IsNullOrEmpty(_scanId))
                 return _scanId;

--- a/src/Automation/OutputFileHelper.cs
+++ b/src/Automation/OutputFileHelper.cs
@@ -69,8 +69,8 @@ namespace Axe.Windows.Automation
 
         public string GetNewA11yTestFilePath()
         {
-            return Path.Combine(_outputDirectory
-                , GetEffectiveScanId() + ".a11ytest");
+            return Path.Combine(_outputDirectory,
+                GetEffectiveScanId() + ".a11ytest");
         }
 
         private string GetEffectiveScanId()

--- a/src/Automation/OutputFileHelper.cs
+++ b/src/Automation/OutputFileHelper.cs
@@ -15,6 +15,8 @@ namespace Axe.Windows.Automation
         private readonly string _outputDirectory;
         private readonly ISystemDateTime _dateTime;
 
+        private string _outputFileNameWithoutExtension = null;
+
         public const string DefaultOutputDirectoryName = "AxeWindowsOutputFiles";
         public const string DefaultFileNameBase = "AxeWindows";
 
@@ -68,16 +70,29 @@ namespace Axe.Windows.Automation
         public string GetNewA11yTestFilePath()
         {
             return Path.Combine(_outputDirectory
-                , GetNewFileName()
+                , GetOutputFileBaseName()
                 + ".a11ytest");
         }
 
-        private string GetNewFileName()
+        private string GetOutputFileBaseName()
+        {
+            if (!string.IsNullOrEmpty(_outputFileNameWithoutExtension))
+                return _outputFileNameWithoutExtension;
+
+            return GetNewFileBaseName();
+        }
+
+        private string GetNewFileBaseName()
         {
             var now = _dateTime.Now;
 
             var nowString = Invariant($"{now:yy-MM-dd_HH-mm-ss.fffffff}");
             return $"{DefaultFileNameBase}_{nowString}";
+        }
+
+        public void SetOutputFileNameWithoutExtension(string outputFileNameWithoutExtension)
+        {
+            _outputFileNameWithoutExtension = outputFileNameWithoutExtension;
         }
     } // class
 } // namespace

--- a/src/Automation/OutputFileHelper.cs
+++ b/src/Automation/OutputFileHelper.cs
@@ -15,7 +15,7 @@ namespace Axe.Windows.Automation
         private readonly string _outputDirectory;
         private readonly ISystemDateTime _dateTime;
 
-        private string _outputFileNameWithoutExtension = null;
+        private string _scanId = null;
 
         public const string DefaultOutputDirectoryName = "AxeWindowsOutputFiles";
         public const string DefaultFileNameBase = "AxeWindows";
@@ -70,19 +70,18 @@ namespace Axe.Windows.Automation
         public string GetNewA11yTestFilePath()
         {
             return Path.Combine(_outputDirectory
-                , GetOutputFileBaseName()
-                + ".a11ytest");
+                , GetEffectiveScanId() + ".a11ytest");
         }
 
-        private string GetOutputFileBaseName()
+        private string GetEffectiveScanId()
         {
-            if (!string.IsNullOrEmpty(_outputFileNameWithoutExtension))
-                return _outputFileNameWithoutExtension;
+            if (!string.IsNullOrEmpty(_scanId))
+                return _scanId;
 
-            return GetNewFileBaseName();
+            return GenerateScanId();
         }
 
-        private string GetNewFileBaseName()
+        private string GenerateScanId()
         {
             var now = _dateTime.Now;
 
@@ -90,9 +89,9 @@ namespace Axe.Windows.Automation
             return $"{DefaultFileNameBase}_{nowString}";
         }
 
-        public void SetOutputFileNameWithoutExtension(string outputFileNameWithoutExtension)
+        public void SetScanId(string scanId)
         {
-            _outputFileNameWithoutExtension = outputFileNameWithoutExtension;
+            _scanId = scanId;
         }
     } // class
 } // namespace

--- a/src/Automation/Scanner.cs
+++ b/src/Automation/Scanner.cs
@@ -38,8 +38,7 @@ namespace Axe.Windows.Automation
         /// <returns></returns>
         public ScanResults Scan(string scanId)
         {
-            // Defer validation of scanId so that we can wrap it inside the
-            // ExecutionWrapper
+            // Defer validation of scanId so that we can wrap it with ExecutionWrapper
             return ExecuteScan(scanId, () => ValidateScanId(scanId));
         }
 

--- a/src/Automation/Scanner.cs
+++ b/src/Automation/Scanner.cs
@@ -44,7 +44,7 @@ namespace Axe.Windows.Automation
 
         private void ValidateScanId(string scanId)
         {
-            if (scanId == null) throw new ArgumentException(nameof(scanId));
+            if (scanId == null) throw new ArgumentNullException(nameof(scanId));
             if (string.IsNullOrWhiteSpace(scanId)) throw new ArgumentException(ErrorMessages.StringNullOrWhiteSpace, nameof(scanId));
         }
 

--- a/src/Automation/Scanner.cs
+++ b/src/Automation/Scanner.cs
@@ -22,12 +22,21 @@ namespace Axe.Windows.Automation
         }
 
         /// <summary>
-        /// See <see cref="IScanner.Scan"/>
+        /// See <see cref="IScanner.Scan()"/>
         /// </summary>
         /// <returns></returns>
         public ScanResults Scan()
         {
-            return SnapshotCommand.Execute(_config, _scanTools);
+            return SnapshotCommand.Execute(_config, _scanTools, null);
+        }
+
+        /// <summary>
+        /// See <see cref="IScanner.Scan(string)"/>
+        /// </summary>
+        /// <returns></returns>
+        public ScanResults Scan(string outputFileNameWithoutExtension)
+        {
+            return SnapshotCommand.Execute(_config, _scanTools, outputFileNameWithoutExtension);
         }
     } // class
 } // namespace

--- a/src/Automation/Scanner.cs
+++ b/src/Automation/Scanner.cs
@@ -27,16 +27,21 @@ namespace Axe.Windows.Automation
         /// <returns></returns>
         public ScanResults Scan()
         {
-            return SnapshotCommand.Execute(_config, _scanTools, null);
+            return ExecuteCommand(null);
         }
 
         /// <summary>
         /// See <see cref="IScanner.Scan(string)"/>
         /// </summary>
         /// <returns></returns>
-        public ScanResults Scan(string outputFileNameWithoutExtension)
+        public ScanResults Scan(string scanId)
         {
-            return SnapshotCommand.Execute(_config, _scanTools, outputFileNameWithoutExtension);
+            return ExecuteCommand(scanId);
+        }
+
+        private ScanResults ExecuteCommand(string scanId)
+        {
+            return SnapshotCommand.Execute(_config, _scanTools, scanId);
         }
     } // class
 } // namespace

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -18,8 +18,9 @@ namespace Axe.Windows.Automation
         /// <param name="config">A set of configuration options</param>
         /// <param name="scanTools">A set of tools for writing output files,
         /// creating the expected results format, and finding the target element to scan</param>
+        /// <param name="outputFileNameWithoutExtension">The name (without extension) for the output file (can be null)</param>
         /// <returns>A SnapshotCommandResult that describes the result of the command</returns>
-        public static ScanResults Execute(Config config, IScanTools scanTools)
+        public static ScanResults Execute(Config config, IScanTools scanTools, string outputFileNameWithoutExtension = null)
         {
             return ExecutionWrapper.ExecuteCommand<ScanResults>(() =>
             {
@@ -28,6 +29,9 @@ namespace Axe.Windows.Automation
                 if (scanTools.TargetElementLocator == null) throw new ArgumentException(ErrorMessages.ScanToolsTargetElementLocatorNull, nameof(scanTools));
                 if (scanTools.Actions == null) throw new ArgumentException(ErrorMessages.ScanToolsActionsNull, nameof(scanTools));
                 if (scanTools.NativeMethods == null) throw new ArgumentException(ErrorMessages.ScanToolsNativeMethodsNull, nameof(scanTools));
+                if (scanTools.OutputFileHelper == null) throw new ArgumentException(ErrorMessages.ScanToolsOutputFileHelperNull, nameof(scanTools));
+
+                scanTools.OutputFileHelper.SetOutputFileNameWithoutExtension(outputFileNameWithoutExtension);
 
                 // We must turn on DPI awareness so we get physical, not logical, UIA element bounding rectangles
                 scanTools.NativeMethods.SetProcessDPIAware();
@@ -58,9 +62,6 @@ namespace Axe.Windows.Automation
 
         private static OutputFile WriteOutputFiles(OutputFileFormat outputFileFormat, IScanTools scanTools, A11yElement element, Guid elementId)
         {
-            if (scanTools == null) throw new ArgumentNullException(nameof(scanTools));
-            if (scanTools.OutputFileHelper == null) throw new ArgumentException(ErrorMessages.ScanToolsOutputFileHelperNull, nameof(scanTools));
-
             string a11yTestOutputFile = null;
 
             if (outputFileFormat.HasFlag(OutputFileFormat.A11yTest))

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -18,9 +18,9 @@ namespace Axe.Windows.Automation
         /// <param name="config">A set of configuration options</param>
         /// <param name="scanTools">A set of tools for writing output files,
         /// creating the expected results format, and finding the target element to scan</param>
-        /// <param name="outputFileNameWithoutExtension">The name (without extension) for the output file (can be null)</param>
+        /// <param name="scanId">The name (without extension) for the output file (can be null)</param>
         /// <returns>A SnapshotCommandResult that describes the result of the command</returns>
-        public static ScanResults Execute(Config config, IScanTools scanTools, string outputFileNameWithoutExtension = null)
+        public static ScanResults Execute(Config config, IScanTools scanTools, string scanId = null)
         {
             return ExecutionWrapper.ExecuteCommand<ScanResults>(() =>
             {
@@ -31,7 +31,7 @@ namespace Axe.Windows.Automation
                 if (scanTools.NativeMethods == null) throw new ArgumentException(ErrorMessages.ScanToolsNativeMethodsNull, nameof(scanTools));
                 if (scanTools.OutputFileHelper == null) throw new ArgumentException(ErrorMessages.ScanToolsOutputFileHelperNull, nameof(scanTools));
 
-                scanTools.OutputFileHelper.SetOutputFileNameWithoutExtension(outputFileNameWithoutExtension);
+                scanTools.OutputFileHelper.SetScanId(scanId);
 
                 // We must turn on DPI awareness so we get physical, not logical, UIA element bounding rectangles
                 scanTools.NativeMethods.SetProcessDPIAware();

--- a/src/AutomationTests/OutputFileHelperUnitTests.cs
+++ b/src/AutomationTests/OutputFileHelperUnitTests.cs
@@ -239,7 +239,7 @@ namespace Axe.Windows.AutomationTests
             mockDirectory.Setup(x => x.Exists(directory)).Returns(true);
 
             var outputFileHelper = new OutputFileHelper(directory, mockSystem.Object);
-            outputFileHelper.SetOutputFileNameWithoutExtension("abc");
+            outputFileHelper.SetScanId("abc");
             var result = outputFileHelper.GetNewA11yTestFilePath();
 
             var expectedFileName = "abc.a11ytest";

--- a/src/AutomationTests/OutputFileHelperUnitTests.cs
+++ b/src/AutomationTests/OutputFileHelperUnitTests.cs
@@ -182,7 +182,7 @@ namespace Axe.Windows.AutomationTests
 
         [TestMethod]
         [Timeout(1000)]
-        public void OutputFileHelper_GetNewA11yTestFilePath_GeneratedOutputFile_CreatesExpectedFileName()
+        public void OutputFileHelper_GetNewA11yTestFilePath_GeneratedScanId_CreatesExpectedFileName()
         {
             var mockSystem = new Mock<ISystem>(MockBehavior.Strict);
             var mockDateTime = new Mock<ISystemDateTime>(MockBehavior.Strict);
@@ -224,7 +224,7 @@ namespace Axe.Windows.AutomationTests
 
         [TestMethod]
         [Timeout(1000)]
-        public void OutputFileHelper_GetNewA11yTestFilePath_SpecificOutputFile_CreatesExpectedFileName()
+        public void OutputFileHelper_GetNewA11yTestFilePath_SpecificScanId_CreatesExpectedFileName()
         {
             var mockSystem = new Mock<ISystem>(MockBehavior.Strict);
             var mockIO = new Mock<ISystemIO>(MockBehavior.Strict);
@@ -239,10 +239,10 @@ namespace Axe.Windows.AutomationTests
             mockDirectory.Setup(x => x.Exists(directory)).Returns(true);
 
             var outputFileHelper = new OutputFileHelper(directory, mockSystem.Object);
-            outputFileHelper.SetScanId("abc");
+            outputFileHelper.SetScanId("myScanId");
             var result = outputFileHelper.GetNewA11yTestFilePath();
 
-            var expectedFileName = "abc.a11ytest";
+            var expectedFileName = "myScanId.a11ytest";
             var actualFileName = Path.GetFileName(result);
             Assert.AreEqual(expectedFileName, actualFileName);
             Assert.AreEqual(directory, Path.GetDirectoryName(result));

--- a/src/AutomationTests/OutputFileHelperUnitTests.cs
+++ b/src/AutomationTests/OutputFileHelperUnitTests.cs
@@ -182,7 +182,7 @@ namespace Axe.Windows.AutomationTests
 
         [TestMethod]
         [Timeout(1000)]
-        public void OutputFileHelper_GetNewA11yTestFilePath_CreatesExpectedFileName()
+        public void OutputFileHelper_GetNewA11yTestFilePath_GeneratedOutputFile_CreatesExpectedFileName()
         {
             var mockSystem = new Mock<ISystem>(MockBehavior.Strict);
             var mockDateTime = new Mock<ISystemDateTime>(MockBehavior.Strict);
@@ -214,9 +214,40 @@ namespace Axe.Windows.AutomationTests
             var expectedFileName = $"{OutputFileHelper.DefaultFileNameBase}_19-04-01_20-08-08.0012345.a11ytest";
             var actualFileName = Path.GetFileName(result);
             Assert.AreEqual(expectedFileName, actualFileName);
+            Assert.AreEqual(directory, Path.GetDirectoryName(result));
 
             mockSystem.VerifyAll();
             mockDateTime.VerifyAll();
+            mockIO.VerifyAll();
+            mockDirectory.VerifyAll();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void OutputFileHelper_GetNewA11yTestFilePath_SpecificOutputFile_CreatesExpectedFileName()
+        {
+            var mockSystem = new Mock<ISystem>(MockBehavior.Strict);
+            var mockIO = new Mock<ISystemIO>(MockBehavior.Strict);
+            var mockDirectory = new Mock<ISystemIODirectory>(MockBehavior.Strict);
+            mockSystem.Setup(x => x.DateTime).Returns(InertDateTime);
+            mockSystem.Setup(x => x.Environment).Returns(InertEnvironment);
+            mockSystem.Setup(x => x.IO).Returns(mockIO.Object);
+
+            mockIO.Setup(x => x.Directory).Returns(mockDirectory.Object);
+
+            string directory = @"c:\TestDir2";
+            mockDirectory.Setup(x => x.Exists(directory)).Returns(true);
+
+            var outputFileHelper = new OutputFileHelper(directory, mockSystem.Object);
+            outputFileHelper.SetOutputFileNameWithoutExtension("abc");
+            var result = outputFileHelper.GetNewA11yTestFilePath();
+
+            var expectedFileName = "abc.a11ytest";
+            var actualFileName = Path.GetFileName(result);
+            Assert.AreEqual(expectedFileName, actualFileName);
+            Assert.AreEqual(directory, Path.GetDirectoryName(result));
+
+            mockSystem.VerifyAll();
             mockIO.VerifyAll();
             mockDirectory.VerifyAll();
         }

--- a/src/AutomationTests/SnapshotCommandUnitTests.cs
+++ b/src/AutomationTests/SnapshotCommandUnitTests.cs
@@ -21,7 +21,7 @@ namespace Axe.Windows.AutomationTests
         private Mock<IOutputFileHelper> _outputFileHelperMock;
         private Mock<IScanResultsAssembler> _resultsAssemblerMock;
         private Config _minimalConfig;
-        private string _actualOutputFileNameWithoutExtension;
+        private string _actualScanId;
 
         public SnapshotCommandUnitTests()
         {
@@ -32,7 +32,7 @@ namespace Axe.Windows.AutomationTests
         [TestInitialize]
         public void TestInit()
         {
-            _actualOutputFileNameWithoutExtension = null;
+            _actualScanId = null;
             _scanToolsMock = _mockRepo.Create<IScanTools>();
             _targetElementLocatorMock = _mockRepo.Create<ITargetElementLocator>();
             _actionsMock = _mockRepo.Create<IAxeWindowsActions>();
@@ -40,8 +40,8 @@ namespace Axe.Windows.AutomationTests
             _nativeMethodsMock.Setup(x => x.SetProcessDPIAware()).Returns(false);
             _resultsAssemblerMock = _mockRepo.Create<IScanResultsAssembler>();
             _outputFileHelperMock = _mockRepo.Create<IOutputFileHelper>();
-            _outputFileHelperMock.Setup(x => x.SetOutputFileNameWithoutExtension(It.IsAny<string>()))
-                .Callback<string>((s) => { _actualOutputFileNameWithoutExtension = s; });
+            _outputFileHelperMock.Setup(x => x.SetScanId(It.IsAny<string>()))
+                .Callback<string>((s) => { _actualScanId = s; });
         }
 
         private void InitResultsCallback(ScanResults results)
@@ -357,7 +357,7 @@ namespace Axe.Windows.AutomationTests
             var actualResults = SnapshotCommand.Execute(config, _scanToolsMock.Object);
             Assert.AreEqual(75, actualResults.ErrorCount);
             Assert.AreEqual(expectedPath, actualResults.OutputFile.A11yTest);
-            Assert.IsNull(_actualOutputFileNameWithoutExtension);
+            Assert.IsNull(_actualScanId);
 
             _scanToolsMock.VerifyAll();
             _nativeMethodsMock.VerifyAll();
@@ -369,7 +369,7 @@ namespace Axe.Windows.AutomationTests
 
         [TestMethod]
         [Timeout(1000)]
-        public void Execute_WithErrors_UserSuppliesOutputBaseFileName_CreatesSnapshotAndA11yTestFile()
+        public void Execute_WithErrors_UserSuppliesScanId_CreatesSnapshotAndA11yTestFile()
         {
             _scanToolsMock.Setup(x => x.TargetElementLocator).Returns(_targetElementLocatorMock.Object);
             _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
@@ -384,7 +384,7 @@ namespace Axe.Windows.AutomationTests
             InitResultsCallback(expectedResults);
 
             var expectedPath = "UserSpecifiedTest.file";
-            const string outputFileNameWithoutExtension = "MyBaseFileName";
+            const string scanId = "MyScanId";
 
             _actionsMock.Setup(x => x.CaptureScreenshot(It.IsAny<Guid>()));
             _actionsMock.Setup(x => x.SaveA11yTestFile(expectedPath, It.IsAny<A11yElement>(), It.IsAny<Guid>()));
@@ -396,10 +396,10 @@ namespace Axe.Windows.AutomationTests
                 .WithOutputFileFormat(OutputFileFormat.A11yTest)
                 .Build();
 
-            var actualResults = SnapshotCommand.Execute(config, _scanToolsMock.Object, outputFileNameWithoutExtension);
+            var actualResults = SnapshotCommand.Execute(config, _scanToolsMock.Object, scanId);
             Assert.AreEqual(75, actualResults.ErrorCount);
             Assert.AreEqual(expectedPath, actualResults.OutputFile.A11yTest);
-            Assert.AreEqual(outputFileNameWithoutExtension, _actualOutputFileNameWithoutExtension);
+            Assert.AreEqual(scanId, _actualScanId);
 
             _scanToolsMock.VerifyAll();
             _nativeMethodsMock.VerifyAll();

--- a/src/AutomationTests/SnapshotCommandUnitTests.cs
+++ b/src/AutomationTests/SnapshotCommandUnitTests.cs
@@ -355,9 +355,9 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.VerifyAll();
             _nativeMethodsMock.VerifyAll();
             _targetElementLocatorMock.VerifyAll();
-            _outputFileHelperMock.VerifyAll();
             _actionsMock.VerifyAll();
             _resultsAssemblerMock.VerifyAll();
+            _outputFileHelperMock.VerifyAll();
         }
     } // class
 } // namespace

--- a/src/AutomationTests/SnapshotCommandUnitTests.cs
+++ b/src/AutomationTests/SnapshotCommandUnitTests.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace Axe.Windows.AutomationTests
 {
-    using ScanResults = Axe.Windows.Automation.ScanResults;
+    using ScanResults = ScanResults;
 
     [TestClass]
     public class SnapshotCommandUnitTests
@@ -21,7 +21,6 @@ namespace Axe.Windows.AutomationTests
         private Mock<IOutputFileHelper> _outputFileHelperMock;
         private Mock<IScanResultsAssembler> _resultsAssemblerMock;
         private Config _minimalConfig;
-        private string _actualScanId;
 
         public SnapshotCommandUnitTests()
         {
@@ -32,16 +31,13 @@ namespace Axe.Windows.AutomationTests
         [TestInitialize]
         public void TestInit()
         {
-            _actualScanId = null;
             _scanToolsMock = _mockRepo.Create<IScanTools>();
             _targetElementLocatorMock = _mockRepo.Create<ITargetElementLocator>();
             _actionsMock = _mockRepo.Create<IAxeWindowsActions>();
             _nativeMethodsMock = _mockRepo.Create<INativeMethods>();
             _nativeMethodsMock.Setup(x => x.SetProcessDPIAware()).Returns(false);
-            _resultsAssemblerMock = _mockRepo.Create<IScanResultsAssembler>();
             _outputFileHelperMock = _mockRepo.Create<IOutputFileHelper>();
-            _outputFileHelperMock.Setup(x => x.SetScanId(It.IsAny<string>()))
-                .Callback<string>((s) => { _actualScanId = s; });
+            _resultsAssemblerMock = _mockRepo.Create<IScanResultsAssembler>();
         }
 
         private void InitResultsCallback(ScanResults results)
@@ -59,8 +55,8 @@ namespace Axe.Windows.AutomationTests
         public void Execute_NullConfig_ThrowsException()
         {
             var action = new Action(() => SnapshotCommand.Execute(config: null, scanTools: _scanToolsMock.Object));
-            var ex = Assert.ThrowsException<AxeWindowsAutomationException>(action);
-            Assert.IsInstanceOfType(ex.InnerException, typeof(ArgumentException));
+            var ex = Assert.ThrowsException<ArgumentNullException>(action);
+            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("config"));
         }
 
@@ -69,8 +65,8 @@ namespace Axe.Windows.AutomationTests
         public void Execute_NullScanTools_ThrowsException()
         {
             var action = new Action(() => SnapshotCommand.Execute(config: _minimalConfig, scanTools: null));
-            var ex = Assert.ThrowsException<AxeWindowsAutomationException>(action);
-            Assert.IsInstanceOfType(ex.InnerException, typeof(ArgumentNullException));
+            var ex = Assert.ThrowsException<ArgumentNullException>(action);
+            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("scanTools"));
         }
 
@@ -80,8 +76,8 @@ namespace Axe.Windows.AutomationTests
         {
             _scanToolsMock.Setup(x => x.TargetElementLocator).Returns<ITargetElementLocator>(null);
             var action = new Action(() => SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object));
-            var ex = Assert.ThrowsException<AxeWindowsAutomationException>(action);
-            Assert.IsInstanceOfType(ex.InnerException, typeof(ArgumentException));
+            var ex = Assert.ThrowsException<ArgumentException>(action);
+            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("TargetElementLocator"));
             _scanToolsMock.VerifyAll();
         }
@@ -94,8 +90,8 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.Actions).Returns<IAxeWindowsActions>(null);
 
             var action = new Action(() => SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object));
-            var ex = Assert.ThrowsException<AxeWindowsAutomationException>(action);
-            Assert.IsInstanceOfType(ex.InnerException, typeof(ArgumentException));
+            var ex = Assert.ThrowsException<ArgumentException>(action);
+            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("Actions"));
             _scanToolsMock.VerifyAll();
         }
@@ -109,25 +105,9 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.NativeMethods).Returns<INativeMethods>(null);
 
             var action = new Action(() => SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object));
-            var ex = Assert.ThrowsException<AxeWindowsAutomationException>(action);
-            Assert.IsInstanceOfType(ex.InnerException, typeof(ArgumentException));
+            var ex = Assert.ThrowsException<ArgumentException>(action);
+            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("NativeMethods"));
-            _scanToolsMock.VerifyAll();
-        }
-
-        [TestMethod]
-        [Timeout(1000)]
-        public void Execute_NullOutputFileHelper_ThrowsException()
-        {
-            _scanToolsMock.Setup(x => x.TargetElementLocator).Returns(_targetElementLocatorMock.Object);
-            _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
-            _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
-            _scanToolsMock.Setup(x => x.OutputFileHelper).Returns<IOutputFileHelper>(null);
-
-            var action = new Action(() => SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object));
-            var ex = Assert.ThrowsException<AxeWindowsAutomationException>(action);
-            Assert.IsInstanceOfType(ex.InnerException, typeof(ArgumentException));
-            Assert.IsTrue(ex.Message.Contains("OutputFileHelper"));
             _scanToolsMock.VerifyAll();
         }
 
@@ -138,41 +118,39 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.TargetElementLocator).Returns(_targetElementLocatorMock.Object);
             _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
             _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
-            _scanToolsMock.Setup(x => x.OutputFileHelper).Returns(_outputFileHelperMock.Object);
 
             _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns<A11yElement>(null);
 
             var action = new Action(() => SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object));
-            var ex = Assert.ThrowsException<AxeWindowsAutomationException>(action);
-            Assert.IsInstanceOfType(ex.InnerException, typeof(InvalidOperationException));
+            var ex = Assert.ThrowsException<InvalidOperationException>(action);
+            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("rootElement"));
 
             _scanToolsMock.VerifyAll();
             _nativeMethodsMock.VerifyAll();
             _targetElementLocatorMock.VerifyAll();
-            _outputFileHelperMock.VerifyAll();
         }
 
         [TestMethod]
         [Timeout(1000)]
         public void Execute_TargetElementLocatorReceivesConfigProcessId()
         {
+            const int expectedProcessId = 42;
+
             _scanToolsMock.Setup(x => x.TargetElementLocator).Returns(_targetElementLocatorMock.Object);
             _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
             _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
-            _scanToolsMock.Setup(x => x.OutputFileHelper).Returns(_outputFileHelperMock.Object);
 
-            _targetElementLocatorMock.Setup(x => x.LocateRootElement(42)).Returns<A11yElement>(null);
+            _targetElementLocatorMock.Setup(x => x.LocateRootElement(expectedProcessId)).Returns<A11yElement>(null);
 
-            var config = Config.Builder.ForProcessId(42).Build();
+            var config = Config.Builder.ForProcessId(expectedProcessId).Build();
 
             var action = new Action(() => SnapshotCommand.Execute(config, _scanToolsMock.Object));
-            Assert.ThrowsException<AxeWindowsAutomationException>(action);
+            Assert.ThrowsException<InvalidOperationException>(action);
 
             _scanToolsMock.VerifyAll();
             _nativeMethodsMock.VerifyAll();
             _targetElementLocatorMock.VerifyAll();
-            _outputFileHelperMock.VerifyAll();
         }
 
         [TestMethod]
@@ -182,7 +160,6 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.TargetElementLocator).Returns(_targetElementLocatorMock.Object);
             _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
             _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
-            _scanToolsMock.Setup(x => x.OutputFileHelper).Returns(_outputFileHelperMock.Object);
 
             var element = new A11yElement();
             _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns(element);
@@ -194,7 +171,6 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.VerifyAll();
             _nativeMethodsMock.VerifyAll();
             _targetElementLocatorMock.VerifyAll();
-            _outputFileHelperMock.VerifyAll();
             _actionsMock.VerifyAll();
         }
 
@@ -206,7 +182,6 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
             _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
             _scanToolsMock.Setup(x => x.ResultsAssembler).Returns(_resultsAssemblerMock.Object);
-            _scanToolsMock.Setup(x => x.OutputFileHelper).Returns(_outputFileHelperMock.Object);
 
             _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns(new A11yElement());
 
@@ -219,7 +194,6 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.VerifyAll();
             _nativeMethodsMock.VerifyAll();
             _targetElementLocatorMock.VerifyAll();
-            _outputFileHelperMock.VerifyAll();
             _actionsMock.VerifyAll();
             _resultsAssemblerMock.VerifyAll();
         }
@@ -232,7 +206,6 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
             _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
             _scanToolsMock.Setup(x => x.ResultsAssembler).Returns<IScanResultsAssembler>(null);
-            _scanToolsMock.Setup(x => x.OutputFileHelper).Returns(_outputFileHelperMock.Object);
 
             _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns(new A11yElement());
 
@@ -242,14 +215,13 @@ namespace Axe.Windows.AutomationTests
                 .Returns(() => tempResults);
 
             var action = new Action(() => SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object));
-            var ex = Assert.ThrowsException<AxeWindowsAutomationException>(action);
-            Assert.IsInstanceOfType(ex.InnerException, typeof(ArgumentException));
+            var ex = Assert.ThrowsException<ArgumentException>(action);
+            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("ResultsAssembler"));
 
             _scanToolsMock.VerifyAll();
             _nativeMethodsMock.VerifyAll();
             _targetElementLocatorMock.VerifyAll();
-            _outputFileHelperMock.VerifyAll();
             _actionsMock.VerifyAll();
         }
 
@@ -260,7 +232,6 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.TargetElementLocator).Returns(_targetElementLocatorMock.Object);
             _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
             _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
-            _scanToolsMock.Setup(x => x.OutputFileHelper).Returns(_outputFileHelperMock.Object);
             _scanToolsMock.Setup(x => x.ResultsAssembler).Returns(_resultsAssemblerMock.Object);
 
             _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns(new A11yElement());
@@ -283,7 +254,30 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.VerifyAll();
             _nativeMethodsMock.VerifyAll();
             _targetElementLocatorMock.VerifyAll();
-            _outputFileHelperMock.VerifyAll();
+            _actionsMock.VerifyAll();
+            _resultsAssemblerMock.VerifyAll();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void Execute_NullOutputFileHelper_ThrowsException()
+        {
+            _scanToolsMock.Setup(x => x.TargetElementLocator).Returns(_targetElementLocatorMock.Object);
+            _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
+            _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
+            _scanToolsMock.Setup(x => x.ResultsAssembler).Returns(_resultsAssemblerMock.Object);
+            _scanToolsMock.Setup(x => x.OutputFileHelper).Returns<IOutputFileHelper>(null);
+            _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns(new A11yElement());
+            var expectedResults = new ScanResults();
+            expectedResults.ErrorCount = 1;
+            InitResultsCallback(expectedResults);
+            var action = new Action(() => SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object));
+            var ex = Assert.ThrowsException<ArgumentException>(action);
+            Assert.IsNull(ex.InnerException);
+            Assert.IsTrue(ex.Message.Contains("OutputFileHelper"));
+            _scanToolsMock.VerifyAll();
+            _nativeMethodsMock.VerifyAll();
+            _targetElementLocatorMock.VerifyAll();
             _actionsMock.VerifyAll();
             _resultsAssemblerMock.VerifyAll();
         }
@@ -314,8 +308,8 @@ namespace Axe.Windows.AutomationTests
                 .Build();
 
             var action = new Action(() => SnapshotCommand.Execute(config, _scanToolsMock.Object));
-            var ex = Assert.ThrowsException<AxeWindowsAutomationException>(action);
-            Assert.IsInstanceOfType(ex.InnerException, typeof(InvalidOperationException));
+            var ex = Assert.ThrowsException<InvalidOperationException>(action);
+            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("a11yTestOutputFile"));
 
             _scanToolsMock.VerifyAll();
@@ -357,49 +351,6 @@ namespace Axe.Windows.AutomationTests
             var actualResults = SnapshotCommand.Execute(config, _scanToolsMock.Object);
             Assert.AreEqual(75, actualResults.ErrorCount);
             Assert.AreEqual(expectedPath, actualResults.OutputFile.A11yTest);
-            Assert.IsNull(_actualScanId);
-
-            _scanToolsMock.VerifyAll();
-            _nativeMethodsMock.VerifyAll();
-            _targetElementLocatorMock.VerifyAll();
-            _outputFileHelperMock.VerifyAll();
-            _actionsMock.VerifyAll();
-            _resultsAssemblerMock.VerifyAll();
-        }
-
-        [TestMethod]
-        [Timeout(1000)]
-        public void Execute_WithErrors_UserSuppliesScanId_CreatesSnapshotAndA11yTestFile()
-        {
-            _scanToolsMock.Setup(x => x.TargetElementLocator).Returns(_targetElementLocatorMock.Object);
-            _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
-            _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
-            _scanToolsMock.Setup(x => x.ResultsAssembler).Returns(_resultsAssemblerMock.Object);
-            _scanToolsMock.Setup(x => x.OutputFileHelper).Returns(_outputFileHelperMock.Object);
-
-            _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns(new A11yElement());
-
-            var expectedResults = new ScanResults();
-            expectedResults.ErrorCount = 75;
-            InitResultsCallback(expectedResults);
-
-            var expectedPath = "UserSpecifiedTest.file";
-            const string scanId = "MyScanId";
-
-            _actionsMock.Setup(x => x.CaptureScreenshot(It.IsAny<Guid>()));
-            _actionsMock.Setup(x => x.SaveA11yTestFile(expectedPath, It.IsAny<A11yElement>(), It.IsAny<Guid>()));
-
-            _outputFileHelperMock.Setup(x => x.GetNewA11yTestFilePath()).Returns(expectedPath);
-
-            var config = Config.Builder
-                .ForProcessId(-1)
-                .WithOutputFileFormat(OutputFileFormat.A11yTest)
-                .Build();
-
-            var actualResults = SnapshotCommand.Execute(config, _scanToolsMock.Object, scanId);
-            Assert.AreEqual(75, actualResults.ErrorCount);
-            Assert.AreEqual(expectedPath, actualResults.OutputFile.A11yTest);
-            Assert.AreEqual(scanId, _actualScanId);
 
             _scanToolsMock.VerifyAll();
             _nativeMethodsMock.VerifyAll();

--- a/src/AutomationTests/SnapshotCommandUnitTests.cs
+++ b/src/AutomationTests/SnapshotCommandUnitTests.cs
@@ -288,36 +288,6 @@ namespace Axe.Windows.AutomationTests
             _resultsAssemblerMock.VerifyAll();
         }
 
-#if THIS_HAS_MOVED_BUT_DIFF_IS_CLEARER_IF_WE_KEEP_IT_TEMPORARILY
-        [TestMethod]
-        [Timeout(1000)]
-        public void Execute_NullOutputFileHelper_ThrowsException()
-        {
-            _scanToolsMock.Setup(x => x.TargetElementLocator).Returns(_targetElementLocatorMock.Object);
-            _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
-            _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
-            _scanToolsMock.Setup(x => x.ResultsAssembler).Returns(_resultsAssemblerMock.Object);
-            _scanToolsMock.Setup(x => x.OutputFileHelper).Returns<IOutputFileHelper>(null);
-
-            _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns(new A11yElement());
-
-            var expectedResults = new ScanResults();
-            expectedResults.ErrorCount = 1;
-            InitResultsCallback(expectedResults);
-
-            var action = new Action(() => SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object));
-            var ex = Assert.ThrowsException<AxeWindowsAutomationException>(action);
-            Assert.IsInstanceOfType(ex.InnerException, typeof(ArgumentException));
-            Assert.IsTrue(ex.Message.Contains("OutputFileHelper"));
-
-            _scanToolsMock.VerifyAll();
-            _nativeMethodsMock.VerifyAll();
-            _targetElementLocatorMock.VerifyAll();
-            _actionsMock.VerifyAll();
-            _resultsAssemblerMock.VerifyAll();
-        }
-#endif
-
         [TestMethod]
         [Timeout(1000)]
         public void Execute_NullOutputFilePath_ThrowsException()

--- a/src/AutomationTests/SnapshotCommandUnitTests.cs
+++ b/src/AutomationTests/SnapshotCommandUnitTests.cs
@@ -56,7 +56,6 @@ namespace Axe.Windows.AutomationTests
         {
             var action = new Action(() => SnapshotCommand.Execute(config: null, scanTools: _scanToolsMock.Object));
             var ex = Assert.ThrowsException<ArgumentNullException>(action);
-            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("config"));
         }
 
@@ -66,7 +65,6 @@ namespace Axe.Windows.AutomationTests
         {
             var action = new Action(() => SnapshotCommand.Execute(config: _minimalConfig, scanTools: null));
             var ex = Assert.ThrowsException<ArgumentNullException>(action);
-            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("scanTools"));
         }
 
@@ -77,7 +75,6 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.TargetElementLocator).Returns<ITargetElementLocator>(null);
             var action = new Action(() => SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object));
             var ex = Assert.ThrowsException<ArgumentException>(action);
-            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("TargetElementLocator"));
             _scanToolsMock.VerifyAll();
         }
@@ -91,7 +88,6 @@ namespace Axe.Windows.AutomationTests
 
             var action = new Action(() => SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object));
             var ex = Assert.ThrowsException<ArgumentException>(action);
-            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("Actions"));
             _scanToolsMock.VerifyAll();
         }
@@ -106,7 +102,6 @@ namespace Axe.Windows.AutomationTests
 
             var action = new Action(() => SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object));
             var ex = Assert.ThrowsException<ArgumentException>(action);
-            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("NativeMethods"));
             _scanToolsMock.VerifyAll();
         }
@@ -123,7 +118,6 @@ namespace Axe.Windows.AutomationTests
 
             var action = new Action(() => SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object));
             var ex = Assert.ThrowsException<InvalidOperationException>(action);
-            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("rootElement"));
 
             _scanToolsMock.VerifyAll();
@@ -216,7 +210,6 @@ namespace Axe.Windows.AutomationTests
 
             var action = new Action(() => SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object));
             var ex = Assert.ThrowsException<ArgumentException>(action);
-            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("ResultsAssembler"));
 
             _scanToolsMock.VerifyAll();
@@ -273,7 +266,6 @@ namespace Axe.Windows.AutomationTests
             InitResultsCallback(expectedResults);
             var action = new Action(() => SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object));
             var ex = Assert.ThrowsException<ArgumentException>(action);
-            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("OutputFileHelper"));
             _scanToolsMock.VerifyAll();
             _nativeMethodsMock.VerifyAll();
@@ -309,7 +301,6 @@ namespace Axe.Windows.AutomationTests
 
             var action = new Action(() => SnapshotCommand.Execute(config, _scanToolsMock.Object));
             var ex = Assert.ThrowsException<InvalidOperationException>(action);
-            Assert.IsNull(ex.InnerException);
             Assert.IsTrue(ex.Message.Contains("a11yTestOutputFile"));
 
             _scanToolsMock.VerifyAll();


### PR DESCRIPTION
#### Describe the change
The automation layer's current scanning code auto-generates a name for the output file. This is fine for code calling the automation layer directly, since the returned data includes the name of the generated file. It's more problematic for the CLI that we're creating, since the CLI can only return an exit code. We could try to create ways to expose the name to the caller, but they all add complexity and increase the work for whoever is writing the script.

To simplify scripting via the CLI, we'll allow the CLI to accept an optional command line parameter that specifies a scan ID, which will then be used as the base file name of the output file. We'll use the current behavior (auto-generating the id/file name) if this command line parameter is omitted. The scanId is managed via the IOutputFileHelper interface, so it's opaque to the SnapshotCommand class.

As part of this change, I've also moved the ExecutionWrapper up the stack to the Scanner class, instead of having it inside the SnapshotCommand wrapper. It was in the wrapper for historical reasons, but makes more logical sense to have it in the Scanner itself.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
