### PR TITLE
chore: Change how Axe.Windows.Automation.xml file is specified

### DIFF
--- a/src/Automation/Automation.csproj
+++ b/src/Automation/Automation.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DocumentationFile>$(OutputDir)\Axe.Windows.Automation.xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <Import Project="..\..\build\NetStandardRelease.targets" />


### PR DESCRIPTION
#### Describe the change
Axe.windows fails to build from VS 16.7.4 unless you're running as administrator. The problem is that it can't write C:\Axe.Windows.Automation.xml without admin privileges, so it fails the build. It works fine when running as administrator, and it ends up creating 2 copies of the XML file--one in the root, and one where it's expected in the bin folder. I'm not sure why it's writing 2 copies or how long it's done this--it could be be a bug in the dev tools.

This change modifies how we specify the XML file. Instead of specifying the file, we just tell VS to build it and it auto-generates the file based on the assembly name (which, happily, is the name that we were explicitly specifying). The [MSDN docs](https://docs.microsoft.com/en-us/dotnet/csharp/codedoc) say that the two methods are equivalent, but they're slightly different--they both write the file we want to the bin folder, but they write an "extra" copy in different locations. The old way wrote the extra copy in the root of the disk, while the new way writes the extra copy in the obj folder (with other temporary files). Using this format works now and will continue to work unmodified if this turns out to be a bug in the build tools.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
