### PR TITLE
Fix [BUG] BoundingRectangleNotNull fails to properly exclude System menu bars if the text is non-English

### DIFF
--- a/src/Rules/Library/BoundingRectangleNotNull.cs
+++ b/src/Rules/Library/BoundingRectangleNotNull.cs
@@ -27,8 +27,8 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            var sysmenubar = ControlType.MenuBar & StringProperties.AutomationID.Is("SystemMenuBar") & StringProperties.Name.Is("System");
-            var sysmenuitem = ControlType.MenuItem & Relationships.Parent(sysmenubar) & StringProperties.Name.Is("System");
+            var sysmenubar = ControlType.MenuBar & StringProperties.AutomationID.Is("SystemMenuBar");
+            var sysmenuitem = ControlType.MenuItem & Relationships.Parent(sysmenubar);
 
             // This exception is meant to apply to the non-Chromium version of Edge
             var edgeGroups = ControlType.Group & StringProperties.Framework.Is(Framework.Edge);

--- a/src/RulesTest/Library/BoundingRectangleNotNullTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotNullTest.cs
@@ -116,5 +116,33 @@ namespace Axe.Windows.RulesTest.Library
                 Assert.IsFalse(Rule.Condition.Matches(e));
             } // using
         }
+
+        [TestMethod]
+        public void BoundingRectangleNotNull_SystemMenu_NotApplicable()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                parent.ControlTypeId = ControlType.MenuBar;
+                parent.AutomationId = "SystemMenuBar";
+                e.ControlTypeId = ControlType.MenuItem;
+                parent.Children.Add(e);
+                e.Parent = parent;
+
+                Assert.IsFalse(Rule.Condition.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void BoundingRectangleNotNull_SystemMenuBar_NotApplicable()
+        {
+            using (var e = new MockA11yElement())
+            {
+                e.ControlTypeId = ControlType.MenuBar;
+                e.AutomationId = "SystemMenuBar";
+
+                Assert.IsFalse(Rule.Condition.Matches(e));
+            } // using
+        }
     } // class
 } // namespace


### PR DESCRIPTION
#### Describe the change

Fix #402

The problem was the code tested for an English Name property string and the tests were run on a non-English application.
The change makes the test more broad, but it should still be limited by the AutomationId of "SystemMenuBar".

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
