### PR TITLE
Creating symbol package (.snupkg) alongside nuget package

### DIFF
--- a/src/CI/Axe.Windows.nuspec
+++ b/src/CI/Axe.Windows.nuspec
@@ -26,6 +26,7 @@
   </metadata>
   <files>
     <file src="bin\$configuration$\axe.windows.*.dll" target="lib\netstandard20" />
+    <file src="bin\Release\axe.windows.*.pdb" target="lib\netstandard20" />
     <file src="bin\$configuration$\Axe.Windows.Automation.xml" target="lib\netstandard20" />
   </files> 
 </package>

--- a/src/CI/Axe.Windows.nuspec
+++ b/src/CI/Axe.Windows.nuspec
@@ -26,7 +26,7 @@
   </metadata>
   <files>
     <file src="bin\$configuration$\axe.windows.*.dll" target="lib\netstandard20" />
-    <file src="bin\Release\axe.windows.*.pdb" target="lib\netstandard20" />
+    <file src="bin\$configuration$\axe.windows.*.pdb" target="lib\netstandard20" />
     <file src="bin\$configuration$\Axe.Windows.Automation.xml" target="lib\netstandard20" />
   </files> 
 </package>

--- a/src/CI/CI.csproj
+++ b/src/CI/CI.csproj
@@ -38,7 +38,7 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
+</PropertyGroup>
   <ItemGroup>
     <None Include="App.config" />
     <None Include="Axe.Windows.nuspec">
@@ -57,7 +57,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Condition=" '$(CreateAxeWindowsNugetPackage)' == 'true' " Name="Pack" AfterTargets="Build">
-    <Exec Command="nuget.exe pack -properties Configuration=$(Configuration);VersionString=&quot;$(SemVerNumber)$(SemVerSuffix)&quot; Axe.Windows.nuspec -OutputDirectory bin\$(Configuration)\NuGet\$(SemVerNumber)$(SemVerSuffix) -NonInteractive" />
+    <Exec Command="nuget.exe pack -properties Configuration=$(Configuration);VersionString=&quot;$(SemVerNumber)$(SemVerSuffix)&quot; Axe.Windows.nuspec -OutputDirectory bin\$(Configuration)\NuGet\$(SemVerNumber)$(SemVerSuffix) -NonInteractive -Symbols -SymbolPackageFormat snupkg" />
   </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/CI/CI.csproj
+++ b/src/CI/CI.csproj
@@ -38,7 +38,7 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugSymbols>true</DebugSymbols>
-</PropertyGroup>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="App.config" />
     <None Include="Axe.Windows.nuspec">


### PR DESCRIPTION
#### Describe the change
This PR causes our nuget pack command to create a [symbols package](https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg) alongside the already produced nuget package. We can then upload the new symbols package to the NuGet.org symbol server when we release. Note that the nuget package is unchanged; the *.pdb files are only included in the symbols package.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
