### PR TITLE
Change the default order in which event handlers are registered

### DIFF
--- a/src/Actions/Actions/ListenAction.cs
+++ b/src/Actions/Actions/ListenAction.cs
@@ -46,11 +46,20 @@ namespace Axe.Windows.Actions
         /// <summary>
         /// Start recording events
         /// </summary>
-        public void Start(IEnumerable<int> eventIDs, IEnumerable<int> propertyIDs)
+        public void Start(IEnumerable<int> eventIDs, IEnumerable<int> propertyIDs, EventRegistrationOrder registrationOrder = EventRegistrationOrder.PropertyEventsFirst)
         {
             this.IsRunning = true;
-            InitIndividualEventListeners(eventIDs);
+
+            if (registrationOrder == EventRegistrationOrder.PropertyEventsLast)
+            {
+                InitIndividualEventListeners(eventIDs);
+                InitPropertyChangeListener(propertyIDs);
+                return;
+            }
+
+            // default is to register for property events first
             InitPropertyChangeListener(propertyIDs);
+            InitIndividualEventListeners(eventIDs);
         }
 
         /// <summary>

--- a/src/Actions/Enums/Enums.cs
+++ b/src/Actions/Enums/Enums.cs
@@ -59,4 +59,18 @@ namespace Axe.Windows.Actions.Enums
         Paused,
         Resumed
     }
+
+    /// <summary>
+    /// Controls the order in which event handlers are registered.
+
+    /// </summary>
+    /// <remarks>
+    /// In some cases, registering for property change events after other types of events
+    /// causes some property change events not to be received.
+    /// </remarks>
+    public enum EventRegistrationOrder
+    {
+        PropertyEventsFirst,
+        PropertyEventsLast,
+    }
 }


### PR DESCRIPTION
#### Describe the change

Changing the order in which event handlers are registered addresses [Accessibility Insights for Windows bug #694](https://github.com/microsoft/accessibility-insights-windows/issues/694). However, because the results of changing the registration order may have as yet unknown side-effects, we are making the ordering of event registration configurable via the EventRegistrationOrder enumeration.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
