### PR TITLE
Fix exception caused by unexpected parameter in FindItemByProperty

### DIFF
--- a/src/Desktop/UIAutomation/Patterns/ItemContainerPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ItemContainerPattern.cs
@@ -27,7 +27,8 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public DesktopElement FindItemByProperty(int propertyId, object value)
         {
-            return new DesktopElement(this.Pattern.FindItemByProperty(this.UIAElement, propertyId, value));
+            // null specifies finding the first matching item
+            return new DesktopElement(this.Pattern.FindItemByProperty(null, propertyId, value));
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
#### Describe the change

The first parameter being passed to the IUIAutomationItemContainerPattern.FindItemByProperty method was the element on which the pattern was implemented and that was throwing an exception. The first parameter should either be an item belonging to the element implementing the pattern or null. The latter indicates the search should start at the first contained element. So the code has been updated to pass null.

See https://docs.microsoft.com/en-us/windows/win32/api/uiautomationcore/nf-uiautomationcore-iitemcontainerprovider-finditembyproperty for further details.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
