### PR TITLE
Add unit tests to check old a11ytest file version compatibility

### DIFF
--- a/src/OldFileVersionCompatibilityTests/Assert.cs
+++ b/src/OldFileVersionCompatibilityTests/Assert.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+namespace OldFileVersionCompatibilityTests
+{
+    static class Assert
+    {
+        public static void AreEqual(object o1, object o2)
+        {
+            if (!o1.Equals(o2))
+                throw new TestAssertionException($"Expected {o1} to be equal to {o2}");
+        }
+
+        public static void AreNotEqual(object o1, object o2)
+        {
+            if (o1.Equals(o2))
+                throw new TestAssertionException($"Expected {o1} not to be equal to {o2}");
+        }
+
+        public static void IsFalse(bool b)
+        {
+            if (b)
+                throw new TestAssertionException($"Expected: false, actual: true");
+        }
+
+        public static void IsNotNull(object o)
+        {
+            if (o == null)
+                throw new TestAssertionException($"Expected the given object not to be null");
+        }
+    } // class
+} // namespace

--- a/src/OldFileVersionCompatibilityTests/ErrorCode.cs
+++ b/src/OldFileVersionCompatibilityTests/ErrorCode.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+namespace OldFileVersionCompatibilityTests
+{
+    enum ErrorCode
+    {
+        Success,
+        Assertion,
+        ProgramException,
+        UnhandledException,
+    } // enum
+} // namespace

--- a/src/OldFileVersionCompatibilityTests/OldFileVersionCompatibilityTests.csproj
+++ b/src/OldFileVersionCompatibilityTests/OldFileVersionCompatibilityTests.csproj
@@ -1,20 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+  </PropertyGroup>
 
-    <IsPackable>false</IsPackable>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net471|AnyCPU'">
+    <!-- These properties must be set in .Net Core in order for the stack trace to get the correct file paths and line numbers for assertions -->
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />

--- a/src/OldFileVersionCompatibilityTests/Program.cs
+++ b/src/OldFileVersionCompatibilityTests/Program.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace OldFileVersionCompatibilityTests
+{
+    class Program
+    {
+        private static string AppName = "OldFileVersionCompatibilityTests";
+
+        [STAThread]
+        static void Main(string[] args)
+        {
+            try
+            {
+                DoTest(args);
+            }
+            catch (TestAssertionException ex)
+            {
+                ExitWithError(ex);
+            }
+            catch (ProgramException ex)
+            {
+                ExitWithError(ex);
+            }
+            catch (Exception ex)
+            {
+                ExitWithError(ex);
+            }
+
+            Exit(ErrorCode.Success);
+        }
+
+        private static void DoTest(string[] args)
+        {
+            if (args.Length != 1) throw new ProgramException("Expected one command line parameter");
+            
+            var methodName = args[0];
+
+            var t = typeof(TestRunner);
+            var method = t.GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+            if (method == null) throw new ProgramException($"Expected {methodName} to be a public member of {t.Name}");
+
+            method.Invoke(new TestRunner(), null);
+        }
+
+        internal static void ExitWithError(TestAssertionException ex)
+        {
+            var errorCode = ErrorCode.Assertion;
+            var errorCodeString = GetErrorCodeString(errorCode);
+            Console.WriteLine($"{ex.FileName}({ex.LineNumber}) : {errorCodeString} {AppName} test assertion failed: {ex.Message}");
+            Exit(ErrorCode.Assertion);
+        }
+
+        internal static void ExitWithError(ProgramException ex)
+        {
+            var errorCode = ErrorCode.ProgramException;
+            var errorCodeString = GetErrorCodeString(errorCode);
+            Console.WriteLine($"{AppName} : {errorCodeString} program exception: {ex.Message}");
+            Exit(errorCode);
+        }
+
+        internal static void ExitWithError(Exception ex)
+        {
+            var errorCode = ErrorCode.UnhandledException;
+            var errorCodeString = GetErrorCodeString(errorCode);
+            Console.WriteLine($"{AppName} : {errorCodeString} unhandled exception: {ex.Message}");
+            Exit(errorCode);
+        }
+
+        private static string GetErrorCodeString(ErrorCode errorCode)
+        {
+            return $"error OFC{(int)errorCode}:";
+        }
+
+        private static void Exit(ErrorCode errorCode)
+        {
+            Environment.Exit((int)errorCode);
+        }
+    } // class
+} // namespace

