### PR TITLE
Reorder Options class to improve auto-generated help

### DIFF
--- a/src/CLI/Options.cs
+++ b/src/CLI/Options.cs
@@ -7,17 +7,17 @@ namespace AxeWindowsCLI
 {
     public class Options : IOptions
     {
-        [Option(Required = false, HelpText = "Output directory")]
-        public string OutputDirectory { get; set; }
-
-        [Option(Required = false, HelpText = "Scan ID")]
-        public string ScanId { get; set; }
-
         [Option(Group = "Target", Required = false, HelpText = "Process Id")]
         public int ProcessId { get; set; }
 
         [Option(Group = "Target", Required = false, HelpText = "Process Name")]
         public string ProcessName { get; set; }
+
+        [Option(Required = false, HelpText = "Output directory")]
+        public string OutputDirectory { get; set; }
+
+        [Option(Required = false, HelpText = "Scan ID")]
+        public string ScanId { get; set; }
 
         [Option(Required = false, HelpText = "Verbosity level (Quiet/Default/Verbose)")]
         public string Verbosity { get; set; }


### PR DESCRIPTION
#### Describe the change

If a users runs the CLI with no parameters, the CommandLineParser library auto-generates help. The help is displayed in the order in which the properties are defined on the Options class. This changes moves the _required_ parameters (processName or processId) to the top of the help display.

Before the change (note that processId and processName are not first):
```
AxeWindowsCLI 0.3.6-prerelease
Copyright c 2020

ERROR(S):
  At least one option from group 'Target' (processid, processname) is required.
  --outputdirectory    Output directory
  --scanid             Scan ID
  --processid          (Group: Target) Process Id
  --processname        (Group: Target) Process Name
  --verbosity          Verbosity level (Quiet/Default/Verbose)
  --help               Display this help screen.
  --version            Display version information.
```
After the change (processId and ProcessName are first listed items):
```
AxeWindowsCLI 0.3.6-prerelease
Copyright c 2020

ERROR(S):
  At least one option from group 'Target' (processid, processname) is required.
  --processid          (Group: Target) Process Id
  --processname        (Group: Target) Process Name
  --outputdirectory    Output directory
  --scanid             Scan ID
  --verbosity          Verbosity level (Quiet/Default/Verbose)
  --help               Display this help screen.
  --version            Display version information.
```
> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
