### PR TITLE
Fix a problem where Visual Studio could not load NuGet packages

### DIFF
--- a/build/NetStandardTest.targets
+++ b/build/NetStandardTest.targets
@@ -1,10 +1,5 @@
 ﻿<Project>
 
-  <!-- The following condition should be true for almost all test projects -->
-  <PropertyGroup Condition="$(TargetFramework) == '' AND $(TargetFrameworks) == ''">
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
-  </PropertyGroup>
-
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <NoWarn>1701;1702;CA1707</NoWarn>

--- a/src/ActionsTests/ActionsTests.csproj
+++ b/src/ActionsTests/ActionsTests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.1" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/src/AutomationTests/AutomationTests.csproj
+++ b/src/AutomationTests/AutomationTests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.1" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.1" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/src/DesktopTests/DesktopTests.csproj
+++ b/src/DesktopTests/DesktopTests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Remove="TestImages\cortana_with_offset_down.bmp" />
     <None Remove="TestImages\cortana_with_offset_up.bmp" />

--- a/src/OldFileVersionCompatibilityTests/OldFileVersionCompatibilityTests.csproj
+++ b/src/OldFileVersionCompatibilityTests/OldFileVersionCompatibilityTests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.1" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/src/RuleSelectionTests/RuleSelectionTests.csproj
+++ b/src/RuleSelectionTests/RuleSelectionTests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.1" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/src/RulesTest/RulesTests.csproj
+++ b/src/RulesTest/RulesTests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.1" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
+++ b/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.1" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/src/TelemetryTests/TelemetryTests.csproj
+++ b/src/TelemetryTests/TelemetryTests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.1" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/src/Win32Tests/Win32Tests.csproj
+++ b/src/Win32Tests/Win32Tests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.12.1" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">


### PR DESCRIPTION
#### Describe the change

The problem was that the <TargetFrameworks> property was specified in netStandard.Test.targets. And that worked fine, until you cleaned your project directory. At that time, the packages that you had previously downloaded were wiped out and Visual Studio wouldn't reload them because the <TargetFrameworks> property wasn't in the project files themselves.

This did not impact the build because the NuGet packages are retrieved by an Azure pipelines task which is, apparently, savvy enough to get the <TargetFrameworks> property from the imported .targets file.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
