### PR TITLE
Publish CLI packages as separate artifacts

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -315,12 +315,24 @@ jobs:
     inputs:
       PathtoPublish: 'src\CI\bin\Release\NuGet'
       ArtifactName: 'NuGet'
-  
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Rules markdown'
     inputs:
       PathtoPublish: 'src\RulesMD\bin\Release\axe-windows-rules.md'
       ArtifactName: 'axe-windows-rules'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: CLI (msi)'
+    inputs:
+      PathtoPublish: 'src\CLI_Installer\bin\Release\AxeWindowsCLI.msi'
+      ArtifactName: 'CLI-msi'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: CLI (zip)'
+    inputs:
+      PathtoPublish: 'src\CLI_Installer\bin\Release\AxeWindowsCLI.zip'
+      ArtifactName: 'CLI-zip'
 
   - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
     displayName: 'Perform Cleanup Tasks'


### PR DESCRIPTION
#### Describe the change

To simplify the publishing process (which may eventually be automated), we want to explicitly publish the CLI artifacts (as opposed to having to find them in the drop artifact). This adds 2 new artifacts, called CLI-msi and CLI-zip. Validation build: https://dev.azure.com/mseng/1ES/_build/results?buildId=11544628&view=artifacts&type=publishedArtifacts

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
