### PR TITLE
Stop publishing symbols from build

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -261,12 +261,6 @@ jobs:
       projects: |
         **\*test*.csproj
 
-  - task: PublishSymbols@1
-    displayName: 'Index Sources'
-    inputs:
-      SearchPattern: '**\bin\**\*.pdb'
-    continueOnError: true
-
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
 
@@ -300,15 +294,6 @@ jobs:
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'
-
-  - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
-    displayName: 'Publish Symbols'
-    inputs:
-      symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
-      requestName: 'CollectionId/$(System.CollectionId)/ProjectId/$(System.TeamProjectId)/BuildId/$(Build.BuildId)'
-      sourcePath: '$(Build.ArtifactStagingDirectory)'
-      detailedLog: true
-      usePat: false
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: NuGet package'


### PR DESCRIPTION
#### Describe the change
This PR removes the symbol publishing tasks from our signed build. We plan to [publish symbol packages (.snupkg)](https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg) instead.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
