### PR TITLE
Add FXCopAnalyzers to production projects

### DIFF
--- a/src/Actions/Actions.csproj
+++ b/src/Actions/Actions.csproj
@@ -14,6 +14,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.BinSkim" Version="1.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Actions/Actions/SelectAction.cs
+++ b/src/Actions/Actions/SelectAction.cs
@@ -67,7 +67,7 @@ namespace Axe.Windows.Actions
         // Backing object for POIElementContext - is disposed via POIElementContext property
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "_POIElementContext")]
         ElementContext _POIElementContext = null;
-        private readonly Object _elementContextLock = new object();
+        private readonly object _elementContextLock = new object();
 
         /// <summary>
         /// Element Context of Point of Interest(a.k.a. selected)

--- a/src/Actions/Actions/SelectAction.cs
+++ b/src/Actions/Actions/SelectAction.cs
@@ -67,6 +67,7 @@ namespace Axe.Windows.Actions
         // Backing object for POIElementContext - is disposed via POIElementContext property
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "_POIElementContext")]
         ElementContext _POIElementContext = null;
+        private readonly Object _elementContextLock = new object();
 
         /// <summary>
         /// Element Context of Point of Interest(a.k.a. selected)
@@ -181,7 +182,7 @@ namespace Axe.Windows.Actions
         /// <param name="el"></param>
         public void SetCandidateElement(A11yElement el)
         {
-            lock (this)
+            lock (_elementContextLock)
             {
                 if (el != null)
                 {
@@ -236,7 +237,7 @@ namespace Axe.Windows.Actions
         /// <param name="handle"></param>
         public void SetCandidateElementFromHandle(IntPtr handle)
         {
-            lock (this)
+            lock (_elementContextLock)
             {
                 var element = A11yAutomation.ElementFromHandle(handle);
                 this.CandidateEC?.Dispose();
@@ -250,7 +251,7 @@ namespace Axe.Windows.Actions
         /// <returns>true when there is new selection</returns>
         public bool Select()
         {
-            lock(this)
+            lock(_elementContextLock)
             {
                 if(CandidateEC != null && ( POIElementContext == null || POIElementContext.Element.IsSameUIElement(CandidateEC.Element) == false))
                 {
@@ -295,7 +296,7 @@ namespace Axe.Windows.Actions
         /// <param name="ec"></param>
         void SetSelectedContextWithLoadedData(ElementContext ec)
         {
-            lock (this)
+            lock (_elementContextLock)
             {
                 POIElementContext?.Dispose();
                 CandidateEC?.Dispose();
@@ -311,7 +312,7 @@ namespace Axe.Windows.Actions
         {
             if (!this.IsPaused)
             {
-                lock (this)
+                lock (_elementContextLock)
                 {
                     POIElementContext = null;
                     CandidateEC?.Dispose();
@@ -329,7 +330,7 @@ namespace Axe.Windows.Actions
         /// <returns></returns>
         public Guid? GetSelectedElementContextId()
         {
-            lock (this)
+            lock (_elementContextLock)
             {
                 return POIElementContext != null ? POIElementContext.Id : (Guid?)null;
             }

--- a/src/Actions/AssemblyInfo.cs
+++ b/src/Actions/AssemblyInfo.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyProduct("Axe.Windows.Actions")]
 [assembly: AssemblyTitle("Axe.Windows.Actions")]
 [assembly: AssemblyCopyright("Copyright © 2020")]
+
+[assembly: NeutralResourcesLanguage("en-US")]
 
 #if ENABLE_SIGNING
 [assembly: InternalsVisibleTo("ActionsTests,PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]

--- a/src/Actions/Trackers/MouseTracker.cs
+++ b/src/Actions/Trackers/MouseTracker.cs
@@ -53,6 +53,7 @@ namespace Axe.Windows.Actions.Trackers
         /// Mouse timer
         /// </summary>
         Timer timerMouse = null;
+        private readonly object _elementSetterLock = new object();
 
         /// <summary>
         /// constructor
@@ -99,7 +100,7 @@ namespace Axe.Windows.Actions.Trackers
         /// <param name="e"></param>
         private void ontimerMouseElapsedEvent(object sender, ElapsedEventArgs e)
         {
-            lock (this)
+            lock (_elementSetterLock)
             {
                 if (this.timerMouse != null && this.IsStarted)
                 {

--- a/src/Actions/Trackers/TreeTracker.cs
+++ b/src/Actions/Trackers/TreeTracker.cs
@@ -22,7 +22,7 @@ namespace Axe.Windows.Actions.Trackers
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "SelectAction")]
         readonly SelectAction SelectAction = null;
         internal TreeViewMode TreeViewMode { get; set; } = TreeViewMode.Raw;
-        private readonly Object _movementLock = new object();
+        private readonly object _movementLock = new object();
 
         public TreeTracker(Action<A11yElement> action, SelectAction selectAction)
             : base(action)

--- a/src/Actions/Trackers/TreeTracker.cs
+++ b/src/Actions/Trackers/TreeTracker.cs
@@ -22,6 +22,7 @@ namespace Axe.Windows.Actions.Trackers
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "SelectAction")]
         readonly SelectAction SelectAction = null;
         internal TreeViewMode TreeViewMode { get; set; } = TreeViewMode.Raw;
+        private readonly Object _movementLock = new object();
 
         public TreeTracker(Action<A11yElement> action, SelectAction selectAction)
             : base(action)
@@ -108,7 +109,7 @@ namespace Axe.Windows.Actions.Trackers
         /// </param>
         private void MoveTo(GetElementDelegate getElementMethod)
         {
-            lock (this)
+            lock (_movementLock)
             {
                 _MoveTo(getElementMethod);
             }

--- a/src/Automation/AssemblyInfo.cs
+++ b/src/Automation/AssemblyInfo.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyProduct("Axe.Windows.Automation")]
 [assembly: AssemblyTitle("Axe.Windows.Automation")]
 [assembly: AssemblyCopyright("Copyright © 2020")]
+
+[assembly: NeutralResourcesLanguage("en-US")]
 
 #if ENABLE_SIGNING
 [assembly: InternalsVisibleTo("AutomationTests,PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]

--- a/src/Automation/Automation.csproj
+++ b/src/Automation/Automation.csproj
@@ -18,6 +18,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.BinSkim" Version="1.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Automation/OutputFileHelper.cs
+++ b/src/Automation/OutputFileHelper.cs
@@ -51,7 +51,7 @@ namespace Axe.Windows.Automation
         /// </summary>
         /// <param name="path"></param>
         /// <exception cref="AxeWindowsAutomationException"/>
-        private void VerifyPathOrThrow(string path)
+        private static void VerifyPathOrThrow(string path)
         {
             try
             {

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -31,7 +31,6 @@ namespace Axe.Windows.Automation
             scanTools.NativeMethods.SetProcessDPIAware();
 
             var rootElement = scanTools.TargetElementLocator.LocateRootElement(config.ProcessId);
-            if (rootElement == null) throw new InvalidOperationException(nameof(rootElement));
 
             return scanTools.Actions.Scan(rootElement, (element, elementId) =>
             {

--- a/src/AutomationTests/SnapshotCommandUnitTests.cs
+++ b/src/AutomationTests/SnapshotCommandUnitTests.cs
@@ -108,20 +108,20 @@ namespace Axe.Windows.AutomationTests
 
         [TestMethod]
         [Timeout(1000)]
-        public void Execute_TargetElementLocatorReturnsNull_ThrowsException()
+        public void Execute_TargetElementLocatorReturnsNull_PassesNullToScan()
         {
             _scanToolsMock.Setup(x => x.TargetElementLocator).Returns(_targetElementLocatorMock.Object);
             _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
             _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
 
             _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns<A11yElement>(null);
+            _actionsMock.Setup(x => x.Scan(null, It.IsNotNull<ScanActionCallback<ScanResults>>())).Returns<ScanResults>(null);
 
-            var action = new Action(() => SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object));
-            var ex = Assert.ThrowsException<InvalidOperationException>(action);
-            Assert.IsTrue(ex.Message.Contains("rootElement"));
+            SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object);
 
             _scanToolsMock.VerifyAll();
             _nativeMethodsMock.VerifyAll();
+            _actionsMock.VerifyAll();
             _targetElementLocatorMock.VerifyAll();
         }
 
@@ -136,15 +136,16 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
 
             _targetElementLocatorMock.Setup(x => x.LocateRootElement(expectedProcessId)).Returns<A11yElement>(null);
+            _actionsMock.Setup(x => x.Scan(null, It.IsNotNull<ScanActionCallback<ScanResults>>())).Returns<ScanResults>(null);
 
             var config = Config.Builder.ForProcessId(expectedProcessId).Build();
 
-            var action = new Action(() => SnapshotCommand.Execute(config, _scanToolsMock.Object));
-            Assert.ThrowsException<InvalidOperationException>(action);
+            SnapshotCommand.Execute(config, _scanToolsMock.Object);
 
             _scanToolsMock.VerifyAll();
             _nativeMethodsMock.VerifyAll();
             _targetElementLocatorMock.VerifyAll();
+            _actionsMock.VerifyAll();
         }
 
         [TestMethod]

--- a/src/CLI/CLI.csproj
+++ b/src/CLI/CLI.csproj
@@ -25,10 +25,6 @@
     <NoWarn>CA1303;$(NoWarn)</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702,CA1303</NoWarn>
-  </PropertyGroup>
-
   <Import Project="..\..\build\NetStandardRelease.targets" />
 
   <ItemGroup>

--- a/src/CLI/CLI.csproj
+++ b/src/CLI/CLI.csproj
@@ -19,7 +19,7 @@
     <AxeDigitalSign>true</AxeDigitalSign>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <PropertyGroup>
     <!-- Suppress the warning (CA1303) for string literals.
     this warning would only be useful if we decided to localize the project. -->
     <NoWarn>CA1303;$(NoWarn)</NoWarn>

--- a/src/CLI/CLI.csproj
+++ b/src/CLI/CLI.csproj
@@ -19,6 +19,16 @@
     <AxeDigitalSign>true</AxeDigitalSign>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <!-- Suppress the warning (CA1303) for string literals.
+    this warning would only be useful if we decided to localize the project. -->
+    <NoWarn>CA1303;$(NoWarn)</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702,CA1303</NoWarn>
+  </PropertyGroup>
+
   <Import Project="..\..\build\NetStandardRelease.targets" />
 
   <ItemGroup>
@@ -29,6 +39,10 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CLI/ParameterException.cs
+++ b/src/CLI/ParameterException.cs
@@ -16,5 +16,8 @@ namespace AxeWindowsCLI
             : this (message, null)
         {
         }
+
+        public ParameterException()
+        { }
     }
 }

--- a/src/CLI/ProcessHelper.cs
+++ b/src/CLI/ProcessHelper.cs
@@ -24,7 +24,9 @@ namespace AxeWindowsCLI
             {
                 processes = _processAbstraction.GetProcessesByName(processName);
             }
+#pragma warning disable CA1031
             catch (Exception e)
+#pragma warning restore CA1031
             {
                 caughtException = e;
             }
@@ -51,7 +53,9 @@ namespace AxeWindowsCLI
             {
                 process = _processAbstraction.GetProcessById(processId);
             }
+#pragma warning disable CA1031
             catch (Exception e)
+#pragma warning restore CA1031
             {
                 innerException = e;
             }

--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -53,10 +53,15 @@ namespace AxeWindowsCLI
             Exception caughtException = null;
             try
             {
-                CaseInsensitiveParser().ParseArguments<Options>(_args)
+                using (var parser = CaseInsensitiveParser())
+                {
+                parser.ParseArguments<Options>(_args)
                     .WithParsed<Options>(RunWithParsedInputs);
+                }
             }
+#pragma warning disable CA1031
             catch (Exception e)
+#pragma warning restore CA1031
             {
                 caughtException = e;
             }

--- a/src/Core/AssemblyInfo.cs
+++ b/src/Core/AssemblyInfo.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyProduct("Axe.Windows.Core")]
 [assembly: AssemblyTitle("Axe.Windows.Core")]
 [assembly: AssemblyCopyright("Copyright © 2020")]
+
+[assembly:NeutralResourcesLanguage("en-US")]
 
 #if ENABLE_SIGNING
 [assembly: InternalsVisibleTo("Axe.Windows.Actions,PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -14,6 +14,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.BinSkim" Version="1.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.0.0">

--- a/src/Core/Results/ScanResults.cs
+++ b/src/Core/Results/ScanResults.cs
@@ -13,6 +13,8 @@ namespace Axe.Windows.Core.Results
     /// </summary>
     public class ScanResults
     {
+        private readonly object _itemsLock = new object();
+
         /// <summary>
         /// Items with ScanResult
         /// </summary>
@@ -46,7 +48,7 @@ namespace Axe.Windows.Core.Results
         /// <param name="report"></param>
         public void AddScanResult(ScanResult report)
         {
-            lock (this)
+            lock (_itemsLock)
             {
                 this.Items.Add(report);
             }

--- a/src/Desktop/AssemblyInfo.cs
+++ b/src/Desktop/AssemblyInfo.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyProduct("Axe.Windows.Desktop")]
 [assembly: AssemblyTitle("Axe.Windows.Desktop")]
 [assembly: AssemblyCopyright("Copyright © 2020")]
+
+[assembly: NeutralResourcesLanguage("en-US")]
 
 #if ENABLE_SIGNING
 [assembly: InternalsVisibleTo("DesktopTests,PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]

--- a/src/Desktop/Desktop.csproj
+++ b/src/Desktop/Desktop.csproj
@@ -14,6 +14,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.BinSkim" Version="1.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/RuleSelection/AssemblyInfo.cs
+++ b/src/RuleSelection/AssemblyInfo.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyProduct("Axe.Windows.RuleSelection")]
 [assembly: AssemblyTitle("Axe.Windows.RuleSelection")]
 [assembly: AssemblyCopyright("Copyright © 2020")]
+
+[assembly: NeutralResourcesLanguage("en-US")]
 
 #if ENABLE_SIGNING
 [assembly: InternalsVisibleTo("RuleSelectionTests,PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]

--- a/src/RuleSelection/RuleSelection.csproj
+++ b/src/RuleSelection/RuleSelection.csproj
@@ -14,6 +14,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.BinSkim" Version="1.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Rules/AssemblyInfo.cs
+++ b/src/Rules/AssemblyInfo.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyProduct("Axe.Windows.Rules")]
 [assembly: AssemblyTitle("Axe.Windows.Rules")]
 [assembly: AssemblyCopyright("Copyright © 2020")]
+
+[assembly: NeutralResourcesLanguage("en-US")]
 
 #if ENABLE_SIGNING
 [assembly: InternalsVisibleTo("RulesTests,PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]

--- a/src/Rules/Library/LocalizedControlTypeIsReasonable.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsReasonable.cs
@@ -29,7 +29,7 @@ namespace Axe.Windows.Rules.Library
             return HasReasonableLocalizedControlType(e) ? EvaluationCode.Pass : EvaluationCode.Warning;
         }
 
-        private bool HasReasonableLocalizedControlType(IA11yElement e)
+        private static bool HasReasonableLocalizedControlType(IA11yElement e)
         {
             var names = GetExpectedLocalizedControlTypeNames(e.ControlTypeId);
 

--- a/src/Rules/Rules.csproj
+++ b/src/Rules/Rules.csproj
@@ -14,6 +14,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.BinSkim" Version="1.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SystemAbstractions/SystemAbstractions.csproj
+++ b/src/SystemAbstractions/SystemAbstractions.csproj
@@ -14,6 +14,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.BinSkim" Version="1.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Telemetry/Telemetry.csproj
+++ b/src/Telemetry/Telemetry.csproj
@@ -14,6 +14,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.BinSkim" Version="1.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
#### Describe the change

The FSCopAnaalyzers were meant to be used in all our production projects, but through some error they were not. The change adds them to production projects and fixes the errors found by the analyzers.

Most errors were of the following types:

- Weak reference in lock
- Methods could be static
- Should catch more specific exception

There is one case where an error check which threw an exception was removed in SnapshotCommand.Execute. This is okay because the call to Scan will immediately check the nullity of the returned value which used to be checked.

The warning CA1303 was suppressed throughout the entirety of the CLI project. The warning flags quoted strings. We have chosen to suppress the warning because the work to address it would only be useful if we planned to localize the project, which we currently do not.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
