### PR TITLE
fix: Normalize mouse tracking

### DIFF
--- a/src/Actions/Actions/SelectAction.cs
+++ b/src/Actions/Actions/SelectAction.cs
@@ -354,9 +354,11 @@ namespace Axe.Windows.Actions
 
             set
             {
-                if (this.TreeTracker == null) return;
+                if (this.MouseTracker != null)
+                    this.MouseTracker.TreeViewMode = value;
 
-                this.TreeTracker.TreeViewMode = value;
+                if (this.TreeTracker != null)
+                    this.TreeTracker.TreeViewMode = value;
             }
         }
 

--- a/src/Actions/Trackers/MouseTracker.cs
+++ b/src/Actions/Trackers/MouseTracker.cs
@@ -135,7 +135,7 @@ namespace Axe.Windows.Actions.Trackers
 
                     LastMousePoint = p;
 
-                    this.timerMouse?.Start(); // make sure that it is disabled.
+                    this.timerMouse?.Start(); // make sure that it is enabled.
                 }
             }
         }

--- a/src/Actions/Trackers/MouseTracker.cs
+++ b/src/Actions/Trackers/MouseTracker.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Desktop.UIAutomation;
 using Axe.Windows.Win32;
@@ -38,6 +39,11 @@ namespace Axe.Windows.Actions.Trackers
                 }
             }
         }
+
+        /// <summary>
+        /// Our current TreeViewMode
+        /// </summary>
+        public TreeViewMode TreeViewMode { get; set; }
 
         /// <summary>
         /// Mouse position of POI (point of intererst)
@@ -108,7 +114,7 @@ namespace Axe.Windows.Actions.Trackers
 
                     if (LastMousePoint.Equals(p) && this.POIPoint.Equals(p) == false)
                     {
-                        var element = GetElementBasedOnScope(A11yAutomation.ElementFromPoint(p.X, p.Y));
+                        var element = GetElementBasedOnScope(A11yAutomation.NormalizedElementFromPoint(p.X, p.Y, this.TreeViewMode));
 
                         if (element != null && element.IsRootElement() == false && element.IsSameUIElement(this.SelectedElementRuntimeId, this.SelectedBoundingRectangle, this.SelectedControlTypeId, this.SelectedName) == false && !POIPoint.Equals(p))
                         {

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -1,9 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Diagnostics;
-using System.Linq;
-using System.Runtime.InteropServices;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;
@@ -11,6 +7,10 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using Axe.Windows.Telemetry;
 using Axe.Windows.Win32;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
 using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation
@@ -213,7 +213,25 @@ namespace Axe.Windows.Desktop.UIAutomation
         }
 
         /// <summary>
-        /// Get IUIAutomationTreeWalker based on inidcated mode.
+        /// Normalize an element to the specified TreeViewMode
+        /// </summary>
+        /// <param name="element">A11yElement</param>
+        /// <param name="treeViewMode">mode to normalize to</param>
+        /// <returns></returns>
+        public static A11yElement GetNormalizedElement(A11yElement element, TreeViewMode treeViewMode)
+        {
+            if (element == null)
+                throw new ArgumentNullException(nameof(element));
+
+            var walker = GetTreeWalker(treeViewMode);
+            var normalizedElement = walker.NormalizeElement((IUIAutomationElement)element.PlatformObject);
+            Marshal.ReleaseComObject(walker);
+
+            return new DesktopElement(normalizedElement, true);
+        }
+
+        /// <summary>
+        /// Get IUIAutomationTreeWalker based on indicated mode.
         /// </summary>
         /// <param name="mode">TreeViewMode to get walker</param>
         /// <returns></returns>
@@ -259,11 +277,50 @@ namespace Axe.Windows.Desktop.UIAutomation
                     e.PopulateMinimumPropertiesForSelection();
 
                     return e;
-
                 }
                 else
                 {
                     Marshal.ReleaseComObject(uia);
+                }
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception e)
+            {
+                e.ReportException();
+            }
+#pragma warning restore CA1031 // Do not catch general exception types
+
+            return null;
+        }
+
+        /// <summary>
+        /// Get a DesktopElement from x, y position, normalized to treeViewMode
+        /// </summary>
+        /// <param name="xPos"></param>
+        /// <param name="yPos"></param>
+        /// <param name="treeViewMode">current TreeViewode</param>
+        /// <returns></returns>
+        public static A11yElement NormalizedElementFromPoint(int xPos, int yPos, TreeViewMode treeViewMode)
+        {
+            try
+            {
+                A11yElement element = ElementFromPoint(xPos, yPos);
+
+                if (element == null)
+                    return null;
+
+                if (treeViewMode == TreeViewMode.Raw)
+                    return element;
+
+                if (treeViewMode == TreeViewMode.Control && element.IsControlElement)
+                    return element;
+
+                if (treeViewMode == TreeViewMode.Content && element.IsContentElement)
+                    return element;
+
+                using (element)
+                {
+                    return GetNormalizedElement(element, treeViewMode);
                 }
             }
 #pragma warning disable CA1031 // Do not catch general exception types

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -298,7 +298,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// </summary>
         /// <param name="xPos"></param>
         /// <param name="yPos"></param>
-        /// <param name="treeViewMode">current TreeViewode</param>
+        /// <param name="treeViewMode">current TreeViewMode</param>
         /// <returns></returns>
         public static A11yElement NormalizedElementFromPoint(int xPos, int yPos, TreeViewMode treeViewMode)
         {


### PR DESCRIPTION
#### Describe the change
This is the axe.windows portion of https://github.com/microsoft/accessibility-insights-windows/issues/974. It modifies the mouse tracking code to normalize the element based on the current TreeViewMode. It also makes a couple of unrelated changes (2 comments, 1 extra newline, and sorting the using blocks) that I happened to notice while I was working on this change.

The change itself is simple. The SelectAction already has the TreeViewMode, so we just need to pass it to the MouseTracker, then use this to normalize the element to the TreeViewMode. The code to check the IsContentElement and IsControlElement properties could be removed if we always calling Normalize, but that complicates the object management, so we make an extra check (which the compiler will optimize easily) and only call Normalize when we know our existing element won't match the current TreeViewMode.

I've validated this new code in AIWin, and it works as expected. Using the sample app from the original issue, I did the following with both old and new code:
1. Start AIWin with "always on top" set to true, let it wait at the welcome screen
2. Start the test app. I'd previously positioned the windows so AIWin would overlap the edit control containing the placeholder (the placeholder is implemented as a TextBlock that returns false for both IsContentElement and IsControlElement properties)
3. Close the AIWin welcome screen
4. Hover over the edit control with the placeholder
5. Check the properties (and grab a screenshot)

Before this change, the TextBlock appears in the hierarchy tree, which in incorrect since TreeViewMode is set to Control. After this change, the TextBlock no longer appears in the hierarchy tree. In the screenshot below, the old behavior is on the top (the TextBlock's entry in the hierarchy tree is highlighted in red), and the new behavior is on the bottom.

![image](https://user-images.githubusercontent.com/45672944/96936152-664fbf00-147a-11eb-9792-8a3eb8107720.png)

I've also checked TreeViewMode values of Raw and Content, and everything worked as expected.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
