### PR TITLE
Set an ADO variable for the CodeCov version

### DIFF
--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -111,7 +111,7 @@ jobs:
   - task: CmdLine@2
     displayName: 'Upload coverage to codecov.io'
     inputs:
-      script: $(USERPROFILE)\.nuget\packages\codecov\1.12.1\tools\win7-x86\codecov.exe -t $(CODECOV_TOKEN) -f **/*coverage.cobertura.xml
+      script: $(USERPROFILE)\.nuget\packages\codecov\$(CODECOV_VERSION)\tools\win7-x86\codecov.exe -t $(CODECOV_TOKEN) -f **/*coverage.cobertura.xml
     #workingDirectory: # Optional
     #failOnStderr: false # Optional
     

--- a/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
+++ b/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
@@ -18,4 +18,18 @@
 
   <Import Project="..\..\build\NetStandardTest.targets" />
 
+  <Target Name="SetADOVariableToPackageVersion" BeforeTargets="BeforeBuild">
+    <!-- This target could be placed in any project which references the CodeCov package -->
+    
+    <ItemGroup>
+      <ReferenceToCodeCovPackage Include="@(PackageReference)"
+                                 Condition="'%(Identity)' == 'Codecov'" />
+    </ItemGroup>
+
+    <Error Condition="'@(ReferenceToCodeCovPackage->Count())' != '1'"  />
+
+    <Message Importance="high"
+             Text="##vso[task.setvariable variable=CODECOV_VERSION]%(ReferenceToCodeCovPackage.Version)" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
#### Describe the change

This will make it possible for dependabot to update the version of CodeCov without an engineer having to manually change the version used in prbuild.yml.


<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
