### PR TITLE
Add support for targeting UWP apps

### DIFF
--- a/src/CLI/OptionsEvaluator.cs
+++ b/src/CLI/OptionsEvaluator.cs
@@ -22,13 +22,8 @@ namespace AxeWindowsCLI
             }
             else if (!string.IsNullOrEmpty(processName))
             {
-                string p = Path.GetFileName(processName);
-                if (p.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
-                {
-                    p = Path.GetFileNameWithoutExtension(p);
-                }
-                processName = p;
-                processId = processHelper.ProcessIdFromName(p);
+                processName = GetReducedProcessName(processName);
+                processId = processHelper.ProcessIdFromName(processName);
             }
             else
             {
@@ -59,6 +54,16 @@ namespace AxeWindowsCLI
                 ScanId = rawInputs.ScanId,
                 VerbosityLevel = verbosityLevel,
             };
+        }
+
+        private static string GetReducedProcessName(string processName)
+        {
+            string reducedProcessName = Path.GetFileName(processName);
+            if (reducedProcessName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+            {
+                reducedProcessName = Path.GetFileNameWithoutExtension(reducedProcessName);
+            }
+            return reducedProcessName;
         }
     }
 }

--- a/src/CLI/OptionsEvaluator.cs
+++ b/src/CLI/OptionsEvaluator.cs
@@ -22,7 +22,11 @@ namespace AxeWindowsCLI
             }
             else if (!string.IsNullOrEmpty(processName))
             {
-                string p = Path.GetFileNameWithoutExtension(processName);
+                string p = Path.GetFileName(processName);
+                if (p.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                {
+                    p = Path.GetFileNameWithoutExtension(p);
+                }
                 processName = p;
                 processId = processHelper.ProcessIdFromName(p);
             }

--- a/src/CLITests/OptionsEvaluatorUnitTests.cs
+++ b/src/CLITests/OptionsEvaluatorUnitTests.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AxeWindowsCLI;
+using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
+using System.ComponentModel.Design;
 
 namespace CLITests
 {
@@ -80,6 +82,54 @@ namespace CLITests
             };
             ValidateOptions(OptionsEvaluator.ProcessInputs(input, _processHelperMock.Object),
                 processId: TestProcessId);
+            VerifyAllMocks();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ProcessInputs_ProcessNameIsSpecifiedWithNoExtension_FindsProcessByName()
+        {
+            const string fullProcessName = @"c:\foo\bar\myprocess";
+            const string reducedProcessName = "myprocess";
+            _processHelperMock.Setup(x => x.ProcessIdFromName(reducedProcessName)).Returns(TestProcessId);
+            Options input = new Options
+            {
+                ProcessName = fullProcessName,
+            };
+            ValidateOptions(OptionsEvaluator.ProcessInputs(input, _processHelperMock.Object),
+                processId: TestProcessId, processName: reducedProcessName);
+            VerifyAllMocks();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ProcessInputs_ProcessNameIsSpecifiedWithExeExtension_FindsProcessByName()
+        {
+            const string fullProcessName = @"c:\foo\bar\myprocess.exe";
+            const string reducedProcessName = "myprocess";
+            _processHelperMock.Setup(x => x.ProcessIdFromName(reducedProcessName)).Returns(TestProcessId);
+            Options input = new Options
+            {
+                ProcessName = fullProcessName,
+            };
+            ValidateOptions(OptionsEvaluator.ProcessInputs(input, _processHelperMock.Object),
+                processId: TestProcessId, processName: reducedProcessName);
+            VerifyAllMocks();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ProcessInputs_ProcessNameIsSpecifiedWithAppExtension_FindsProcessByName()
+        {
+            const string fullProcessName = @"c:\foo\bar\myprocess.app";
+            const string reducedProcessName = "myprocess.app";
+            _processHelperMock.Setup(x => x.ProcessIdFromName(reducedProcessName)).Returns(TestProcessId);
+            Options input = new Options
+            {
+                ProcessName = fullProcessName,
+            };
+            ValidateOptions(OptionsEvaluator.ProcessInputs(input, _processHelperMock.Object),
+                processId: TestProcessId, processName: reducedProcessName);
             VerifyAllMocks();
         }
 

--- a/src/CLITests/OptionsEvaluatorUnitTests.cs
+++ b/src/CLITests/OptionsEvaluatorUnitTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AxeWindowsCLI;
-using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
-using System.ComponentModel.Design;
 
 namespace CLITests
 {


### PR DESCRIPTION
#### Describe the change

While experimenting with UWP apps, I found apps where the process name is ".App" instead of ".exe", and that's exactly how it shows up in the list of processes. To allow targeting of these apps. update the process name targeting to only remove the extension if it's ".exe". Add unit tests to cover the various code paths.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
