### PR TITLE
Use CredScan V2

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -104,6 +104,7 @@ jobs:
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
     displayName: 'Run CredScan'
     inputs:
+      toolMajorVersion: V2
       verboseOutput: true
       debugMode: false
 


### PR DESCRIPTION
#### Describe the change

CredScan V1 is on the road to deprecation and we're starting to receive warnings during build. The recommended change is to use CredScan V2. As outlined in https://www.1eswiki.com/wiki/CredScan_Azure_DevOps_Build_Task, this involves setting the toolMajorVerion input to V2. Validation build is at https://dev.azure.com/mseng/1ES/_build/results?buildId=11457625&view=results. Compare the CredScan results (in the ComplianceDebug job) to previous results, and you'll note that we're no longer getting the warning.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
