### PR TITLE
chore: Use newer version of signing plugin

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -198,7 +198,7 @@ jobs:
   - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
     displayName: 'Install Localization Plugin'
 
-  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
+  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@2
     displayName: 'Install Signing Plugin'
     inputs:
       signType: real


### PR DESCRIPTION
#### Describe the change
Signed builds broke as a result of a change in the signing plugin. Apparently our version is no longer supported, so we need to upgrade. I'll make a similar change in AIWin.

Validation build showing it works: https://dev.azure.com/mseng/1ES/_build/results?buildId=12757078&view=results

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
