### PR TITLE
Upgrade from .NET Core 3.0 to .NET Core 3.1 in tests and CLI

### DIFF
--- a/src/ActionsTests/ActionsTests.csproj
+++ b/src/ActionsTests/ActionsTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/AutomationTests/AutomationTests.csproj
+++ b/src/AutomationTests/AutomationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/CLI/CLI.csproj
+++ b/src/CLI/CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>AxeWindowsCLI</AssemblyName>
     <RootNamespace>AxeWindowsCLI</RootNamespace>
   </PropertyGroup>

--- a/src/CLITests/CLITests.csproj
+++ b/src/CLITests/CLITests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/CLI_Full/CLI_Full.csproj
+++ b/src/CLI_Full/CLI_Full.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>AxeWindowsCLI</AssemblyName>
     <RootNamespace>AxeWindowsCLI</RootNamespace>
     <RuntimeIdentifier>win7-x86</RuntimeIdentifier>

--- a/src/CLI_Installer/CLI_Installer.wixproj
+++ b/src/CLI_Installer/CLI_Installer.wixproj
@@ -75,7 +75,7 @@
 	-->
 
   <Target Condition=" '$(CreateAxeWindowsZippedCLI)' == 'true' AND '$(ConfigurationName)' == 'Release' " Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\BuildZippedCLI.ps1 -SrcDir $(SolutionDir)CLI_Full\bin\$(ConfigurationName)\netcoreapp3.0\win7-x86 -TargetDir $(TargetDir) -Configuration $(ConfigurationName)" />
+    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\BuildZippedCLI.ps1 -SrcDir $(SolutionDir)CLI_Full\bin\$(ConfigurationName)\netcoreapp3.1\win7-x86 -TargetDir $(TargetDir) -Configuration $(ConfigurationName)" />
   </Target>
 
 </Project>

--- a/src/CLI_Installer/Product.wxs
+++ b/src/CLI_Installer/Product.wxs
@@ -44,7 +44,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <Directory Id="TARGETDIR" Name="SourceDir" >
       <Directory Id="ProgramFilesFolder" >
         <Directory Id="AxeWindowsCLIFolder" Name ="AxeWindowsCLI" >
-          <Directory Id="INSTALLFOLDER" Name="1.0" >
+          <Directory Id="INSTALLFOLDER" Name="$(var.SemVer)" >
             <Directory Id="RuntimesFolder" Name="runtimes" >
               <Directory Id="WinFolder" Name="win" >
                 <Directory Id="LibFolder" Name="lib" >

--- a/src/CLI_Installer/Product.wxs
+++ b/src/CLI_Installer/Product.wxs
@@ -20,13 +20,13 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <Property Id="NETCORERUNTIMEFOUNDX86">
       <DirectorySearch Id="NetCoreDirectoryFoundx86" Path="[ProgramFilesFolder]dotnet" >
-        <FileSearch Name="dotnet.exe" MinVersion="3.0"/>
+        <FileSearch Name="dotnet.exe" MinVersion="3.1"/>
       </DirectorySearch>
     </Property>
 
     <Property Id="NETCORERUNTIMEFOUNDX64">
       <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="[ProgramFiles64Folder]dotnet" >
-        <FileSearch Name="dotnet.exe" MinVersion="3.0"/>
+        <FileSearch Name="dotnet.exe" MinVersion="3.1"/>
       </DirectorySearch>
     </Property>
 
@@ -34,13 +34,10 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <Feature Id="ProductFeature" Title="Axe.Windows CLI" Level="1">
       <ComponentGroupRef Id="ProductComponents" />
-      <ComponentGroupRef Id="NetCoreApp20Components" />
-      <ComponentGroupRef Id="NetCoreApp21Components" />
       <ComponentGroupRef Id="NetCoreApp30Components" />
-      <ComponentGroupRef Id="NetStandard20Components" />
     </Feature>
 
-    <Condition Message="[ProductName] requires .NET Core Runtime 3.0 or newer. Please visit https://dotnet.microsoft.com/download/dotnet-core">
+    <Condition Message="[ProductName] requires .NET Core Runtime 3.1 or newer. Please visit https://dotnet.microsoft.com/download/dotnet-core">
       <![CDATA[Installed OR NETCORERUNTIMEFOUNDX64 OR NETCORERUNTIMEFOUNDX86]]>
     </Condition>
 
@@ -51,10 +48,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
             <Directory Id="RuntimesFolder" Name="runtimes" >
               <Directory Id="WinFolder" Name="win" >
                 <Directory Id="LibFolder" Name="lib" >
-                  <Directory Id="NetCoreApp20Folder" Name="netcoreapp2.0" />
-                  <Directory Id="NetCoreApp21Folder" Name="netcoreapp2.1" />
                   <Directory Id="NetCoreApp30Folder" Name="netcoreapp3.0" />
-                  <Directory Id="NetStandard20Folder" Name="netstandard2.0" />
                 </Directory>
               </Directory>
             </Directory>
