### PR TITLE
Add dependency group for .Net Standard 2.0 to nuspec

### DIFF
--- a/src/CI/Axe.Windows.nuspec
+++ b/src/CI/Axe.Windows.nuspec
@@ -15,10 +15,12 @@
     <copyright>© Microsoft and contributors</copyright>
     <tags>axe windows accessibility automation</tags>
     <dependencies>
-      <dependency id="Newtonsoft.Json" version="12.0.3" />
-      <dependency id="Microsoft.Win32.Registry" version="4.7.0" />
-      <dependency id="System.Drawing.Common" version="4.7.0" />
-      <dependency id="System.IO.Packaging" version="4.7.0" />
+      <group targetFramework="netstandard2.0">
+        <dependency id="Newtonsoft.Json" version="12.0.3" />
+        <dependency id="Microsoft.Win32.Registry" version="4.7.0" />
+        <dependency id="System.Drawing.Common" version="4.7.0" />
+        <dependency id="System.IO.Packaging" version="4.7.0" />
+      </group>
     </dependencies>
     <releaseNotes>https://github.com/microsoft/axe-windows/releases</releaseNotes>
   </metadata>


### PR DESCRIPTION
#### Describe the change

Fix #335 - [ENG] Warning NU5128 in builds

This change should match the target frameworks of the dependencies specified in the nuspec file to the frameworks of the assemblies contained in the nuget package.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
