### PR TITLE
Reenable nuget signing

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -190,7 +190,7 @@ jobs:
   pool: VSEng-MicroBuildVS2019
   variables:
     PublicRelease: 'true'
-    MicroBuild_NuPkgSigningEnabled: 'false'
+    MicroBuild_NuPkgSigningEnabled: 'true'
     SignAppForRelease: 'true'
     runCodesignValidationInjection: 'true'
   steps:


### PR DESCRIPTION
#### Describe the change

A previous PR (#83) disabled signing our nuget package. Because our guidance has change, we now want to sign the package. This PR reenables signing of the package. You can find a signed build output [here](https://dev.azure.com/mseng/1ES/_build/results?buildId=12548401&view=results).

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
