### PR TITLE
Revert "Set an ADO variable for the CodeCov version (#405)"

### DIFF
--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -111,7 +111,7 @@ jobs:
   - task: CmdLine@2
     displayName: 'Upload coverage to codecov.io'
     inputs:
-      script: $(USERPROFILE)\.nuget\packages\codecov\$(CODECOV_VERSION)\tools\win7-x86\codecov.exe -t $(CODECOV_TOKEN) -f **/*coverage.cobertura.xml
+      script: $(USERPROFILE)\.nuget\packages\codecov\1.12.1\tools\win7-x86\codecov.exe -t $(CODECOV_TOKEN) -f **/*coverage.cobertura.xml
     #workingDirectory: # Optional
     #failOnStderr: false # Optional
     

--- a/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
+++ b/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
@@ -22,18 +22,4 @@
 
   <Import Project="..\..\build\NetStandardTest.targets" />
 
-  <Target Name="SetADOVariableToPackageVersion" BeforeTargets="BeforeBuild">
-    <!-- This target could be placed in any project which references the CodeCov package -->
-    
-    <ItemGroup>
-      <ReferenceToCodeCovPackage Include="@(PackageReference)"
-                                 Condition="'%(Identity)' == 'Codecov'" />
-    </ItemGroup>
-
-    <Error Condition="'@(ReferenceToCodeCovPackage->Count())' != '1'"  />
-
-    <Message Importance="high"
-             Text="##vso[task.setvariable variable=CODECOV_VERSION]%(ReferenceToCodeCovPackage.Version)" />
-  </Target>
-
 </Project>


### PR DESCRIPTION
#### Describe the change

This reverts commit be06b530c6c18cc0264c31d4e568b1724690892d.

This change tried to make it so that when dependabot updated the version of the CodeCov package, the build wouldn't break because of the discrepancy between the version in the project and the version specified in prbuild.yml. The variable should have been correctly set based on the output from the target added to SystemAbstractionsTest.csproj. But either the variable wasn't specified correctly, or it wasn't picked up by the Azure pipeline. Unfortunately, the pipeline didn't fail to let us know the change wasn't working. Either way, the change caused our code coverage data to drop; so we're reverting it.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
