### PR TITLE
Fix Issue #320 - AI-Win not properly reporting text pattern on Win32 up down control

### DIFF
--- a/src/Desktop/UIAutomation/EventHandlers/EventListenerFactory.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventListenerFactory.cs
@@ -349,7 +349,8 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     case EventType.UIA_AutomationFocusChangedEventId:
                         if (this.EventListenerFocusChanged == null)
                         {
-                            this.EventListenerFocusChanged = new FocusChangedEventListener(this.UIAutomation, msgData.Listener);
+                            var uia = (IUIAutomation) UIAutomation8 ?? UIAutomation;
+                            this.EventListenerFocusChanged = new FocusChangedEventListener(uia, msgData.Listener);
                         }
                         break;
                     case EventType.UIA_StructureChangedEventId:

--- a/src/Desktop/UIAutomation/EventHandlers/FocusChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/FocusChangedEventListener.cs
@@ -21,9 +21,9 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         /// </summary>
         public bool ReadyToListen { get; set; } = false;
 
-        private CUIAutomation UIAutomation = null;
+        private IUIAutomation UIAutomation = null;
 
-        public FocusChangedEventListener(CUIAutomation uia, HandleUIAutomationEventMessage peDelegate)
+        public FocusChangedEventListener(IUIAutomation uia, HandleUIAutomationEventMessage peDelegate)
         {
             if (uia == null) throw new ArgumentNullException(nameof(uia));
 


### PR DESCRIPTION
#### Describe the change

The problem was that the event listener code registered for focus events on the CUIAutomation object, as opposed to the CUIAutomation8 object. We don't know exactly why CUIAutomation.PoleForPotentialSupportedPatterns  does not provide the text pattern as a supported pattern on the Win32 edit field. But CUIAutomation8 does and the text pattern is retrieved successfully.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
