### PR TITLE
Remove hardcoded calls to System.Diagnostics.Debugger.Break

### DIFF
--- a/src/Core/Misc/ExtensionMethods.cs
+++ b/src/Core/Misc/ExtensionMethods.cs
@@ -420,11 +420,7 @@ namespace Axe.Windows.Core.Misc
                 }
                 else if (HasTestResults(tss, ScanStatus.NoResult))
                 {
-                    // it means that there was no rule executed or 
-                    if (System.Diagnostics.Debugger.IsAttached)
-                    {
-                         System.Diagnostics.Debugger.Break();
-                    }
+                    return ScanStatus.NoResult;
                 }
 
                 return ScanStatus.Pass;

--- a/src/Core/Misc/ExtensionMethods.cs
+++ b/src/Core/Misc/ExtensionMethods.cs
@@ -418,10 +418,6 @@ namespace Axe.Windows.Core.Misc
                 {
                     return ScanStatus.Uncertain;
                 }
-                else if (HasTestResults(tss, ScanStatus.NoResult))
-                {
-                    return ScanStatus.NoResult;
-                }
 
                 return ScanStatus.Pass;
             }

--- a/src/Desktop/UIAutomation/DesktopElement.cs
+++ b/src/Desktop/UIAutomation/DesktopElement.cs
@@ -151,10 +151,6 @@ namespace Axe.Windows.Desktop.UIAutomation
             catch (Exception e)
             {
                 e.ReportException();
-                if (System.Diagnostics.Debugger.IsAttached)
-                {
-                    System.Diagnostics.Debugger.Break();
-                }
             }
 #pragma warning restore CA1031 // Do not catch general exception types
         }

--- a/src/RuleSelection/RuleRunner.cs
+++ b/src/RuleSelection/RuleRunner.cs
@@ -27,11 +27,6 @@ namespace Axe.Windows.RuleSelection
             catch (Exception ex)
             {
                 ex.ReportException();
-                if (System.Diagnostics.Debugger.IsAttached)
-                {
-                    System.Diagnostics.Debug.WriteLine(ex.ToString());
-                    System.Diagnostics.Debugger.Break();
-                }
             }
 #pragma warning restore CA1031 // Do not catch general exception types
         }

--- a/src/Rules/Conditions/Condition.cs
+++ b/src/Rules/Conditions/Condition.cs
@@ -74,5 +74,8 @@ namespace Axe.Windows.Rules
 
         public static Condition True = Create(e => true, ConditionDescriptions.True);
         public static Condition False = Create(e => false, ConditionDescriptions.False);
+#if DEBUG
+        public static Condition DebugBreak = Create(e => { System.Diagnostics.Debugger.Break(); return true; });
+#endif
     } // class
 } // namespace

--- a/src/Rules/Conditions/Condition.cs
+++ b/src/Rules/Conditions/Condition.cs
@@ -74,6 +74,5 @@ namespace Axe.Windows.Rules
 
         public static Condition True = Create(e => true, ConditionDescriptions.True);
         public static Condition False = Create(e => false, ConditionDescriptions.False);
-        public static Condition DebugBreak = Create(e => { System.Diagnostics.Debugger.Break(); return true; });
     } // class
 } // namespace

--- a/src/RulesTest/MonsterTest.cs
+++ b/src/RulesTest/MonsterTest.cs
@@ -4,7 +4,6 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.UnitTestSharedLibrary;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -1020,16 +1019,6 @@ namespace Axe.Windows.RulesTest
         {
             var results = Axe.Windows.Rules.Rules.RunAll(e);
             return results.ToDictionary(r => r.RuleInfo.ID, r => r.EvaluationCode);
-        }
-
-        private static void WriteResultsToDebugOutput(Dictionary<RuleId, EvaluationCode> results)
-        {
-            System.Diagnostics.Debug.WriteLine("{");
-
-            foreach (var key in results.Keys.OrderBy(k => k.ToString()))
-                System.Diagnostics.Debug.WriteLine($"Assert.AreEqual(EvaluationCode.{results[key]}, results[RuleId.{key}]);");
-
-            System.Diagnostics.Debug.WriteLine("}");
         }
     } // class
 } // namespace

--- a/src/RulesTest/MonsterTest.cs
+++ b/src/RulesTest/MonsterTest.cs
@@ -1020,5 +1020,15 @@ namespace Axe.Windows.RulesTest
             var results = Axe.Windows.Rules.Rules.RunAll(e);
             return results.ToDictionary(r => r.RuleInfo.ID, r => r.EvaluationCode);
         }
+
+        private static void WriteResultsToDebugOutput(Dictionary<RuleId, EvaluationCode> results)
+        {
+            System.Diagnostics.Debug.WriteLine("{");
+
+            foreach (var key in results.Keys.OrderBy(k => k.ToString()))
+                System.Diagnostics.Debug.WriteLine($"Assert.AreEqual(EvaluationCode.{results[key]}, results[RuleId.{key}]);");
+
+            System.Diagnostics.Debug.WriteLine("}");
+        }
     } // class
 } // namespace


### PR DESCRIPTION
#### Describe the change

There are 5 places in the code where Axe.Windows is hardcoded to call Debugger.Break. These were added to provide a way to catch unexpected scenarios in Axe.Windows, but they are a real nuisance when trying to debug an app that consumes Axe.Windows (and where the exceptions aren't really that interesting). Of the 5 places where Debugger.Break was called:
- 2 were in unused methods
- 2 were in a block where an exception is reported (which means that the exception will be detectable in telemetry)
- 1 was in a scenario that telemetry suggested never occurred

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
