### PR TITLE
Enable DotNetCore tests in PR and signed builds

### DIFF
--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -59,7 +59,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
     inputs:
-      arguments: --no-build --blame --verbosity detailed --configuration release
+      arguments: --no-build --blame --verbosity normal --configuration release
       command: test
       projects: |
         **\*test*.csproj
@@ -111,7 +111,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
     inputs:
-      arguments: --no-build --blame --verbosity detailed --configuration debug
+      arguments: --no-build --blame --verbosity normal --configuration debug
       command: test
       projects: |
         **\*test*.csproj

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -59,7 +59,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
     inputs:
-      arguments: --blame --verbosity detailed --configuration release
+      arguments: --no-build --blame --verbosity detailed --configuration release
       command: test
       projects: |
         **\*test*.csproj
@@ -111,7 +111,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
     inputs:
-      arguments: --blame --verbosity detailed --configuration debug
+      arguments: --no-build --blame --verbosity detailed --configuration debug
       command: test
       projects: |
         **\*test*.csproj

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -56,6 +56,14 @@ jobs:
       configuration: release
       rerunFailedTests: true
 
+  - task: DotNetCoreCLI@2
+    displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
+    inputs:
+      arguments: --blame --verbosity detailed --configuration release
+      command: test
+      projects: |
+        **\*test*.csproj
+
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
 
@@ -99,3 +107,12 @@ jobs:
       platform: '$(BuildPlatform)'
       configuration: debug
       rerunFailedTests: true
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
+    inputs:
+      arguments: --blame --verbosity detailed --configuration debug
+      command: test
+      projects: |
+        **\*test*.csproj
+

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -58,7 +58,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
     inputs:
-      arguments: --no-build --blame --verbosity detailed --configuration release
+      arguments: --no-build --blame --verbosity normal --configuration release
       command: test
       projects: |
         **\*test*.csproj
@@ -175,7 +175,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
     inputs:
-      arguments: --no-build --blame --verbosity detailed --configuration debug
+      arguments: --no-build --blame --verbosity normal --configuration debug
       command: test
       projects: |
         **\*test*.csproj
@@ -271,7 +271,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
     inputs:
-      arguments: --no-build --blame --verbosity detailed --configuration release
+      arguments: --no-build --blame --verbosity normal --configuration release
       command: test
       projects: |
         **\*test*.csproj

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -55,6 +55,14 @@ jobs:
       configuration: release
       rerunFailedTests: true
 
+  - task: DotNetCoreCLI@2
+    displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
+    inputs:
+      arguments: --blame --verbosity detailed --configuration release
+      command: test
+      projects: |
+        **\*test*.csproj
+
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
 
@@ -164,6 +172,14 @@ jobs:
       configuration: debug
       rerunFailedTests: true
 
+  - task: DotNetCoreCLI@2
+    displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
+    inputs:
+      arguments: --blame --verbosity detailed --configuration debug
+      command: test
+      projects: |
+        **\*test*.csproj
+
   - task: CopyFiles@2
     displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
     inputs:
@@ -251,6 +267,14 @@ jobs:
       platform: '$(BuildPlatform)'
       configuration: release
       rerunFailedTests: true
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
+    inputs:
+      arguments: --blame --verbosity detailed --configuration release
+      command: test
+      projects: |
+        **\*test*.csproj
 
   - task: PublishSymbols@1
     displayName: 'Index Sources'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -58,7 +58,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
     inputs:
-      arguments: --blame --verbosity detailed --configuration release
+      arguments: --no-build --blame --verbosity detailed --configuration release
       command: test
       projects: |
         **\*test*.csproj
@@ -175,7 +175,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
     inputs:
-      arguments: --blame --verbosity detailed --configuration debug
+      arguments: --no-build --blame --verbosity detailed --configuration debug
       command: test
       projects: |
         **\*test*.csproj
@@ -271,7 +271,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
     inputs:
-      arguments: --blame --verbosity detailed --configuration release
+      arguments: --no-build --blame --verbosity detailed --configuration release
       command: test
       projects: |
         **\*test*.csproj


### PR DESCRIPTION
#### Describe the change
Our old build loops run tests via vstest.exe, which only understands .NET Framework unit tests. As a result, we were losing tests as we migrated to .NET Core-based tests. This is the root cause of #152. We need to add a task to run the .Net Core CLI task in both the PR and signed build loop definitions. 

Validation in signed build: https://dev.azure.com/mseng/1ES/_build/results?buildId=11295667&view=results

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
