### PR TITLE
Add README.MD to CLI, install it with tool

### DIFF
--- a/src/CLI/CLI.csproj
+++ b/src/CLI/CLI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -33,6 +33,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Automation\Automation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="README.MD">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -1,6 +1,6 @@
 ﻿# Welcome to the Axe.Windows Command Line Interface (AxeWindowsCLI.exe)
 
-This tool allows you to scan your application for certain classes of accessibility issues from your currently existing scripting system.
+This tool allows you to scan your application for accessibility issues from your currently existing scripting system.
 
 ## Running the tool
 You invoke the scanner by running `AxeWindowsCLI.exe`. By default, this tool gets installed to `c:\users\Program Files (x86)\AxeWindowsCLI\1.0\AxeWindowsCLI.exe`, although you can install it into other locations if you wish.

--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -1,0 +1,57 @@
+﻿# Welcome to the Axe.Windows Command Line Interface (AxeWindowsCLI.exe)
+
+This tool allows you to scan your application for certain classes of accessibility issues from your currently existing scripting system.
+
+## Running the tool
+You invoke the scanner by running `AxeWindowsCLI.exe`. By default, this tool gets installed to `c:\users\Program Files (x86)\AxeWindowsCLI\1.0\AxeWindowsCLI.exe`, although you can install it into other locations if you wish.
+
+If you run the tool without parameters, you'll be presented with the help screen:
+
+```
+AxeWindowsCLI.exe
+
+  --processid                Process Id
+
+  --processname              Process Name
+
+  --outputdirectory          Output directory
+
+  --scanid                   Scan ID
+
+  --verbosity                Verbosity level (Quiet/Default/Verbose)
+
+  --showthirdpartynotices    Display Third Party Notices (opens file in browser
+                             without executing scan). If specified, all other
+                             options will be ignored.
+
+  --help                     Display this help screen.
+
+  --version                  Display version information.
+```
+
+  To scan an application, you need run AxeWindowsCLI with the information to know _which_ process to scan via either the `--processId` or `--processName` parameters
+
+### Command line parameters
+
+Parameter|Description
+|---|---|
+|processId|Identifies the process ID of the application to be scanned. Must be specified as an integer value|
+|processName|Identifies the name of the process to be scanned. Requires that the process to scan be the _only_ process of that name currently running on the system.|
+|outputDirectory|Identifies the folder where output files will be created. If not specified, this will default to `.\AxeWindowsOutputFiles` (relative to the current working directory)|
+|scanid|Identifies the specific ID of the scan. This allows you to preassign a name to the given scan (and output file). If omitted, an dynamic name in the format AxeWindows_YY-MM-DD_hh-mm-ss.fffffff will be used.|
+|verbosity|Identifies the level of detail you want in the output. Valid values are `quiet` (minimal output), `default` (typical output), or `verbose` (maximum output).
+|showThirdPartyNotices|If specified, displays the third party notices for components used by AxeWindowsCLI. This inforation is also available in the `thirdpartynotices.html1 file that is installed with AxeWindowsCLI.
+
+### Scan results
+A summary of scan results will be displayed after the scan is run. In addition, an A11yTest file will be generated if 1 or more errors were detected. The location of this file will be reported in the tool output (see the documentation of the `outputDirectory` and `scanId` parameters for ways to alter the name or location of the output file). This file can then be opened with **Accessibility Insights for Windows**, which is freely available at http://accessibilityinsights.io
+
+A detailed description of scan results will also be displayed if you specify verbose output (see the `verbosity` parameter).
+
+## Troubleshooting
+
+### Error message: A fatal error occurred. The required library hostfxr.dll could not be found.
+AxeWindowsCLI requires the presence of the .NET Core runtime, version 3.0 or greater. You can download the framework from https://dotnet.microsoft.com/download/dotnet-core. This error should go away after installing an appropriate runtime of the .NET Core.
+
+### Exception: Unable to locate root element
+This can occur if you are trying to scan a process that is running in an elevated context. To get around it, try running your process non-elevated, or try launching the scan from an elevated process.
+

--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -40,7 +40,7 @@ Parameter|Description
 |outputDirectory|Identifies the folder where output files will be created. If not specified, this will default to `.\AxeWindowsOutputFiles` (relative to the current working directory)|
 |scanid|Identifies the specific ID of the scan. This allows you to preassign a name to the given scan (and output file). If omitted, an dynamic name in the format AxeWindows_YY-MM-DD_hh-mm-ss.fffffff will be used.|
 |verbosity|Identifies the level of detail you want in the output. Valid values are `quiet` (minimal output), `default` (typical output), or `verbose` (maximum output).
-|showThirdPartyNotices|If specified, displays the third party notices for components used by AxeWindowsCLI. This inforation is also available in the `thirdpartynotices.html1 file that is installed with AxeWindowsCLI.
+|showThirdPartyNotices|If specified, displays the third party notices for components used by AxeWindowsCLI. This information is also available in the `thirdpartynotices.html` file that is installed with AxeWindowsCLI.
 
 ### Scan results
 A summary of scan results will be displayed after the scan is run. In addition, an A11yTest file will be generated if 1 or more errors were detected. The location of this file will be reported in the tool output (see the documentation of the `--outputDirectory` and `--scanId` parameters for ways to alter the name or location of the output file). This file can then be opened with **Accessibility Insights for Windows**, which is freely available at http://accessibilityinsights.io
