### PR TITLE
chore: Remove unused HotkeyModifier enum

### DIFF
--- a/src/Win32/Win32Enums.cs
+++ b/src/Win32/Win32Enums.cs
@@ -4,19 +4,6 @@
 namespace Axe.Windows.Win32
 {
     /// <summary>
-    /// https://msdn.microsoft.com/en-us/library/windows/desktop/ms646309(v=vs.85).aspx
-    /// </summary>
-    internal enum HotkeyModifier : int
-    {
-        MOD_ALT = 0x0001,
-        MOD_CONTROL = 0x0002,
-        MOD_NOREPEAT = 0x4000,
-        MOD_SHIFT = 0x0004,
-        MOD_WIN = 0x0008,
-        MOD_NoModifier = -1,
-    }
-
-    /// <summary>
     /// Flag used when in OS comparison methods
     /// </summary>
     internal enum OsComparisonResult


### PR DESCRIPTION
#### Describe the change

The HotKey class was removed from Axe.Windows months ago, but somehow the HotkeyModifier enum was overlooked. We just noticed it was still there in a recent code review. Removing it since it no longer adds value.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
