### PR TITLE
Add nuget restore to pipeline builds

### DIFF
--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -20,6 +20,13 @@ jobs:
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
 
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet restore'
+    inputs:
+      command: restore
+      projects: |
+        **\*.csproj
+
   - task: PowerShell@2
     displayName: 'License Header Check'
     inputs:
@@ -65,6 +72,13 @@ jobs:
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet restore'
+    inputs:
+      command: restore
+      projects: |
+        **\*.csproj
 
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -24,6 +24,11 @@ jobs:
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
 
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet restore'
+    inputs:
+      command: restore
+
   - task: PowerShell@2
     displayName: 'License Header Check'
     inputs:
@@ -76,6 +81,11 @@ jobs:
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet restore'
+    inputs:
+      command: restore
 
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
@@ -195,6 +205,11 @@ jobs:
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet restore'
+    inputs:
+      command: restore
 
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -27,6 +27,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'dotnet restore'
     inputs:
+      arguments: src\AxeWindows.sln
       command: restore
 
   - task: PowerShell@2
@@ -85,6 +86,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'dotnet restore'
     inputs:
+      arguments: src\AxeWindows.sln
       command: restore
 
   - task: VSBuild@1
@@ -209,6 +211,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'dotnet restore'
     inputs:
+      arguments: src\AxeWindows.sln
       command: restore
 
   - task: VSBuild@1

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -27,8 +27,9 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'dotnet restore'
     inputs:
-      arguments: src\AxeWindows.sln
       command: restore
+      projects: |
+        **\*.csproj
 
   - task: PowerShell@2
     displayName: 'License Header Check'
@@ -86,8 +87,9 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'dotnet restore'
     inputs:
-      arguments: src\AxeWindows.sln
       command: restore
+      projects: |
+        **\*.csproj
 
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
@@ -211,8 +213,9 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'dotnet restore'
     inputs:
-      arguments: src\AxeWindows.sln
       command: restore
+      projects: |
+        **\*.csproj
 
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'


### PR DESCRIPTION
#### Describe the change

Pipeline builds started failing in the SignedBuild job because we weren't running **dotnet restore** before building. This is called out as a requirement in the [task documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/build/dotnet-core-cli?view=azure-devops), but it seems to have just started to take effect when we moved to updated versions of the MSTest.TestFramework and MSTest.TestAdapter packages. I've added it to all builds, just as a precaution.

Signed build validation: https://dev.azure.com/mseng/1ES/_build/results?buildId=11445099&view=results

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