--- a/src/OldFileVersionCompatibilityTests/ProgramException.cs
+++ b/src/OldFileVersionCompatibilityTests/ProgramException.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace OldFileVersionCompatibilityTests
+{
+    class ProgramException : Exception
+    {
+        public ProgramException(string message)
+            : base(message)
+        { }
+    } // class
+} // namespace

--- a/src/OldFileVersionCompatibilityTests/TestAssertionException.cs
+++ b/src/OldFileVersionCompatibilityTests/TestAssertionException.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Diagnostics;
+
+namespace OldFileVersionCompatibilityTests
+{
+    class TestAssertionException : Exception
+    {
+        public string FileName { get; }
+        public int LineNumber { get; }
+
+        public TestAssertionException(string message)
+            : base(message)
+        {
+            var trace = new StackTrace(true);
+            var frame = trace.GetFrame(2);
+            if (frame == null) throw new ProgramException("Unable to get stack frame for assertion");
+
+            FileName = frame.GetFileName();
+            LineNumber = frame.GetFileLineNumber();
+        }
+    } // class
+} // namespace

--- a/src/OldFileVersionCompatibilityTests/TestRunner.cs
+++ b/src/OldFileVersionCompatibilityTests/TestRunner.cs
@@ -6,17 +6,14 @@ using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Results;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Axe.Windows.OldFileVersionCompatibilityTests
+namespace OldFileVersionCompatibilityTests
 {
-    [TestClass]
-    public class LoadOldFileVersions
+    public class TestRunner
     {
-        // [TestMethod]
         public void ValidateFileVersion_0_1_0()
         {
             const string filePath = @".\TestFiles\WildlifeManager_AxeWindows_0_1_0.a11ytest";
@@ -25,7 +22,6 @@ namespace Axe.Windows.OldFileVersionCompatibilityTests
             ValidateOneFile(filePath, expectedFailureCount, expectedProcessId);
         }
 
-        // [TestMethod]
         public void ValidateFileVersion_0_2_0()
         {
             const string filePath = @".\TestFiles\WildlifeManager_AxeWindows_0_2_0.a11ytest";
@@ -34,7 +30,6 @@ namespace Axe.Windows.OldFileVersionCompatibilityTests
             ValidateOneFile(filePath, expectedFailureCount, expectedProcessId);
         }
 
-        // [TestMethod]
         public void ValidateFileVersion_0_3_1()
         {
             const string filePath = @".\TestFiles\WildlifeManager_AxeWindows_0_3_1.a11ytest";
@@ -43,7 +38,7 @@ namespace Axe.Windows.OldFileVersionCompatibilityTests
             ValidateOneFile(filePath, expectedFailureCount, expectedProcessId);
         }
 
-        #region UtilityFunctions
+#region UtilityFunctions
 
         internal static void ValidateOneFile(string filePath, int expectedFailureCount,
             int expectedProcessId)
@@ -130,6 +125,6 @@ namespace Axe.Windows.OldFileVersionCompatibilityTests
 
             return list;
         }
-        #endregion
+#endregion
     }
 }


### PR DESCRIPTION
#### Describe the change

Changing the OldFileVersionCompatibilityTests project so that it is a console app rather than a test app.

The problem was that since we changed the project to .Net Core, running all three unit tests which checked for old file version compatibility caused all three tests to appear not to run. The investigation into the problem determined there was a missing dll: Microsoft.IntelliTrace.Core. The trail went cold at that point: there is no documentation on this problem except that it exists and that it should have been fixed in the latest version of Visual Studio and .Net Core, although there are examples of users who still experience the problem with the latest versions just like us.

Since the tests run and pass individually, the solution (implemented herein) is to run each test by calling a console app and specifying the particular test function to run.

It isn't pretty, but there it is.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
