### PR TITLE
chore: Bump build version to 1.0.3

### DIFF
--- a/src/props/version.props
+++ b/src/props/version.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SemVerNumber Condition="$(SemVerNumber) == ''">1.0.2</SemVerNumber>
+    <SemVerNumber Condition="$(SemVerNumber) == ''">1.0.3</SemVerNumber>
     <SemVerSuffix></SemVerSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### Describe the change

Bump version number to 1.0.3 since we just released 1.0.2

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
