### PR TITLE
Purge unnecessary System.Collections.Immutable goo

### DIFF
--- a/src/CurrentFileVersionCompatibilityTests/App.config
+++ b/src/CurrentFileVersionCompatibilityTests/App.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/CurrentFileVersionCompatibilityTests/App.config
+++ b/src/CurrentFileVersionCompatibilityTests/App.config
@@ -1,25 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/CurrentFileVersionCompatibilityTests/CurrentFileVersionCompatibilityTests.csproj
+++ b/src/CurrentFileVersionCompatibilityTests/CurrentFileVersionCompatibilityTests.csproj
@@ -64,24 +64,10 @@
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.2.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.7.1\lib\net461\System.Collections.Immutable.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Assert.cs" />

--- a/src/CurrentFileVersionCompatibilityTests/CurrentFileVersionCompatibilityTests.csproj
+++ b/src/CurrentFileVersionCompatibilityTests/CurrentFileVersionCompatibilityTests.csproj
@@ -64,9 +64,6 @@
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
-    </Reference>
     <Reference Include="System.Drawing" />
   </ItemGroup>
   <ItemGroup>

--- a/src/CurrentFileVersionCompatibilityTests/Program.cs
+++ b/src/CurrentFileVersionCompatibilityTests/Program.cs
@@ -8,7 +8,6 @@ using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Results;
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 
 namespace CurrentFileVersionCompatibilityTests
@@ -35,8 +34,6 @@ namespace CurrentFileVersionCompatibilityTests
                     Console.WriteLine("ErrorLevel is 0 on success, non-zero on error");
                     return (int)ReturnValue.BadUsage;
                 }
-
-                RequireSystemCollectionsImmutable(args);
 
                 string filePath = args[0];
                 int expectedFailureCount = int.Parse(args[1]);
@@ -152,17 +149,6 @@ namespace CurrentFileVersionCompatibilityTests
             }
 
             return list;
-        }
-
-        static void RequireSystemCollectionsImmutable(string[] args)
-        {
-            // This code exists to force a build break if we revise the version of
-            // System.Collections.Immutable without upgrading the project reference
-            var dependencyCheck = args.ToImmutableArray<string>();
-            if (args.Length != dependencyCheck.Length)
-            {
-                throw new ArgumentException("This should never happen!", nameof(args));
-            }
         }
     }
 }

--- a/src/CurrentFileVersionCompatibilityTests/packages.config
+++ b/src/CurrentFileVersionCompatibilityTests/packages.config
@@ -1,10 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Axe.Windows" version="0.3.1-prerelease" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
-  <package id="System.Buffers" version="4.5.1" targetFramework="net471" />
-  <package id="System.Collections.Immutable" version="1.7.1" targetFramework="net471" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net471" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net471" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net472" />
 </packages>

--- a/src/CurrentFileVersionCompatibilityTests/packages.config
+++ b/src/CurrentFileVersionCompatibilityTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Axe.Windows" version="0.3.1-prerelease" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
+  <package id="Axe.Windows" version="0.3.1-prerelease" targetFramework="net472"/>
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472"/>
 </packages>

--- a/src/CurrentFileVersionCompatibilityTests/packages.config
+++ b/src/CurrentFileVersionCompatibilityTests/packages.config
@@ -2,5 +2,4 @@
 <packages>
   <package id="Axe.Windows" version="0.3.1-prerelease" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
-  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
#### Describe the change
After merging #411, it occurred to me that there might be a cleaner solution. Rather than add infrastructure to keep dependabot changes from introducing warnings that we couldn't detect, perhaps we can remove the root cause of the warnings. Some history:

- Axe.Windows has _never_ needed System.Collections.Immutable--it was a legacy of a completely unrelated component that happened to not get removed when we created Axe.Windows.
- As dependabot identified new versions of System.Collections.Immutable, we dutifully updated the csproj file to the new version, even though they weren't being used.
- New versions of System.Collections.Immutable pulled in new dependencies, which also got updated, and so on...

So here's a different approach:
1. MANUALLY remove all package references from the csproj and *.config files
2. MANUALLY remove the code that was added in #411
3. Use VS tooling to add `System`
4. Use VS tooling to add `Axe.Windows` 0.3.1; `Newtonsoft.Json` 9.X and `System.Collections.Immutable` get added automatically because they're listed as dependencies in the NuSpec file. At this point in time, we're essentially where we were when the project was initially created.
4. Use VS tooling to update `Newtonsoft.Json` to the current version (12.X)
5. MANUALLY remove all references to `System.Collections.immutable` from the .csproj and packages.config files

The net result is that we're now decoupled from any changes to assemblies that we don't actually need. Dependabot changes to `Newtonsoft.Json` will continue to require manual help (no change there), but `Newtonsoft.Json` is now the _only_ assembly that will require manual tweaks to this project.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
