### PR TITLE
Consistently put a space before parentheses in descriptions

### DIFF
--- a/src/Core/Types/HeadingLevelType.cs
+++ b/src/Core/Types/HeadingLevelType.cs
@@ -59,7 +59,7 @@ namespace Axe.Windows.Core.Types
             StringBuilder sb = new StringBuilder(name);
 
             sb.Replace("None", "_None");
-            sb.Append(Invariant($"({id})"));
+            sb.Append(Invariant($" ({id})"));
 
             return sb.ToString();
         }

--- a/src/Core/Types/LandmarkType.cs
+++ b/src/Core/Types/LandmarkType.cs
@@ -59,7 +59,7 @@ namespace Axe.Windows.Core.Types
             sb.Replace("UIA_", "");
             sb.Replace("Id", "");
 
-            sb.Append(Invariant($"({id})"));
+            sb.Append(Invariant($" ({id})"));
 
             return sb.ToString();
         }

--- a/src/Core/Types/TypeBase.cs
+++ b/src/Core/Types/TypeBase.cs
@@ -93,7 +93,7 @@ namespace Axe.Windows.Core.Types
                 return this.Dic[id];
             }
 
-            return Invariant($"Unknown({id})");
+            return Invariant($"Unknown ({id})");
         }
 
         /// <summary>

