### PR TITLE
Update codesign validation

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -193,6 +193,7 @@ jobs:
     MicroBuild_NuPkgSigningEnabled: 'true'
     SignAppForRelease: 'true'
     runCodesignValidationInjection: 'true'
+    GDN_CODESIGN_TARGETDIRECTORY: '$(Build.ArtifactStagingDirectory)\SigningValidation'
   steps:
   - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
     displayName: 'Install Localization Plugin'
@@ -318,6 +319,22 @@ jobs:
     inputs:
       PathtoPublish: 'src\CLI_Installer\bin\Release\AxeWindowsCLI.zip'
       ArtifactName: 'CLI-zip'
+
+  - task: CopyFiles@2
+    displayName: 'Copy CLI_Full Files for Signing Validation'
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)\src'
+      Contents: |
+       CLI_Full\bin\release\netcoreapp3.1\win7-x86\?(*.exe|*.dll)
+       !CLI_Full\bin\release\netcoreapp3.1\win7-x86\?(CommandLine.dll|Newtonsoft.Json.dll)
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\SigningValidation'
+
+  - task: CopyFiles@2
+    displayName: 'Copy CLI Files for Signing Validation'
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)\src'
+      Contents: 'CLI\bin\release\netcoreapp3.1\**\?(*.exe|*.dll)'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\SigningValidation'
 
   - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
     displayName: 'Perform Cleanup Tasks'

--- a/tools/scripts/BuildZippedCLI.ps1
+++ b/tools/scripts/BuildZippedCLI.ps1
@@ -38,13 +38,7 @@ function Get-UniqueTempFolder([string] $app){
     $uniqueName=$app + '_' + $guid
     $tempFolder=Join-Path $env:temp $uniqueName
 	New-Item -Path $tempFolder -ItemType Directory
-    Set-CodeSignValidationDirectory $tempFolder
     return $tempFolder
-}
-
-function Set-CodeSignValidationDirectory([string] $dir){
-    Write-Verbose "Setting ADO job variable GDN_CODESIGN_TARGETDIRECTORY to $dir"
-    Write-Host "##vso[task.setvariable variable=GDN_CODESIGN_TARGETDIRECTORY]$dir"
 }
 
 function Copy-Files([string]$src, [string]$pattern, [string]$dst) {
@@ -101,6 +95,8 @@ function Create-Zipfile([string]$srcDir, [string]$otherSignedSrcDir, [string]$ap
     Prepare-Zipfile $srcDir $otherSignedSrcDir $scratch $patternsToRemove $otherSignedAssemblies
 
     Create-Archive $scratch $zipFile
+
+    Remove-Item $scratch -Force -Recurse
 }
 
 function CreateCLIZip([string]$srcDir, [string]$otherSignedSrcDir, [string]$targetDir, [string]$zipFileName){


### PR DESCRIPTION
#### Describe the change
This PR replaces the work in PR #398 to validate CLI and CLI_Full's assemblies rather than just CLI_Full's. This ensures complete codesign validation coverage. An example run can be found [here](https://dev.azure.com/mseng/1ES/_build/results?buildId=12624793&view=results).

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
