### PR TITLE
Fix Issue #352 False-negative result for the rule "An element's IsOffScreen property must be false when its clickable point is on screen."

### DIFF
--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -16,7 +16,7 @@ namespace Axe.Windows.AutomationTests
     public class AutomationIntegrationTests
     {
         // These values should change only in response to intentional rule modifications
-        const int WildlifeManagerKnownErrorCount = 13;
+        const int WildlifeManagerKnownErrorCount = 12;
         const int Win32ControlSamplerKnownErrorCount = 0;
         const int WindowsFormsControlSamplerKnownErrorCount = 6;
         const int WpfControlSamplerKnownErrorCount = 5;

--- a/src/Rules/Library/ClickablePointOnScreen.cs
+++ b/src/Rules/Library/ClickablePointOnScreen.cs
@@ -30,7 +30,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return ClickablePoint.OnScreen;
+            return IsKeyboardFocusable & ClickablePoint.OnScreen;
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/ClickablePointOnScreen.cs
+++ b/src/RulesTest/Library/ClickablePointOnScreen.cs
@@ -49,9 +49,10 @@ namespace Axe.Windows.RulesTest.Library
         }
 
         [TestMethod]
-        public void ClickablePointOnScreen_IsClickable_Matches()
+        public void ClickablePointOnScreen_FocusableClickable_Matches()
         {
             SetupTryGetProperty(new Point(100, 100));
+            mockElement.Setup(m => m.IsKeyboardFocusable).Returns(true);
             Assert.IsTrue(Rule.Condition.Matches(mockElement.Object));
             mockElement.VerifyAll();
         }
@@ -60,6 +61,15 @@ namespace Axe.Windows.RulesTest.Library
         public void ClickablePointOnScreen_IsNotClickable_NoMatch()
         {
             SetupTryGetProperty(new Point(-100, -100));
+            mockElement.Setup(m => m.IsKeyboardFocusable).Returns(true);
+            Assert.IsFalse(Rule.Condition.Matches(mockElement.Object));
+            mockElement.VerifyAll();
+        }
+
+        [TestMethod]
+        public void ClickablePointOnScreen_IsNotFocusable_NoMatch()
+        {
+            mockElement.Setup(m => m.IsKeyboardFocusable).Returns(false);
             Assert.IsFalse(Rule.Condition.Matches(mockElement.Object));
             mockElement.VerifyAll();
         }


### PR DESCRIPTION
#### Describe the change

Fix #352

The rule is meant to ensure element's with valid clickable points are marked as on screen so that ATs can recognize those elements as clickable. In the case given in the bug, the button has a valid clickable point and is not off screen (according to UIA), which is an error. However, the element is also not focusable, which means it cannot be focused or (theoretically) invoked. In this case, the button does not actually appear on screen.

When the element is not keyboard focusable, the rules cannot determine if the element's IsOffScreen property is correct or not. Therefore, the rule will not be run when the element is not keyboard focusable.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
