### PR TITLE
Exclude Axe.Windows.CI.pdb from symbols package

### DIFF
--- a/src/CI/Axe.Windows.nuspec
+++ b/src/CI/Axe.Windows.nuspec
@@ -26,7 +26,7 @@
   </metadata>
   <files>
     <file src="bin\$configuration$\axe.windows.*.dll" target="lib\netstandard20" />
-    <file src="bin\$configuration$\axe.windows.*.pdb" target="lib\netstandard20" />
+    <file src="bin\$configuration$\axe.windows.*.pdb" target="lib\netstandard20" exclude="bin\$configuration$\Axe.Windows.CI.pdb"/>
     <file src="bin\$configuration$\Axe.Windows.Automation.xml" target="lib\netstandard20" />
   </files> 
 </package>


### PR DESCRIPTION
#### Describe the change
Currently, all .pdb files are included in our snupkg. However, Axe.Windows.CI.exe is not included in our nupkg. This PR brings the packages into alignment by excluding Axe.Windows.CI.pdb from the snupkg.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
