### PR TITLE
Fix minor typo in Telemetry.md

### DIFF
--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -61,7 +61,7 @@ To set the object you created in the section above as the sink for Axe.Windows t
 
 ### Telemetry properties
 
-Wehn "Scan_Statistics" is sent to `PublishEvent` as the event name, the following items are expected in the properties dictionary:
+When "Scan_Statistics" is sent to `PublishEvent` as the event name, the following items are expected in the properties dictionary:
 
 Property | Data
 --- | ---


### PR DESCRIPTION
Fixed a minor typo, `When` instead of `Wehn`

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
