### PR TITLE
Fix: [BUG] AIWin doesn't report a Win32/WinForms ListView's support for UIA Grid and Table patterns

### DIFF
--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -10,6 +10,7 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using Axe.Windows.Telemetry;
+using Axe.Windows.Win32;
 using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation
@@ -19,14 +20,21 @@ namespace Axe.Windows.Desktop.UIAutomation
     /// </summary>
     public static class A11yAutomation
     {
-        static CUIAutomation UIAutomation = new CUIAutomation();
+        static readonly IUIAutomation UIAutomation = GetUIAutomationInterface();
+
+        private static IUIAutomation GetUIAutomationInterface()
+        {
+            return Win32Helper.IsWindows7()
+                ? new CUIAutomation() as IUIAutomation
+                : new CUIAutomation8() as IUIAutomation;
+        }
 
         /// <summary>
         /// Get UIAutomation8 Object
         /// it is singleton model. basically when you call it, it returns precreated object as needed. 
         /// </summary>
         /// <returns></returns>
-        public static CUIAutomation GetUIAutomationObject()
+        public static IUIAutomation GetUIAutomationObject()
         {
             return UIAutomation;
         }
@@ -213,18 +221,18 @@ namespace Axe.Windows.Desktop.UIAutomation
         {
             IUIAutomationTreeWalker walker = null;
 
-            CUIAutomation h = A11yAutomation.GetUIAutomationObject();
+            var uia = A11yAutomation.GetUIAutomationObject();
 
             switch (mode)
             {
                 case TreeViewMode.Content:
-                    walker = h.ContentViewWalker;
+                    walker = uia.ContentViewWalker;
                     break;
                 case TreeViewMode.Control:
-                    walker = h.ControlViewWalker;
+                    walker = uia.ControlViewWalker;
                     break;
                 case TreeViewMode.Raw:
-                    walker = h.RawViewWalker;
+                    walker = uia.RawViewWalker;
                     break;
             }
 

--- a/src/Desktop/UIAutomation/DesktopElementHelper.cs
+++ b/src/Desktop/UIAutomation/DesktopElementHelper.cs
@@ -70,7 +70,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// <param name="pps">Property ids</param>
         /// <param name="pts">Pattern ids</param>
         /// <returns></returns>
-        public static IUIAutomationCacheRequest GetPropertiesCache(CUIAutomation uia, List<int> pps, List<int> pts)
+        public static IUIAutomationCacheRequest GetPropertiesCache(IUIAutomation uia, List<int> pps, List<int> pts)
         {
             if (uia == null) throw new ArgumentNullException(nameof(uia));
 


### PR DESCRIPTION
#### Describe the change

This change fixes AI-Win issue [#811](https://github.com/microsoft/accessibility-insights-windows/issues/811).

The problem was that the A11yAutomation class used an older version of the CUIAutomation object.


<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
