### PR TITLE
Build zipped form of AxeWindowsCLI

### DIFF
--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -4,6 +4,7 @@ pr: none
 variables:
   BuildPlatform: 'x86'
   CreateAxeWindowsNugetPackage: 'true'
+  CreateAxeWindowsZippedCLI: 'true'
   PublicRelease: 'false'
   SignAppForRelease: 'false'
 

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -4,6 +4,7 @@ pr: none
 variables:
   BuildPlatform: 'x86'
   CreateAxeWindowsNugetPackage: 'true'
+  CreateAxeWindowsZippedCLI: 'true'
   PublicRelease: 'false'
   SignAppForRelease: 'false'
   MicroBuild_NuPkgSigningEnabled: 'false'

--- a/src/CLI/CLI.csproj
+++ b/src/CLI/CLI.csproj
@@ -23,4 +23,8 @@
     <ProjectReference Include="..\Automation\Automation.csproj" />
   </ItemGroup>
 
+  <Target Condition=" '$(CreateAxeWindowsZippedCLI)' == 'true' " Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\BuildZippedCLI.ps1 -TargetDir $(TargetDir) -Configuration $(ConfigurationName)" />
+  </Target>
+
 </Project>

--- a/tools/scripts/BuildZippedCLI.ps1
+++ b/tools/scripts/BuildZippedCLI.ps1
@@ -20,6 +20,9 @@ param(
     [Parameter(Mandatory=$true)][String]$TargetDir
 )
 
+Set-StrictMode -Version Latest
+$script:ErrorActionPreference = 'Stop'
+
 # Uncomment the next line for debugging
 #$VerbosePreference='continue'
 
