### PR TITLE
Enable authenticode signing with 3rd party cert

### DIFF
--- a/build/settings.targets
+++ b/build/settings.targets
@@ -19,6 +19,7 @@
         <Otherwise>
           <ItemGroup>
             <FilesToSign Include="@(DropSignedFile)">
+              <Authenticode>3PartySHA2</Authenticode>
               <StrongName>StrongName</StrongName>
             </FilesToSign>
           </ItemGroup>


### PR DESCRIPTION
Currently, we do not digitally sign axe-windows assemblies. This PR enables digital signing for its assemblies using the proper Microsoft 3rd party cert. [Successful signed build here](https://dev.azure.com/mseng/1ES/_build/results?buildId=12530233&view=results).

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