--- a/src/CoreTests/Types/HeadingLevelTypeTests.cs
+++ b/src/CoreTests/Types/HeadingLevelTypeTests.cs
@@ -13,61 +13,61 @@ namespace Axe.Windows.Core.Types.Tests
         [TestMethod()]
         public void HeadingLevelNone()
         {
-            Assert.AreEqual("HeadingLevel_None(80050)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevelNone));
+            Assert.AreEqual("HeadingLevel_None (80050)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevelNone));
         }
 
         [TestMethod()]
         public void HeadingLevel1()
         {
-            Assert.AreEqual("HeadingLevel1(80051)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel1));
+            Assert.AreEqual("HeadingLevel1 (80051)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel1));
         }
 
         [TestMethod()]
         public void HeadingLevel2()
         {
-            Assert.AreEqual("HeadingLevel2(80052)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel2));
+            Assert.AreEqual("HeadingLevel2 (80052)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel2));
         }
 
         [TestMethod()]
         public void HeadingLevel3()
         {
-            Assert.AreEqual("HeadingLevel3(80053)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel3));
+            Assert.AreEqual("HeadingLevel3 (80053)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel3));
         }
 
         [TestMethod()]
         public void HeadingLevel4()
         {
-            Assert.AreEqual("HeadingLevel4(80054)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel4));
+            Assert.AreEqual("HeadingLevel4 (80054)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel4));
         }
 
         [TestMethod()]
         public void HeadingLevel5()
         {
-            Assert.AreEqual("HeadingLevel5(80055)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel5));
+            Assert.AreEqual("HeadingLevel5 (80055)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel5));
         }
 
         [TestMethod()]
         public void HeadingLevel6()
         {
-            Assert.AreEqual("HeadingLevel6(80056)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel6));
+            Assert.AreEqual("HeadingLevel6 (80056)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel6));
         }
 
         [TestMethod()]
         public void HeadingLevel7()
         {
-            Assert.AreEqual("HeadingLevel7(80057)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel7));
+            Assert.AreEqual("HeadingLevel7 (80057)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel7));
         }
 
         [TestMethod()]
         public void HeadingLevel8()
         {
-            Assert.AreEqual("HeadingLevel8(80058)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel8));
+            Assert.AreEqual("HeadingLevel8 (80058)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel8));
         }
 
         [TestMethod()]
         public void HeadingLevel9()
         {
-            Assert.AreEqual("HeadingLevel9(80059)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel9));
+            Assert.AreEqual("HeadingLevel9 (80059)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel9));
         }
     }
 }

--- a/src/Desktop/Styles/StyleId.cs
+++ b/src/Desktop/Styles/StyleId.cs
@@ -71,7 +71,7 @@ namespace Axe.Windows.Desktop.Styles
             StringBuilder sb = new StringBuilder(name);
 
             sb.Replace(Prefix, "");
-            sb.Append(Invariant($"({id})"));
+            sb.Append(Invariant($" ({id})"));
 
             return sb.ToString();
         }

--- a/src/Desktop/Types/ChangeInfoType.cs
+++ b/src/Desktop/Types/ChangeInfoType.cs
@@ -52,7 +52,7 @@ namespace Axe.Windows.Desktop.Types
         {
             StringBuilder sb = new StringBuilder(name);
 
-            sb.Append(Invariant($"({id})"));
+            sb.Append(Invariant($" ({id})"));
 
             return sb.ToString();
         }

--- a/src/DesktopTests/Styles/StyleIdTests.cs
+++ b/src/DesktopTests/Styles/StyleIdTests.cs
@@ -14,109 +14,109 @@ namespace Axe.Windows.DesktopTests.Styles.Tests
         [TestMethod()]
         public void StyleId_Custom()
         {
-            Assert.AreEqual("Custom(70000)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Custom));
+            Assert.AreEqual("Custom (70000)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Custom));
         }
 
         [TestMethod()]
         public void StyleId_Heading1()
         {
-            Assert.AreEqual("Heading1(70001)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading1));
+            Assert.AreEqual("Heading1 (70001)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading1));
         }
 
         [TestMethod()]
         public void StyleId_Heading2()
         {
-            Assert.AreEqual("Heading2(70002)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading2));
+            Assert.AreEqual("Heading2 (70002)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading2));
         }
 
         [TestMethod()]
         public void StyleId_Heading3()
         {
-            Assert.AreEqual("Heading3(70003)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading3));
+            Assert.AreEqual("Heading3 (70003)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading3));
         }
 
         [TestMethod()]
         public void StyleId_Heading4()
         {
-            Assert.AreEqual("Heading4(70004)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading4));
+            Assert.AreEqual("Heading4 (70004)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading4));
         }
 
         [TestMethod()]
         public void StyleId_Heading5()
         {
-            Assert.AreEqual("Heading5(70005)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading5));
+            Assert.AreEqual("Heading5 (70005)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading5));
         }
 
         [TestMethod()]
         public void StyleId_Heading6()
         {
-            Assert.AreEqual("Heading6(70006)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading6));
+            Assert.AreEqual("Heading6 (70006)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading6));
         }
 
         [TestMethod()]
         public void StyleId_Heading7()
         {
-            Assert.AreEqual("Heading7(70007)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading7));
+            Assert.AreEqual("Heading7 (70007)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading7));
         }
 
         [TestMethod()]
         public void StyleId_Heading8()
         {
-            Assert.AreEqual("Heading8(70008)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading8));
+            Assert.AreEqual("Heading8 (70008)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading8));
         }
 
         [TestMethod()]
         public void StyleId_Heading9()
         {
-            Assert.AreEqual("Heading9(70009)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading9));
+            Assert.AreEqual("Heading9 (70009)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading9));
         }
 
         [TestMethod()]
         public void StyleId_Title()
         {
-            Assert.AreEqual("Title(70010)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Title));
+            Assert.AreEqual("Title (70010)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Title));
         }
 
         [TestMethod()]
         public void StyleId_Subtitle()
         {
-            Assert.AreEqual("Subtitle(70011)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Subtitle));
+            Assert.AreEqual("Subtitle (70011)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Subtitle));
         }
 
         [TestMethod()]
         public void StyleId_Normal()
         {
-            Assert.AreEqual("Normal(70012)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Normal));
+            Assert.AreEqual("Normal (70012)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Normal));
         }
 
         [TestMethod()]
         public void StyleId_Emphasis()
         {
-            Assert.AreEqual("Emphasis(70013)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Emphasis));
+            Assert.AreEqual("Emphasis (70013)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Emphasis));
         }
 
         [TestMethod()]
         public void StyleId_Quote()
         {
-            Assert.AreEqual("Quote(70014)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Quote));
+            Assert.AreEqual("Quote (70014)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Quote));
         }
 
         [TestMethod()]
         public void StyleId_BulletedList()
         {
-            Assert.AreEqual("BulletedList(70015)", StyleId.GetInstance().GetNameById(StyleId.StyleId_BulletedList));
+            Assert.AreEqual("BulletedList (70015)", StyleId.GetInstance().GetNameById(StyleId.StyleId_BulletedList));
         }
 
         [TestMethod()]
         public void StyleId_NumberedList()
         {
-            Assert.AreEqual("NumberedList(70016)", StyleId.GetInstance().GetNameById(StyleId.StyleId_NumberedList));
+            Assert.AreEqual("NumberedList (70016)", StyleId.GetInstance().GetNameById(StyleId.StyleId_NumberedList));
         }
 
         [TestMethod()]
         public void StyleId_Unknown()
         {
-            Assert.AreEqual("Unknown(70099)", StyleId.GetInstance().GetNameById(70099));
+            Assert.AreEqual("Unknown (70099)", StyleId.GetInstance().GetNameById(70099));
         }
     }
 }


### PR DESCRIPTION
#### Describe the change

Our rendering of properties are inconsistent--some have a space before the parentheses, while others don't. This change makes the rendering more consistent.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
