### PR TITLE
System collection immutable warning

### DIFF
--- a/src/CurrentFileVersionCompatibilityTests/CurrentFileVersionCompatibilityTests.csproj
+++ b/src/CurrentFileVersionCompatibilityTests/CurrentFileVersionCompatibilityTests.csproj
@@ -68,7 +68,7 @@
       <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.7.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\packages\System.Collections.Immutable.1.7.1\lib\net461\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/src/CurrentFileVersionCompatibilityTests/Program.cs
+++ b/src/CurrentFileVersionCompatibilityTests/Program.cs
@@ -3,12 +3,14 @@
 
 using Axe.Windows.Actions;
 using Axe.Windows.Actions.Contexts;
-using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Results;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
+
 
 namespace CurrentFileVersionCompatibilityTests
 {
@@ -34,6 +36,8 @@ namespace CurrentFileVersionCompatibilityTests
                     Console.WriteLine("ErrorLevel is 0 on success, non-zero on error");
                     return (int)ReturnValue.BadUsage;
                 }
+
+                RequireSystemCollectionsImmutable(args);
 
                 string filePath = args[0];
                 int expectedFailureCount = int.Parse(args[1]);
@@ -149,6 +153,17 @@ namespace CurrentFileVersionCompatibilityTests
             }
 
             return list;
+        }
+
+        static void RequireSystemCollectionsImmutable(string[] args)
+        {
+            // This code exists to force a build break if we revise the version of
+            // System.Collections.Immutable without upgrading the project reference
+            var dependencyCheck = args.ToImmutableArray<string>();
+            if (args.Length != dependencyCheck.Length)
+            {
+                throw new ArgumentException("This should never happen!", nameof(args));
+            }
         }
     }
 }

--- a/src/CurrentFileVersionCompatibilityTests/Program.cs
+++ b/src/CurrentFileVersionCompatibilityTests/Program.cs
@@ -11,7 +11,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
-
 namespace CurrentFileVersionCompatibilityTests
 {
     class Program


### PR DESCRIPTION
#### Describe the change
Our builds (local and in the pipeline) have been producing the following warning for some time now:

Warning MSB3245: Could not resolve this reference. Could not locate the assembly "System.Collections.Immutable, Version=1.2.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors.

The root cause of this warning is that we upgraded (via dependabot) System.Collections.Immutable from version 1.7.0 to version 1.7.1, without updating the CurrentFileVersionCompatibilityTests project. This project intentionally pulls in an old version of Axe.Windows, and that old version of Axe.Windows incorrectly listed System.Collections.Imutable as a dependency, which is why it's listed in this project. While I fully understand that this warning is benign, I also understand that once we get used to ignoring a few errors, we're likely to ignore future warnings when they appear, and that they may not be as benign as this one is. Since there are exactly 2 warnings in the pipeline (the other involves signing and I'll look at it next), I'm proposing that we fix this warning and avoid its recurrence by intentionally breaking the build if System.Collections.Immutable gets revised without a corresponding revision in the project. Yes, this will prevent dependabot from upgrading the assembly automatically, but since dependabot is what led to our current scenario, it seems like the best long-term play.

I forced the current version mismatch and confirmed that it fails the compatibility test (we return an unexpected exit code).

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
