### PR TITLE
Fix: AIWin unexpectedly reports failures with WPF DataGrid's which contain cells with text duplicated between cells · Issue #417

### DIFF
--- a/src/Rules/Library/SiblingUniqueAndFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndFocusable.cs
@@ -24,6 +24,7 @@ namespace Axe.Windows.Rules.Library
             return IsKeyboardFocusable
                 & IsContentOrControlElement
                 & ~ExcludedType
+                & ~Patterns.GridItem
                 & ParentExists
                 & Name.NotNullOrEmpty
                 & LocalizedControlType.NotNullOrEmpty

--- a/src/RulesTest/Library/SiblingUniqueAndFocusableTest.cs
+++ b/src/RulesTest/Library/SiblingUniqueAndFocusableTest.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
 using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
@@ -11,8 +13,7 @@ namespace Axe.Windows.RulesTest.Library
     {
         private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.SiblingUniqueAndFocusable();
 
-        [TestMethod]
-        public void TestTypeMismatchPass()
+        private static MockA11yElement CreateParentWithMatchingChildren()
         {
             var parent = new MockA11yElement();
             var child1 = new MockA11yElement();
@@ -22,7 +23,7 @@ namespace Axe.Windows.RulesTest.Library
             child1.IsContentElement = true;
             child2.IsContentElement = true;
             child1.LocalizedControlType = "MyType1";
-            child2.LocalizedControlType = "MyType2";
+            child2.LocalizedControlType = "MyType1";
             child1.Name = "Alice";
             child2.Name = "Alice";
             child1.IsKeyboardFocusable = true;
@@ -31,6 +32,16 @@ namespace Axe.Windows.RulesTest.Library
             child2.Parent = parent;
             parent.Children.Add(child1);
             parent.Children.Add(child2);
+
+            return parent;
+        }
+
+        [TestMethod]
+        public void TestTypeMismatchPass()
+        {
+            var parent = CreateParentWithMatchingChildren();
+            var child2 = parent.Children[1] as MockA11yElement;
+            child2.LocalizedControlType = "MyType2";
 
             Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
         }
@@ -38,23 +49,9 @@ namespace Axe.Windows.RulesTest.Library
         [TestMethod]
         public void TestNameMismatchPass()
         {
-            var parent = new MockA11yElement();
-            var child1 = new MockA11yElement();
-            var child2 = new MockA11yElement();
-            child1.BoundingRectangle = new Rectangle(0, 0, 25, 25);
-            child2.BoundingRectangle = new Rectangle(0, 0, 25, 25);
-            child1.IsContentElement = true;
-            child2.IsContentElement = true;
-            child1.LocalizedControlType = "MyType";
-            child2.LocalizedControlType = "MyType";
-            child1.Name = "Alice";
+            var parent = CreateParentWithMatchingChildren();
+            var child2 = parent.Children[1] as MockA11yElement;
             child2.Name = "Bob";
-            child1.IsKeyboardFocusable = true;
-            child2.IsKeyboardFocusable = true;
-            child1.Parent = parent;
-            child2.Parent = parent;
-            parent.Children.Add(child1);
-            parent.Children.Add(child2);
 
             Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
         }
@@ -62,23 +59,19 @@ namespace Axe.Windows.RulesTest.Library
         [TestMethod]
         public void TestFocusableMismatchPass()
         {
-            var parent = new MockA11yElement();
-            var child1 = new MockA11yElement();
-            var child2 = new MockA11yElement();
-            child1.BoundingRectangle = new Rectangle(0, 0, 25, 25);
-            child2.BoundingRectangle = new Rectangle(0, 0, 25, 25);
-            child1.IsContentElement = true;
-            child2.IsContentElement = true;
-            child1.LocalizedControlType = "MyType";
-            child2.LocalizedControlType = "MyType";
-            child1.Name = "Alice";
-            child2.Name = "Alice";
-            child1.IsKeyboardFocusable = true;
+            var parent = CreateParentWithMatchingChildren();
+            var child2 = parent.Children[1] as MockA11yElement;
             child2.IsKeyboardFocusable = false;
-            child1.Parent = parent;
-            child2.Parent = parent;
-            parent.Children.Add(child1);
-            parent.Children.Add(child2);
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+        }
+
+        [TestMethod]
+        public void TestGridItemPatternPass()
+        {
+            var parent = CreateParentWithMatchingChildren();
+            var child2 = parent.Children[1] as MockA11yElement;
+            child2.Patterns.Add(new A11yPattern(child2, PatternIDs.GridItem));
 
             Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
         }
@@ -86,23 +79,8 @@ namespace Axe.Windows.RulesTest.Library
         [TestMethod]
         public void TestMatchError()
         {
-            var parent = new MockA11yElement();
-            var child1 = new MockA11yElement();
-            var child2 = new MockA11yElement();
-            child1.BoundingRectangle = new Rectangle(0, 0, 25, 25);
-            child2.BoundingRectangle = new Rectangle(0, 0, 25, 25);
-            child1.IsContentElement = true;
-            child2.IsContentElement = true;
-            child1.LocalizedControlType = "MyType";
-            child2.LocalizedControlType = "MyType";
-            child1.Name = "Alice";
-            child2.Name = "Alice";
-            child1.IsKeyboardFocusable = true;
-            child2.IsKeyboardFocusable = true;
-            child1.Parent = parent;
-            child2.Parent = parent;
-            parent.Children.Add(child1);
-            parent.Children.Add(child2);
+            var parent = CreateParentWithMatchingChildren();
+            var child2 = parent.Children[1] as MockA11yElement;
 
             Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(child2));
         }


### PR DESCRIPTION
#### Describe the change

The fix is to make elements which support the GridItem exempt from checking for duplicate siblings under the assumption that such elements can be distinguished by their row and column information.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
