### PR TITLE
fix: Revise BoundingRectangleSizeReasonble to ignore Separators

### DIFF
--- a/src/Rules/Library/BoundingRectangleSizeReasonable.cs
+++ b/src/Rules/Library/BoundingRectangleSizeReasonable.cs
@@ -30,7 +30,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            var ignoreableText = Text & ~IsKeyboardFocusable & Name.NullOrEmpty & ~ChildrenExist;
+            var ignoreableText = (Text | Separator) & ~IsKeyboardFocusable & Name.NullOrEmpty & ~ChildrenExist;
 
             return IsNotOffScreen
                 & BoundingRectangle.NotNull

--- a/src/RulesTest/Library/BoundingRectangleSizeReasonableTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleSizeReasonableTest.cs
@@ -63,5 +63,18 @@ namespace Axe.Windows.RulesTest.Library
 
             Assert.IsFalse(Rule.Condition.Matches(e));
         }
+
+        [TestMethod]
+        public void BoundingRectangleSizeReasonable_SeparatorNonApplicable()
+        {
+            var e = new MockA11yElement();
+
+            // valid rectangle, no name, IsKeyboardFocusable false, no children
+
+            e.BoundingRectangle = new Rectangle(0, 0, 2, 2);
+            e.ControlTypeId = ControlType.Separator;
+
+            Assert.IsFalse(Rule.Condition.Matches(e));
+        }
     }// class
 } // namespace


### PR DESCRIPTION
#### Describe the change
Issue #432 suggested that separators should be exempt from the `BoundingRectangleSizeReasonable` rule. After internal review, we agreed. This change excludes separators and updates the unit tests.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
