### PR TITLE
Fixing RuleSelection unit tests which were not being run

### DIFF
--- a/src/RuleSelection/Resources/DefaultGuidelineUrls.Designer.cs
+++ b/src/RuleSelection/Resources/DefaultGuidelineUrls.Designer.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.RuleSelection.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class DefaultGuidelineUrls {

--- a/src/RuleSelection/Resources/ErrorMessages.Designer.cs
+++ b/src/RuleSelection/Resources/ErrorMessages.Designer.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.RuleSelection.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ErrorMessages {

--- a/src/RuleSelection/RuleSelection.csproj
+++ b/src/RuleSelection/RuleSelection.csproj
@@ -30,4 +30,37 @@
     <ProjectReference Include="..\Telemetry\Telemetry.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="Resources\DefaultGuidelineShortDescriptions.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>DefaultGuidelineShortDescriptions.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Resources\DefaultGuidelineUrls.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>DefaultGuidelineUrls.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Resources\ErrorMessages.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ErrorMessages.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Resources\DefaultGuidelineShortDescriptions.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>DefaultGuidelineShortDescriptions.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources\DefaultGuidelineUrls.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>DefaultGuidelineUrls.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources\ErrorMessages.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>ErrorMessages.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/src/RuleSelectionTests/RuleSelectionTests.csproj
+++ b/src/RuleSelectionTests/RuleSelectionTests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\RuleSelection\RuleSelection.csproj" />
+    <ProjectReference Include="..\Rules\Rules.csproj" />
   </ItemGroup>
 
   <Import Project="..\..\build\NetStandardTest.targets" />


### PR DESCRIPTION
#### Describe the change

There were 4 unit tests not being run in the RuleSelectionTests project, those in DefaultReferenceLinksTests and ReferenceLinksTests. The reason seems to be that the reflection info for the A11yCriteriaId enum was not retrieveable because the Rules project was not a dependency of the test project.

Also, updated the RuleSelection project so that resource cs files are generated when resx files are changed.


<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
