### PR TITLE
chore: Reorder some Assert.Are[Not]Equal parameters

### DIFF
--- a/src/RulesTest/Library/BoundingRectangleContainedInParentTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleContainedInParentTest.cs
@@ -34,7 +34,7 @@ namespace Axe.Windows.RulesTest.Library
 
                 e.Parent = parent;
 
-                Assert.AreEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 
@@ -58,7 +58,7 @@ namespace Axe.Windows.RulesTest.Library
                 e.Parent = parent;
                 parent.Parent = grandParent;
 
-                Assert.AreEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 
@@ -83,7 +83,7 @@ namespace Axe.Windows.RulesTest.Library
                 e.Parent = parent;
                 parent.Parent = grandParent;
 
-                Assert.AreEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 
@@ -132,7 +132,7 @@ namespace Axe.Windows.RulesTest.Library
                 e.Parent = parent;
                 parent.Parent = grandParent;
 
-                Assert.AreEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 
@@ -154,7 +154,7 @@ namespace Axe.Windows.RulesTest.Library
 
                 e.Parent = parent;
 
-                Assert.AreEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 
@@ -173,7 +173,7 @@ namespace Axe.Windows.RulesTest.Library
 
                 e.Parent = parent;
 
-                Assert.AreNotEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 
@@ -192,7 +192,7 @@ namespace Axe.Windows.RulesTest.Library
 
                 e.Parent = parent;
 
-                Assert.AreNotEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 
@@ -211,7 +211,7 @@ namespace Axe.Windows.RulesTest.Library
 
                 e.Parent = parent;
 
-                Assert.AreNotEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 
@@ -230,7 +230,7 @@ namespace Axe.Windows.RulesTest.Library
 
                 e.Parent = parent;
 
-                Assert.AreNotEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 
@@ -270,7 +270,7 @@ namespace Axe.Windows.RulesTest.Library
             parent.Patterns.Add(pattern);
             e.Parent = parent;
 
-            Assert.AreEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
         }
 
         [TestMethod]
@@ -292,7 +292,7 @@ namespace Axe.Windows.RulesTest.Library
             parent.Patterns.Add(pattern);
             e.Parent = parent;
 
-            Assert.AreEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/BoundingRectangleDataFormatCorrectTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleDataFormatCorrectTest.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.RulesTest.Library
             {
                 var p = new A11yProperty(PropertyType.UIA_BoundingRectanglePropertyId, new double[] {  1, 2, 3, 4 });
                 e.Properties.Add(PropertyType.UIA_BoundingRectanglePropertyId, p);
-                Assert.AreEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 
@@ -30,7 +30,7 @@ namespace Axe.Windows.RulesTest.Library
             {
                 var p = new A11yProperty(PropertyType.UIA_BoundingRectanglePropertyId, new double[] { 1, 2, 3 });
                 e.Properties.Add(PropertyType.UIA_BoundingRectanglePropertyId, p);
-                Assert.AreNotEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 
@@ -41,7 +41,7 @@ namespace Axe.Windows.RulesTest.Library
             {
                 var p = new A11yProperty(PropertyType.UIA_BoundingRectanglePropertyId, new int[] { 1, 2, 3, 4 });
                 e.Properties.Add(PropertyType.UIA_BoundingRectanglePropertyId, p);
-                Assert.AreNotEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 
@@ -50,7 +50,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             using (var e = new MockA11yElement())
             {
-                Assert.AreNotEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
     } // class

--- a/src/RulesTest/Library/BoundingRectangleNotAllZerosTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotAllZerosTest.cs
@@ -16,7 +16,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.BoundingRectangle = new Rectangle(0, 0, 0, 1);
-            Assert.AreEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
         }
 
         [TestMethod]
@@ -24,7 +24,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.BoundingRectangle = new Rectangle(0, 0, 0, 0);
-            Assert.AreNotEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+            Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/BoundingRectangleNotNullTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotNullTest.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.RulesTest.Library
             using (var e = new MockA11yElement())
             {
                 e.BoundingRectangle = Rectangle.Empty;
-                Assert.AreEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 
@@ -27,7 +27,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             using (var e = new MockA11yElement())
             {
-                Assert.AreNotEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 

--- a/src/RulesTest/Library/BoundingRectangleNotValidButOffScreenTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotValidButOffScreenTest.cs
@@ -13,7 +13,7 @@ namespace Axe.Windows.RulesTest.Library
         [TestMethod]
         public void TestBoundingRectangleNotValidButOffScreenInformation()
         {
-            Assert.AreEqual(Rule.Evaluate(null), EvaluationCode.Note);
+            Assert.AreEqual(EvaluationCode.Note, Rule.Evaluate(null));
         }
     }
 }

--- a/src/RulesTest/Library/BoundingRectangleSizeReasonableTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleSizeReasonableTest.cs
@@ -20,7 +20,7 @@ namespace Axe.Windows.RulesTest.Library
             using (var e = new MockA11yElement())
             {
                 e.BoundingRectangle = rect;
-                Assert.AreEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 
@@ -30,7 +30,7 @@ namespace Axe.Windows.RulesTest.Library
             using (var e = new MockA11yElement())
             {
                 e.BoundingRectangle = Rectangle.Empty;
-                Assert.AreNotEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 
@@ -40,7 +40,7 @@ namespace Axe.Windows.RulesTest.Library
             using (var e = new MockA11yElement())
             {
                 e.BoundingRectangle = new Rectangle(0, 0, 12, 2);
-                Assert.AreNotEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 

--- a/src/RulesTest/Library/NameIsInformative.cs
+++ b/src/RulesTest/Library/NameIsInformative.cs
@@ -26,7 +26,7 @@ namespace Axe.Windows.RulesTest.Library
                 foreach (var s in stringsToTry)
                     {
                     e.Name = s;
-                    Assert.AreNotEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                    Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
                 }
             } // using
         }
@@ -49,7 +49,7 @@ namespace Axe.Windows.RulesTest.Library
                 foreach (var s in stringsToTry)
                 {
                     e.Name = s;
-                    Assert.AreEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                    Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
                 }
             } // using
         }

--- a/src/RulesTest/Library/NameIsNotEmpty.cs
+++ b/src/RulesTest/Library/NameIsNotEmpty.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Name = "";
 
-            Assert.AreNotEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+            Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
         }
 
         [TestMethod]
