### PR TITLE
Update NuGet installer task

### DIFF
--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -13,10 +13,10 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   steps:
-  - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 5.0.0'
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet 5.x'
     inputs:
-      versionSpec: '5.0.0'
+      versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
@@ -68,10 +68,10 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   steps:
-  - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 5.0.0'
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet 5.x'
     inputs:
-      versionSpec: '5.0.0'
+      versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -17,10 +17,10 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   steps:
-  - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 5.0.0'
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet 5.x'
     inputs:
-      versionSpec: '5.0.0'
+      versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
@@ -77,10 +77,10 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   steps:
-  - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 5.0.0'
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet 5.x'
     inputs:
-      versionSpec: '5.0.0'
+      versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
@@ -204,10 +204,10 @@ jobs:
       esrpSigning: true
     condition: and(succeeded(), ne(variables['SignType'], ''))
 
-  - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 5.0.0'
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet 5.x'
     inputs:
-      versionSpec: '5.0.0'
+      versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'


### PR DESCRIPTION
Inspired by an [AI-Win PR](https://github.com/microsoft/accessibility-insights-windows/pull/733), this PR updates the remote build's use of a [deprecated NuGet install task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/prev-versions/nuget-installer-0?view=azure-devops) to the current version of that task. It also allows the use of all 5.x versions of NuGet. A test signed build can [be found here](https://dev.azure.com/mseng/1ES/_build/results?buildId=11746771&view=results).

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
