### PR TITLE
chore: Update RulesDescription.md to reflect recent rule split

### DIFF
--- a/docs/RulesDescription.md
+++ b/docs/RulesDescription.md
@@ -83,7 +83,8 @@ ControlShouldSupportInvokePattern | An element of the given ControlType must sup
 ControlShouldSupportScrollItemPattern | An element whose parent supports the Scroll pattern must support the ScrollItem pattern. | Section 508 502.3.10 AvailableActions | Error
 ControlShouldSupportSelectionItemPattern | An element of the given ControlType must support the SelectionItem pattern. | Section 508 502.3.10 AvailableActions | Error
 ControlShouldSupportSelectionPattern | An element of the given ControlType must support the Selection pattern. | Section 508 502.3.10 AvailableActions | Error
-ControlShouldSupportSetInfo | The element's ControlType requires valid values for SizeOfSet and PositionInSet. | Section 508 502.3.1 ObjectInformation | Error
+ControlShouldSupportSetInfoWPF | The element's ControlType requires valid values for SizeOfSet and PositionInSet. | Section 508 502.3.1 ObjectInformation | Warning
+ControlShouldSupportSetInfoXAML | The element's ControlType requires valid values for SizeOfSet and PositionInSet. | Section 508 502.3.1 ObjectInformation | Error
 ControlShouldSupport SpreadsheetItemPattern | An element whose parent supports the Spreadsheet pattern must support the SpreadsheetItem pattern. | Section 508 502.3.10 AvailableActions | Error
 ControlShouldSupportTableItemPattern | An element whose parent supports the Table pattern must support the TableItem pattern. | Section 508 502.3.10 AvailableActions | Error
 ControlShouldSupportTablePattern | An element of the given ControlType must support the Table pattern. | Section 508 502.3.10 AvailableActions | Error


### PR DESCRIPTION
#### Describe the change

PR #445  Split the `ControlShouldSupportSetInfo` rule into 2 rules:
- `ControlShouldSupportSetInfoWPF` applies only to WPF and returns a warning on failure
- `ControlShouldSupportSetInfoXAML` applies only to XAML and returns an error on failure

Update the RulesDescription.md accordingly
