### PR TITLE
Update tool references and instructions

### DIFF
--- a/docs/AutomationReference.md
+++ b/docs/AutomationReference.md
@@ -151,7 +151,7 @@ You can get the files via a NuGet package; configure NuGet to retrieve the
 then use the classes in the Axe.Windows.Automation namespace (see
 example below):
 
--   Prerequisite: Your project *must* use .NET 4.7.1 (this is required by Axe-Windows).
+-   Prerequisite: Your project *must* be able to use .NET Standard 2.0 libraries.
 -   If you’re using NuGet, add the appropriate feed to your project.
 -   Add **using Axe.Windows.Automation;** to your code.
 -   Follow the steps in [How To Run An Automated Scan](#how-to-run-an-automated-scan).

--- a/docs/NewProject.md
+++ b/docs/NewProject.md
@@ -9,52 +9,16 @@
 2. Before creating a pull request, verify that Visual Studio can successfully load and build the entire solution in both Debug and Release.
 3. If your project requires NuGet dependencies which need to be installed alongside it, update the <dependencies> section of `./src/ci/axe.windows.nuspec`.
 
-### For all .NET Framework projects
+#### For *production (not test)* .NET Standard projects
 
-1. Right-click on the project and select Properties.
-2. In the Application tab, configure "Target Framework" to use the same .NET Framework version used by the `axe.windows.core` project, currently .NET Framework 4.7.1.
-3. In the build tab, set the following for both Debug and Release configurations:
-   1. "Warning level" to 4.
-   2. "Treat warnings as errors" to "All".
+1. Use src\Core\Core.csproj as your template. Remove all ItemGroup blocks except the one that includes the analyzers.
+2. Update the `AssemblyName` and `RootNamespace` entries to match your new project.
+3. Add the new project to the assembly.
+4. Add your files in Visual Studio
 
-#### For *production (not test)* .NET Framework projects
+#### For *test* .NET Standard projects
 
-1. Add the following NuGet packages in Visual Studio to enable signing and code analysis:<br>
-   ```
-   Microsoft.VisualStudioEng.MicroBuild.Core
-   Microsoft.CodeAnalysis.FxCopAnalyzers
-   ```
-2. Close the solution and use your text editor to make the following changes to your `.csproj` file to properly configure the version and signing options:
-   1. Add the following line alongside the existing `<Compile>` statements:<br>
-   `<Compile Include="$(TEMP)\AxeWindowsVersionInfo.cs" />`
-   2. Add the following below the last ItemGroup:<br>
-   ```
-   <ItemGroup>
-      <DropSignedFile Include="$(TargetPath)" />
-   </ItemGroup>
-   <Import Project="..\..\build\settings.targets" />
-   ```
-3. Use your text editor to make the following changes to your project's `Properties\AssemblyInfo` file to set the correct version:
-   1. Remove the following lines, as well as the commented lines above them: <br>
-      ```
-      [assembly: AssemblyVersion("1.0.*")]
-      [assembly: AssemblyFileVersion("1.0.0.0")]
-      ```
-
-#### For *test* .NET Framework projects
-
-1. Close the solution and use your text editor to add the following line to your `.csproj` file to properly configure [Strong Naming](https://docs.microsoft.com/en-us/dotnet/framework/app-domains/strong-named-assemblies) for your assembly:<br>
-   `<Import Project="..\..\build\delaysign.targets" />`
-2. Build the entire solution in both Debug and Release. Ensure that the tests are appropriately discovered in the test explorer, and that they all run successfully.
-
-### .NET Standard and .NET Core projects
-
-#### For *production (not test)* .NET Standard/Core projects
-
-In a text editor, add the following line:<br>
-`<Import Project="..\..\build\NetStandardRelease.targets" />`
-
-#### For *test* .NET Standard/Core projects
-
-In a text editor, add the following line:<br>
-`<Import Project="..\..\build\NetStandardTest.targets" />`
+1. Use src\CoreTests\CoreTests.csproj as your template. Remove all ItemGroup blocks except the one that includes the test adapters, test framework, Moq, etc.
+2. Update the `AssemblyName` and `RootNamespace` entries to match your new project.
+3. Add the new project to the assembly.
+4. Add your files in Visual Studio

--- a/docs/NewProject.md
+++ b/docs/NewProject.md
@@ -19,6 +19,5 @@
 #### For *test* .NET Standard projects
 
 1. Use src\CoreTests\CoreTests.csproj as your template. Remove all ItemGroup blocks except the one that includes the test adapters, test framework, Moq, etc.
-2. Update the `AssemblyName` and `RootNamespace` entries to match your new project.
-3. Add the new project to the assembly.
-4. Add your files in Visual Studio
+2. Add the new project to the assembly.
+3. Add your files in Visual Studio

--- a/docs/SetUpDevEnv.md
+++ b/docs/SetUpDevEnv.md
@@ -4,6 +4,6 @@
 ## Set up your development environment
 
 ### Install Visual Studio
-1. Install Visual Studio 2017 from [here](https://visualstudio.microsoft.com/vs/)
+1. Install Visual Studio 2019 from [here](https://visualstudio.microsoft.com/vs/)
    - Choose ".NET desktop development" option
-   - Add ".NET Framework 4.7.1 development tools"
+   - Add ".NET Framework 4.7.2 development tools" (used for some non-production projects)

--- a/src/CI/App.config
+++ b/src/CI/App.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup> 
-      <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" />
+      <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/src/CI/CI.csproj
+++ b/src/CI/CI.csproj
@@ -10,7 +10,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Axe.Windows.CI</RootNamespace>
     <AssemblyName>Axe.Windows.CI</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />

--- a/src/CurrentFileVersionCompatibilityTests/App.config
+++ b/src/CurrentFileVersionCompatibilityTests/App.config
@@ -1,25 +1,25 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/CurrentFileVersionCompatibilityTests/CurrentFileVersionCompatibilityTests.csproj
+++ b/src/CurrentFileVersionCompatibilityTests/CurrentFileVersionCompatibilityTests.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>CurrentFileVersionCompatibilityTests</RootNamespace>
     <AssemblyName>CurrentFileVersionCompatibilityTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>

--- a/src/RulesMD/App.config
+++ b/src/RulesMD/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/src/RulesMD/RulesMD.csproj
+++ b/src/RulesMD/RulesMD.csproj
@@ -16,7 +16,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>RulesMD</RootNamespace>
     <AssemblyName>RulesMD</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>


### PR DESCRIPTION
#### Describe the change

I installed a fresh version of VS, and installed only .NET 4.7.2 for AIWin, with no 4.7.1 installed. To my surprise, Axe.Windows refused to load. As it turns out, the three non-production projects that still use the old csproj format (and there are specific reasons that they can't switch formats) are still using .NET 4.7.1, which is scheduled to reach end-of-life in October 2020.

This PR does the following:
- Specifies .NET 2019 as our target build environment
- Specifies .NET Standard 2.0 as our required format
- Targets .NET 4.7.2 in the 3 projects that were targeting 4.7.1
- Updates `NewProject.md` to steer the user towards starting with an existing csproj file then customizing it. This should also be resilient to future changes, since the reference file will get updated as changes occur.
- Removed any references to .NET Framework from `NewProject.md`, since nobody should be adding new projects in the old format.

The VS tools tweaked the whitespace a little bit--I didn't bother to revert these since future changes will presumably be handled by these same tools. The only manual edit was to `RulesMD\RulesMD.csproj, which wanted to replace the `$(IntermediateOutputPath)` variable for `MarkdownCreator.cs`

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
