### PR TITLE
Fix #285 Add .Net Framework tests in addition to .Net Core tests

### DIFF
--- a/build/NetStandardTest.targets
+++ b/build/NetStandardTest.targets
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-        <IsPackable>false</IsPackable>
-<NoWarn>1701;1702;CA1707</NoWarn>
+    <IsPackable>false</IsPackable>
+    <NoWarn>1701;1702;CA1707</NoWarn>
   </PropertyGroup>
 
   <Import Project=".\NetStandardAll.targets" />

--- a/build/NetStandardTest.targets
+++ b/build/NetStandardTest.targets
@@ -1,7 +1,13 @@
 ﻿<Project>
 
+  <!-- The following condition should be true for almost all test projects -->
+  <PropertyGroup Condition="$(TargetFramework) == '' AND $(TargetFrameworks) == ''">
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+  </PropertyGroup>
+
   <PropertyGroup>
-    <NoWarn>1701;1702;CA1707</NoWarn>
+        <IsPackable>false</IsPackable>
+<NoWarn>1701;1702;CA1707</NoWarn>
   </PropertyGroup>
 
   <Import Project=".\NetStandardAll.targets" />

--- a/src/ActionsTests/ActionsTests.csproj
+++ b/src/ActionsTests/ActionsTests.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.0" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/src/AutomationTests/AutomationTests.csproj
+++ b/src/AutomationTests/AutomationTests.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.0" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/src/CLITests/CLITests.csproj
+++ b/src/CLITests/CLITests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.0" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/src/DesktopTests/DesktopTests.csproj
+++ b/src/DesktopTests/DesktopTests.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
   <ItemGroup>
     <None Remove="TestImages\cortana_with_offset_down.bmp" />
     <None Remove="TestImages\cortana_with_offset_up.bmp" />

--- a/src/OldFileVersionCompatibilityTests/OldFileVersionCompatibilityTests.csproj
+++ b/src/OldFileVersionCompatibilityTests/OldFileVersionCompatibilityTests.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.0" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/src/RuleSelectionTests/RuleSelectionTests.csproj
+++ b/src/RuleSelectionTests/RuleSelectionTests.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.0" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/src/RulesTest/RulesTests.csproj
+++ b/src/RulesTest/RulesTests.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.0" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
+++ b/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.0" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/src/TelemetryTests/TelemetryTests.csproj
+++ b/src/TelemetryTests/TelemetryTests.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.0" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/src/Win32Tests/Win32Tests.csproj
+++ b/src/Win32Tests/Win32Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.0" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Win32Tests/Win32Tests.csproj
+++ b/src/Win32Tests/Win32Tests.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
-  <ItemGroup>
+    <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.0" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
#### Describe the change

Using .Net Framework 4.72 because that is what Accessibility Insights for Windows uses.

Moved target frameworks property to a common .target file where it can easily be reused. The condition in the .target file is needed because CLITests references CLI, which is built for the .Net Core Framework and not .Net Standard (So .Net Framework is not compatible with CLI).


<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
