### PR TITLE
Update a netcore3.0 comment that was overlooked

### DIFF
--- a/tools/scripts/BuildZippedCLI.ps1
+++ b/tools/scripts/BuildZippedCLI.ps1
@@ -15,7 +15,7 @@ The directory where the full install config was built
 The directory where the .zip file will be dropped. Don't put this under SrcDir or the zip file will be "nested" in subsequent runs
 
 .Example Usage
-.\BuildZippedCLI.ps1 -Configuration release -SrcDir c:\myrepo\src\CLI_Full\bin\release\netcoreapp3.0\win7-x86 -TargetDir c:\myrepo\src\CLI_Installer\bin\release
+.\BuildZippedCLI.ps1 -Configuration release -SrcDir c:\myrepo\src\CLI_Full\bin\release\netcoreapp3.1\win7-x86 -TargetDir c:\myrepo\src\CLI_Installer\bin\release
 #>
 
 param(


### PR DESCRIPTION
#### Describe the change
This just updates the usage comment in a script. We changed from .NET core 3.0 to .NET core 3.1 but missed this.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