@@ -54,4 +54,3 @@ AxeWindowsCLI requires the presence of the .NET Core runtime, version 3.0 or gre
 
 ### Exception: Unable to locate root element
 This can occur if you are trying to scan a process that is running in an elevated context. To get around it, try running your process non-elevated, or try launching the scan from an elevated process.
-

--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -29,7 +29,7 @@ AxeWindowsCLI.exe
   --version                  Display version information.
 ```
 
-  To scan an application, you need run AxeWindowsCLI with the information to know _which_ process to scan via either the `--processId` or `--processName` parameters
+  To scan an application, you need to specify the application's process via either the `--processId` or `--processName` parameters
 
 ### Command line parameters
 

--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -43,7 +43,7 @@ Parameter|Description
 |showThirdPartyNotices|If specified, displays the third party notices for components used by AxeWindowsCLI. This inforation is also available in the `thirdpartynotices.html1 file that is installed with AxeWindowsCLI.
 
 ### Scan results
-A summary of scan results will be displayed after the scan is run. In addition, an A11yTest file will be generated if 1 or more errors were detected. The location of this file will be reported in the tool output (see the documentation of the `outputDirectory` and `scanId` parameters for ways to alter the name or location of the output file). This file can then be opened with **Accessibility Insights for Windows**, which is freely available at http://accessibilityinsights.io
+A summary of scan results will be displayed after the scan is run. In addition, an A11yTest file will be generated if 1 or more errors were detected. The location of this file will be reported in the tool output (see the documentation of the `--outputDirectory` and `--scanId` parameters for ways to alter the name or location of the output file). This file can then be opened with **Accessibility Insights for Windows**, which is freely available at http://accessibilityinsights.io
 
 A detailed description of scan results will also be displayed if you specify verbose output (see the `verbosity` parameter).
 

--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -50,7 +50,7 @@ A detailed description of scan results will also be displayed if you specify ver
 ## Troubleshooting
 
 ### Error message: A fatal error occurred. The required library hostfxr.dll could not be found.
-AxeWindowsCLI requires the presence of the .NET Core runtime, version 3.0 or greater. You can download the framework from https://dotnet.microsoft.com/download/dotnet-core. This error should go away after installing an appropriate runtime of the .NET Core.
+AxeWindowsCLI requires the presence of version 3.0 (or greater) of the .NET Core runtime. You can download the framework from https://dotnet.microsoft.com/download/dotnet-core. This error should go away after installing an appropriate runtime of the .NET Core.
 
 ### Exception: Unable to locate root element
 This can occur if you are trying to scan a process that is running in an elevated context. To get around it, try running your process non-elevated, or try launching the scan from an elevated process.

--- a/src/CLI_Installer/Product.wxs
+++ b/src/CLI_Installer/Product.wxs
@@ -71,6 +71,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
         <File Source="..\CLI\bin\Release\netcoreapp3.0\System.Security.AccessControl.dll" />
         <File Source="..\CLI\bin\Release\netcoreapp3.0\System.Security.Principal.Windows.dll" />
         <File Source="..\CLI\bin\Release\netcoreapp3.0\thirdpartynotices.html" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.0\README.MD" />
       </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
#### Describe the change

This change adds a README.MD file to the CLI project and installs it via the MSI. I went for a markdown file instead of a text file because of its richer ability to convey formatted information, as well as the fact that we're addressing a developer audience with this tool.

The readme may grow over time. For now, the primary goal is to get people up and running and to unblock potential issues (like the absence of the .NET Core runtime)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
