### PR TITLE
Update Win32.HighContrast to fix unit test crash

### DIFF
--- a/src/Win32/HighContrast.cs
+++ b/src/Win32/HighContrast.cs
@@ -5,24 +5,28 @@ using System.Runtime.InteropServices;
 
 namespace Axe.Windows.Win32
 {
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
-    internal struct HighContrast
+    internal class HighContrast
     {
-        public UInt32 Size { get; private set; }
-        public Int32 Flags { get; private set; }
-        public string DefaultScheme { get; private set; }
-        public bool IsOn => (Flags & HighContrastOnFlag) == HighContrastOnFlag;
-
         private const uint SPI_GetHighContrast = 0x0042;
         private const UInt32 HighContrastOnFlag = 0x1;
 
+        private HighContrastData _data;
+
+        public bool IsOn => (_data.Flags & HighContrastOnFlag) == HighContrastOnFlag;
+
+        private HighContrast(HighContrastData data)
+        {
+            _data = data;
+        }
+
         public static HighContrast Create()
         {
-            var hc = new HighContrast { Size = (UInt32)Marshal.SizeOf(typeof(HighContrast)) };
+            var data = new HighContrastData();
+            data.Size = (UInt32)Marshal.SizeOf(data);
 
-            NativeMethods.SystemParametersInfoHighContrast(SPI_GetHighContrast, hc.Size, ref hc, 0);
+            NativeMethods.SystemParametersInfoHighContrast(SPI_GetHighContrast, data.Size, ref data, 0);
 
-            return hc;
+            return new HighContrast(data);
         }
     } // struct
 } // namespace

--- a/src/Win32/HighContrastData.cs
+++ b/src/Win32/HighContrastData.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Runtime.InteropServices;
+
+namespace Axe.Windows.Win32
+{
+    [StructLayout(LayoutKind.Sequential)]
+    struct HighContrastData
+    {
+        public UInt32 Size;
+        public Int32 Flags;
+
+        // changing the following type to string will cause .Net Core to crash during the unit tests
+        public IntPtr DefaultScheme;
+    } // struct
+} // namespace

--- a/src/Win32/NativeMethods.cs
+++ b/src/Win32/NativeMethods.cs
@@ -35,7 +35,7 @@ namespace Axe.Windows.Win32
         [DllImport("user32.dll")]
         internal static extern bool GetCursorPos(out Point lpPoint);
 
-        [DllImport("user32.dll", EntryPoint = "SystemParametersInfo", SetLastError = true)]
-        internal static extern bool SystemParametersInfoHighContrast(uint action, uint param, ref HighContrast vparam, uint init);
+        [DllImport("user32.dll", EntryPoint = "SystemParametersInfoW", SetLastError = true)]
+        internal static extern bool SystemParametersInfoHighContrast(uint action, uint param, ref HighContrastData vparam, uint init);
     }
 }


### PR DESCRIPTION
#### Describe the change

Previously,, the unit tests in OldFileVersionCompatibilityTests were not running because something in .Net Core was crashing the test process. No exception was thrown and the error did not produce a helpful error message. To work around the problem, we converted the OldFileVersionCompatibilityTests project to a console app and ran the tests from the AutomationTests project.

By working with the .Net Core team, we now see the cause of the crash was in the HighContrast class in the Wind32 project. For reasons which are still obscure, .Net Core will crash the second time the SystemParametersInfo function is called when the defaultScheme parameter of the passed-in struct is a string. When the defaultScheme parameter is changed to an IntPtr, the problem goes away. There may still be a problem in the .Net Core runtime, but at least axe-windows no longer crashes.

This change is the precursor to reverting the OldFileVersionCompatibilityTests project back into a unit test project.

Changes:

- Change defaultScheme type to IntPtr
- Create HighContrastData struct so that the size passed to SystemParametersInfo is closer to that of the Win32 struct. "Closer" because the native size of the struct is 12 bytes, while the managed size is 16 bytes. This difference does not seem to cause a problem in practice.
- Change the native call entry point to SystemParametersInfoW; it just seems better to use the UTF16 version rather than the Ansi version

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
