### PR TITLE
Move Zip creation to CLI_Installer project

### DIFF
--- a/src/CLI/CLI.csproj
+++ b/src/CLI/CLI.csproj
@@ -35,8 +35,4 @@
     <ProjectReference Include="..\Automation\Automation.csproj" />
   </ItemGroup>
 
-  <Target Condition=" '$(CreateAxeWindowsZippedCLI)' == 'true' " Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\BuildZippedCLI.ps1 -TargetDir $(TargetDir) -Configuration $(ConfigurationName)" />
-  </Target>
-
 </Project>

--- a/src/CLI_Installer/CLI_Installer.wixproj
+++ b/src/CLI_Installer/CLI_Installer.wixproj
@@ -71,4 +71,9 @@
 	<Target Name="AfterBuild">
 	</Target>
 	-->
+
+  <Target Condition=" '$(CreateAxeWindowsZippedCLI)' == 'true' AND '$(ConfigurationName)' == 'Release' " Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\BuildZippedCLI.ps1 -TargetDir $(SolutionDir)CLI\bin\$(ConfigurationName)\netcoreapp3.0 -Configuration $(ConfigurationName)" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
#### Describe the change

Once CLI signing was enabled, we discovered that the ZIP version of the CLI was being built before
the signing took place, meaning that we would have multiple sets of files to support. To avoid this, we decided to make the CLI_Installer responsible for building the ZIP version of the CLI. Like the Installer itself, it will only build the release version by default.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