@@ -72,9 +75,9 @@ function Create-Zipfile($src, $app, $zipFile, [string[]]$extensionsToPrune, [str
     Remove-Item $scratch -Force -Recurse
 }
 
-function CreateCLIZip($confguration, $targetDir, $zipFileName){
+function CreateCLIZip($configuration, $targetDir, $zipFileName){
     Write-Host "Creating a CLI zip file from files in $targetDir"
-    if ($confguration -eq 'debug') {
+    if ($configuration -eq 'debug') {
         $extensionsToPrune=@('dev.json')
     } else {
         $extensionsToPrune=@('pdb', 'dev.json')

--- a/tools/scripts/BuildZippedCLI.ps1
+++ b/tools/scripts/BuildZippedCLI.ps1
@@ -26,9 +26,9 @@ param(
 # This suppresses the progress indicator while creating the zip file
 $ProgressPreference='SilentlyContinue'
 
-function Get-UniqueTempFolder($baseName){
+function Get-UniqueTempFolder($app){
     $guid=New-Guid
-    $uniqueName=$baseName + '_' + $guid
+    $uniqueName=$app + '_' + $guid
     $tempFolder=Join-Path $env:temp $uniqueName
     return $tempFolder
 }

--- a/tools/scripts/BuildZippedCLI.ps1
+++ b/tools/scripts/BuildZippedCLI.ps1
@@ -26,8 +26,6 @@ param(
 # This suppresses the progress indicator while creating the zip file
 $ProgressPreference='SilentlyContinue'
 
-Clear-Host
-
 function Get-UniqueTempFolder($baseName){
     $guid=New-Guid
     $uniqueName=$baseName + '_' + $guid

--- a/tools/scripts/BuildZippedCLI.ps1
+++ b/tools/scripts/BuildZippedCLI.ps1
@@ -1,0 +1,101 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+<#
+.SYNOPSIS
+Builds a ZIP file that contains the Axe.Windows CLI. Output is named AxeWindowsCLI.zip
+
+.PARAMETER Configuration
+Debug or Release. Will retain PDB files in the ZIP file if DEBUG. Use $(ConfigurationName) if calling from a csproj file
+
+.PARAMETER TargetDir
+The directory where the files were built (and where the ZIP file will be dropped). Use $(TargetDir) if calling from a csproj file
+
+.Example Usage
+.\BuildZippedCLI.ps1 -Configuration release -TargetDir c:\myrepo\src\CLI\bin\release\netcoreapp3.0
+#>
+
+param(
+    $Configuration,
+    $TargetDir
+)
+
+# Uncomment the next line for debugging
+#$VerbosePreference='continue'
+
+# This suppresses the progress indicator while creating the zip file
+$ProgressPreference='SilentlyContinue'
+
+Clear-Host
+
+function Get-UniqueTempFolder($baseName){
+    $guid=New-Guid
+    $uniqueName=$baseName + '_' + $guid
+    $tempFolder=Join-Path $env:temp $uniqueName
+    return $tempFolder
+}
+
+function Copy-SourceTree($src, $dst){
+    Copy-Item $src $dst -force -recurse >$null
+}
+
+function Remove-FilesByExtension($path, $extension){
+    $pattern='*.' + $extension
+    Get-ChildItem $path -File -Recurse -Include $pattern | Remove-Item
+}
+
+function Remove-FoldersByName($path, $name){
+    Get-ChildItem $path -Directory -Recurse -Include $name | Remove-Item -Force -Recurse
+}
+
+function Create-Archive($src, $dst){
+    $from=$src + '\*'
+    Compress-Archive -Force -Path $from -DestinationPath $dst
+}
+
+function Create-Zipfile($src, $app, $zipFile, [string[]]$extensionsToPrune, [string[]]$foldersToPrune){
+    Write-Verbose "src = $src"
+    Write-Verbose "app = $app"
+    Write-Verbose "zipFile = $zipFile"
+    Write-Verbose "extensionsToPrune = $extensionsToPrune"
+    Write-Verbose "foldersToPrune = $foldersToPrune"
+
+    $scratch=Get-UniqueTempFolder $app
+    Write-Verbose "$scratch = $scratch"
+    Copy-SourceTree $src $scratch
+    foreach ($extension in $extensionsToPrune) {
+        Remove-FilesByExtension $scratch $extension
+    }
+    foreach ($folder in $foldersToPrune) {
+        Remove-FoldersByName $scratch $folder
+    }
+    Create-Archive $scratch $zipFile
+
+    Remove-Item $scratch -Force -Recurse
+}
+
+function CreateCLIZip($confguration, $targetDir, $zipFileName){
+    Write-Host "Creating a CLI zip file from files in $targetDir"
+    if ($confguration -eq 'debug') {
+        $extensionsToPrune=@('dev.json')
+    } else {
+        $extensionsToPrune=@('pdb', 'dev.json')
+    }
+    $foldersToPrune=@('unix')
+    $zipFile=Join-Path $targetDir $zipFileName
+    Create-ZipFile $targetDir 'CLI' $zipFile $extensionsToPrune $foldersToPrune
+    Write-Host 'Successfully Created' $zipFile
+}
+
+if ($TargetDir -eq $null) {
+    Write-Host 'TargetDir is a required parameter'
+    exit 1
+}
+
+if ($Configuration -eq $null) {
+    Write-Host 'Configuration is a required parameter'
+    exit 1
+}
+
+CreateCLIZip $Configuration $TargetDir 'AxeWindowsCLI.zip'
+exit 0

--- a/tools/scripts/BuildZippedCLI.ps1
+++ b/tools/scripts/BuildZippedCLI.ps1
@@ -16,8 +16,8 @@ The directory where the files were built (and where the ZIP file will be dropped
 #>
 
 param(
-    $Configuration,
-    $TargetDir
+    [Parameter(Mandatory=$true)][String]$Configuration,
+    [Parameter(Mandatory=$true)][String]$TargetDir
 )
 
 # Uncomment the next line for debugging
@@ -83,16 +83,6 @@ function CreateCLIZip($confguration, $targetDir, $zipFileName){
     $zipFile=Join-Path $targetDir $zipFileName
     Create-ZipFile $targetDir 'CLI' $zipFile $extensionsToPrune $foldersToPrune
     Write-Host 'Successfully Created' $zipFile
-}
-
-if ($TargetDir -eq $null) {
-    Write-Host 'TargetDir is a required parameter'
-    exit 1
-}
-
-if ($Configuration -eq $null) {
-    Write-Host 'Configuration is a required parameter'
-    exit 1
 }
 
 CreateCLIZip $Configuration $TargetDir 'AxeWindowsCLI.zip'


### PR DESCRIPTION
#### Describe the change

We have an MSI installer for installing the CLI, but there are likely to be automation scenarios where people want to avoid the hassle of an MSI. To support this scenario, we will allow people to access the CLI as a ZIP file. For a given release of Axe.Windows, we'll probably publish both the MSI and ZIP formats, so people can use whichever best fits their needs.

This PR adds a PowerShell script to generate the ZIP file. The script is launched after successfully building the CLI project. Since not all dev machines are configured to allow PowerShell scripts to run automatically, we put the execution of the script behind a new environment variable: `CreateAxeWindowsZippedCLI`. This environment variable is set in the PR and signed builds, so the ZIP file will be available as an artifact for publishing.

To aid in debugging, the debug version of AxeWindowsCLI.zip also includes PDB files. We probably won't publish this one, but we'll have it available for our use if we need it.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
