### PR TITLE
Add checks for existence of .NET Core runtime 3.0 or higher

### DIFF
--- a/src/CLI_Installer/Product.wxs
+++ b/src/CLI_Installer/Product.wxs
@@ -18,6 +18,18 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER"/>
 
+    <Property Id="NETCORERUNTIMEFOUNDX86">
+      <DirectorySearch Id="NetCoreDirectoryFoundx86" Path="[ProgramFilesFolder]dotnet" >
+        <FileSearch Name="dotnet.exe" MinVersion="3.0"/>
+      </DirectorySearch>
+    </Property>
+
+    <Property Id="NETCORERUNTIMEFOUNDX64">
+      <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="[ProgramFiles64Folder]dotnet" >
+        <FileSearch Name="dotnet.exe" MinVersion="3.0"/>
+      </DirectorySearch>
+    </Property>
+
     <MediaTemplate EmbedCab="yes" />
 
     <Feature Id="ProductFeature" Title="Axe.Windows CLI" Level="1">
@@ -27,6 +39,10 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
       <ComponentGroupRef Id="NetCoreApp30Components" />
       <ComponentGroupRef Id="NetStandard20Components" />
     </Feature>
+
+    <Condition Message="[ProductName] requires .NET Core Runtime 3.0 or newer. Please visit https://dotnet.microsoft.com/download/dotnet-core">
+      <![CDATA[Installed OR NETCORERUNTIMEFOUNDX64 OR NETCORERUNTIMEFOUNDX86]]>
+    </Condition>
 
     <Directory Id="TARGETDIR" Name="SourceDir" >
       <Directory Id="ProgramFilesFolder" >
@@ -100,4 +116,5 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     </ComponentGroup>
 
   </Product>
+
 </Wix>


### PR DESCRIPTION
#### Describe the change

The CLI requires .NET Runtime 3.0 or newer to be installed. Add a check to block installation if it's not there.

Our logic checks the version of dotnet.exe in its default install location. If it's 3.0 or above, then we allow the install to continue. If it's missing or the wrong version, then we display a message saying "Axe.Windows Command Line Interface (CLI) requires .NET Core Runtime 3.0 or newer. Please visit https://dotnet.microsoft.com/download/dotnet-core". Here's a screenshot:

![image](https://user-images.githubusercontent.com/45672944/74298429-9d23e180-4cfe-11ea-934f-9ef18648ce46.png)

After clicking the OK button, the user is taken to the final setup dialog (included in the existing boilerplate), which says "Axe.Windows Command Line Interface (CLI) Setup Wizard ended prematurely because of an error. Your system has not been modified. To install this program at a later time, run Setup Wizard again. Click the Finish button to exit the Setup Wizard." Here's the screenshot:

![image](https://user-images.githubusercontent.com/45672944/74298542-f3912000-4cfe-11ea-8d56-c3315005220d.png)

As long as the .NET Core framework exists in either "Program Files" or "Program Files (x86)", the setup will continue normally.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
