### PR TITLE
Apply SemVer property to MSI that installs the CLI

### DIFF
--- a/src/CLI_Installer/CLI_Installer.wixproj
+++ b/src/CLI_Installer/CLI_Installer.wixproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" Condition="Exists('..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.props')" />
   <Import Project="..\packages\WiX.3.11.2\build\wix.props" Condition="Exists('..\packages\WiX.3.11.2\build\wix.props')" />
+  <Import Project="..\props\version.props" Condition="Exists('..\props\version.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -18,11 +19,12 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug</DefineConstants>
+    <DefineConstants>Debug;SemVer=$(SemVerNumber);</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants>SemVer=$(SemVerNumber);</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Product.wxs" />

--- a/src/CLI_Installer/Product.wxs
+++ b/src/CLI_Installer/Product.wxs
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft. All rights reserved.
 Licensed under the MIT license. See LICENSE file in the project root for full license information.-->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Name="Axe.Windows Command Line Interface (CLI)" Language="1033" Version="1.0.0.0" Manufacturer="Microsoft" UpgradeCode="186aeebb-f5d4-4161-a0ba-0f22d8d8a15a">
+  <Product Id="*" Name="Axe.Windows Command Line Interface (CLI)" Language="1033" Version="$(var.SemVer)" Manufacturer="Microsoft" UpgradeCode="186aeebb-f5d4-4161-a0ba-0f22d8d8a15a">
     <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" Platform="x86" />
 
     <MajorUpgrade Schedule="afterInstallInitialize" RemoveFeatures="All"


### PR DESCRIPTION
#### Describe the change

The MSI to install the MSI is currently hardcoded to version 1.0.0.0, which is incorrect. The value for `SemVerNumber` is set in src/props/version.props, and we should apply that version to the MSI. WiX requires that this value conform to a System.Version object, so we can't include the value set for `SemVerSuffix`.

Validated by installing the built MSI, then opening Programs in Control Panel and confirming that the displayed version was 0.9.0 (which matches the current value of `SemVerNumber`)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
