### PR TITLE
Add a temporary reference to System.Collections.Immutable

### DIFF
--- a/src/SystemAbstractions/SystemAbstractions.csproj
+++ b/src/SystemAbstractions/SystemAbstractions.csproj
@@ -19,6 +19,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <!-- The following is not used. It's here temporarily to retrigger component governance output in the build pipelines -->
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
     <PackageReference Include="Text.Analyzers" Version="2.6.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
#### Describe the change

This change is temporary to retrigger component governance output in the build pipelines

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