@@ -65,54 +59,33 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
       <Component Id="ProductComponent" Guid="548A9965-21AD-4CDF-99AD-A6F2A47D0AE8">
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\AxeWindowsCLI.exe" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\AxeWindowsCLI.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\AxeWindowsCLI.deps.json" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\AxeWindowsCLI.runtimeconfig.json" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\Axe.Windows.Actions.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\Axe.Windows.Automation.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\Axe.Windows.Core.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\Axe.Windows.Desktop.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\Axe.Windows.Rules.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\Axe.Windows.RuleSelection.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\Axe.Windows.SystemAbstractions.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\Axe.Windows.Telemetry.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\Axe.Windows.Win32.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\CommandLine.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\Microsoft.Win32.Registry.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\Microsoft.Win32.SystemEvents.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\Newtonsoft.Json.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\System.Drawing.Common.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\System.IO.Packaging.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\System.Security.AccessControl.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\System.Security.Principal.Windows.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\thirdpartynotices.html" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\README.MD" />
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="NetCoreApp20Components" Directory="NetCoreApp20Folder">
-      <Component Id="NetCoreApp20Component" Guid="EEECBA82-5E46-46DD-9508-B15C4AA47383">
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\runtimes\win\lib\netcoreapp2.0\System.Security.AccessControl.dll" Id="core20_accesscontrol" />
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="NetCoreApp21Components" Directory="NetCoreApp21Folder">
-      <Component Id="NetCoreApp21Component" Guid="9CD7CCD2-F6DF-4451-978E-020476EFBDD7">
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\runtimes\win\lib\netcoreapp2.1\System.Security.Principal.Windows.dll" Id="core21_securityprincipal" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\AxeWindowsCLI.exe" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\AxeWindowsCLI.dll" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\AxeWindowsCLI.deps.json" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\AxeWindowsCLI.runtimeconfig.json" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.Actions.dll" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.Automation.dll" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.Core.dll" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.Desktop.dll" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.Rules.dll" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.RuleSelection.dll" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.SystemAbstractions.dll" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.Telemetry.dll" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.Win32.dll" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\CommandLine.dll" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\Microsoft.Win32.SystemEvents.dll" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\Newtonsoft.Json.dll" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\System.Drawing.Common.dll" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\System.IO.Packaging.dll" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\thirdpartynotices.html" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\README.MD" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="NetCoreApp30Components" Directory="NetCoreApp30Folder">
       <Component Id="NetCoreApp30Component" Guid="1D2C21D8-E43C-45F6-8530-B59CA4BAF9A6">
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\runtimes\win\lib\netcoreapp3.0\Microsoft.Win32.SystemEvents.dll" Id="core30_systemevents" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\runtimes\win\lib\netcoreapp3.0\System.Drawing.Common.dll" Id="core30_drawingcommon" />
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="NetStandard20Components" Directory="NetStandard20Folder">
-      <Component Id="NetStandard20Component" Guid="3C60E6DF-ED96-4071-BD25-0FBB9ECE15DF">
-        <File Source="..\CLI\bin\Release\netcoreapp3.0\runtimes\win\lib\netstandard2.0\Microsoft.Win32.Registry.dll" Id="standard20_registry" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\runtimes\win\lib\netcoreapp3.0\Microsoft.Win32.SystemEvents.dll" Id="core30_systemevents" />
+        <File Source="..\CLI\bin\Release\netcoreapp3.1\runtimes\win\lib\netcoreapp3.0\System.Drawing.Common.dll" Id="core30_drawingcommon" />
       </Component>
     </ComponentGroup>
 

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/DesktopTests/DesktopTests.csproj
+++ b/src/DesktopTests/DesktopTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/OldFileVersionCompatibilityTests/OldFileVersionCompatibilityTests.csproj
+++ b/src/OldFileVersionCompatibilityTests/OldFileVersionCompatibilityTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/RuleSelectionTests/RuleSelectionTests.csproj
+++ b/src/RuleSelectionTests/RuleSelectionTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/RulesTest/RulesTests.csproj
+++ b/src/RulesTest/RulesTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
+++ b/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/TelemetryTests/TelemetryTests.csproj
+++ b/src/TelemetryTests/TelemetryTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Win32Tests/Win32Tests.csproj
+++ b/src/Win32Tests/Win32Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
#### Describe the change

According to https://dotnet.microsoft.com/platform/support/policy/dotnet-core, .NET Core 3.1 is the LTS version, and .NET Core 3.0 (which we use for tests and CLI) isn't officially supported anymore. We originally had to use .NET Core because note all build environments supported .NET Core 3.1. That has now been fixed, so this upgrades us to .NET Core 3.1 for tests and the CLI. The CLI installer had to be modified to use an updated version check and to reflect the fact that the set of created files are slightly different (no more `netcoreapp20`, `netcoreapp21` or `netstandard20` runtime folders, and we ship fewer assemblies because we leverage the versions in the runtime.

Testing included signed builds, installing the CLI MSI, validating the install location, validating that apps can be tested, and that the resulting a11ytest file loads successfully into AIWin

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
