### PR TITLE
Update Microsoft.NET.Test.Sdk reference in OldFileVersionCompatibilityTests

### DIFF
--- a/src/OldFileVersionCompatibilityTests/OldFileVersionCompatibilityTests.csproj
+++ b/src/OldFileVersionCompatibilityTests/OldFileVersionCompatibilityTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />


### PR DESCRIPTION
#### Describe the change

The Microsoft.NET.Test.Sdk version was accedentally reverted when a later commit reverted the project file to make OldFileVersionCompatibilityTests a unit test project once again.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