@@ -28,7 +28,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Name = " ";
 
-            Assert.AreEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/NameIsNotNull.cs
+++ b/src/RulesTest/Library/NameIsNotNull.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Name = null;
 
-            Assert.AreNotEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+            Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
         }
 
         [TestMethod]
@@ -28,7 +28,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Name = "";
 
-            Assert.AreEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/NameIsNotWhiteSpace.cs
+++ b/src/RulesTest/Library/NameIsNotWhiteSpace.cs
@@ -39,7 +39,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.Name = "   ";
-            Assert.AreNotEqual(this.Rule.Evaluate(e), EvaluationCode.Pass);
+            Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
         }
 
         [TestMethod]
@@ -47,7 +47,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.Name = "hello world!";
-            Assert.AreEqual(this.Rule.Evaluate(e), EvaluationCode.Pass);
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/NameIsNotWhiteSpace.cs
+++ b/src/RulesTest/Library/NameIsNotWhiteSpace.cs
@@ -39,7 +39,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.Name = "   ";
-            Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.AreNotEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
         }
 
         [TestMethod]
@@ -47,7 +47,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.Name = "hello world!";
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/NameIsReasonableLength.cs
+++ b/src/RulesTest/Library/NameIsReasonableLength.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.RulesTest.Library
             using (var e = new MockA11yElement())
             {
                 e.Name = "Hello";
-                Assert.AreEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 
@@ -33,7 +33,7 @@ namespace Axe.Windows.RulesTest.Library
                     s.Append(s.ToString() + s.ToString());
 
                 e.Name = s.ToString();
-                Assert.AreNotEqual(Rule.Evaluate(e), EvaluationCode.Pass);
+                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
             } // using
         }
 


### PR DESCRIPTION
#### Describe the change
While working on #439, I noticed that NameExcludesSpecialCharacters was specifying the parameters to `Assert.AreEqual` in the wrong order. Correct order is expected value first, actual value second. The tests will pass or fail the same with either ordering, but the error message is incorrect if the parameters are specified in the incorrect order. The incorrect error message made it harder to identify my problem :(

I scanned other tests and found 11 other files where the ordering to `Assert.AreEqual` or `Assert.AreNotEqual` was incorrect in one or more unit tests. This PR simply corrects the ordering. Ironically, it leaves the existing (incorrect) order in NameExcludesSpecialCharacters, since that file is going away. This is a preemptive action to avoid a merge conflict once both PR's are merged.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
