### PR TITLE
Set Codesign Validation scan directory when creating zip

### DIFF
--- a/tools/scripts/BuildZippedCLI.ps1
+++ b/tools/scripts/BuildZippedCLI.ps1
@@ -38,7 +38,13 @@ function Get-UniqueTempFolder([string] $app){
     $uniqueName=$app + '_' + $guid
     $tempFolder=Join-Path $env:temp $uniqueName
 	New-Item -Path $tempFolder -ItemType Directory
+    Set-CodeSignValidationDirectory $tempFolder
     return $tempFolder
+}
+
+function Set-CodeSignValidationDirectory([string] $dir){
+    Write-Verbose "Setting ADO job variable GDN_CODESIGN_TARGETDIRECTORY to $dir"
+    Write-Host "##vso[task.setvariable variable=GDN_CODESIGN_TARGETDIRECTORY]$dir"
 }
 
 function Copy-Files([string]$src, [string]$pattern, [string]$dst) {
@@ -95,8 +101,6 @@ function Create-Zipfile([string]$srcDir, [string]$otherSignedSrcDir, [string]$ap
     Prepare-Zipfile $srcDir $otherSignedSrcDir $scratch $patternsToRemove $otherSignedAssemblies
 
     Create-Archive $scratch $zipFile
-
-    Remove-Item $scratch -Force -Recurse
 }
 
 function CreateCLIZip([string]$srcDir, [string]$otherSignedSrcDir, [string]$targetDir, [string]$zipFileName){


### PR DESCRIPTION
#### Describe the change
Currently, the auto injected Codesign Validation task scans our entire project for signing violations. Since we only ship specific 
assemblies, this leads to hundreds of false positives. A build variable is available to set the root directory that the task scans. This PR sets that variable to the temp directory we create while making our zipped CLI package. This package contains a superset of all the assemblies that we ship (MSI, zip, and Nuget package), so it seems like a good choice for where to direct the Codesign Validation task--I'm open to other suggestions for where to scan, though. You can find an example of the impact on the build task [here](https://dev.azure.com/mseng/1ES/_build/results?buildId=12617518&view=logs&j=7c3ebc89-e7dd-5791-8c02-2ea1f3a27b50&t=95036218-ae8d-5d14-6fa9-97adee74970f) (different branch, same variable setting).

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
