### PR TITLE
Chore: Break ControlShouldSupportTablePattern rule into two rules

### DIFF
--- a/docs/RulesDescription.md
+++ b/docs/RulesDescription.md
@@ -88,6 +88,7 @@ ControlShouldSupportSetInfoXAML | The element's ControlType requires valid value
 ControlShouldSupport SpreadsheetItemPattern | An element whose parent supports the Spreadsheet pattern must support the SpreadsheetItem pattern. | Section 508 502.3.10 AvailableActions | Error
 ControlShouldSupportTableItemPattern | An element whose parent supports the Table pattern must support the TableItem pattern. | Section 508 502.3.10 AvailableActions | Error
 ControlShouldSupportTablePattern | An element of the given ControlType must support the Table pattern. | Section 508 502.3.10 AvailableActions | Error
+ControlShouldSupportTablePatternInEdge | An element of the given ControlType must support the Table pattern. | Section 508 502.3.10 AvailableActions | Warning
 ControlShouldSupportTogglePattern | An element of the given ControlType must support the Toggle pattern. | Section 508 502.3.10 AvailableActions | Error
 ControlShouldSupportTransformPattern | An element that can be resized must support the Transform pattern. | Section 508 502.3.10 AvailableActions | Error
 ControlShouldSupportTextPattern | An element of the given ControlType must support the Text pattern. | Section 508 502.3.10 AvailableActions | Error

--- a/src/Core/Enums/RuleId.cs
+++ b/src/Core/Enums/RuleId.cs
@@ -126,6 +126,7 @@ namespace Axe.Windows.Core.Enums
         ControlShouldSupportSpreadsheetItemPattern,
         ControlShouldSupportTableItemPattern,
         ControlShouldSupportTablePattern,
+        ControlShouldSupportTablePatternInEdge,
         ControlShouldSupportTogglePattern,
         ControlShouldSupportTransformPattern,
         ControlShouldSupportTextPattern,

--- a/src/Rules/Library/ControlShouldSupportTablePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTablePattern.cs
@@ -25,7 +25,7 @@ namespace Axe.Windows.Rules.Library
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-                return Patterns.Table.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return Patterns.Table.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldSupportTablePatternInEdge.cs
+++ b/src/Rules/Library/ControlShouldSupportTablePatternInEdge.cs
@@ -10,10 +10,10 @@ using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library
 {
-    [RuleInfo(ID = RuleId.ControlShouldSupportTablePattern)]
-    class ControlShouldSupportTablePattern : Rule
+    [RuleInfo(ID = RuleId.ControlShouldSupportTablePatternInEdge)]
+    class ControlShouldSupportTablePatternInEdge : Rule
     {
-        public ControlShouldSupportTablePattern()
+        public ControlShouldSupportTablePatternInEdge()
         {
             this.Info.Description = Descriptions.ControlShouldSupportTablePattern;
             this.Info.HowToFix = HowToFix.ControlShouldSupportTablePattern;
@@ -25,12 +25,12 @@ namespace Axe.Windows.Rules.Library
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-                return Patterns.Table.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return Patterns.Table.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Warning;
         }
 
         protected override Condition CreateCondition()
         {
-            return (Calendar | Table) & ~StringProperties.Framework.Is(Framework.Edge);
+            return (Calendar | Table) & StringProperties.Framework.Is(Framework.Edge);
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/ControlShouldSupportTablePattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTablePattern.cs
@@ -51,7 +51,7 @@ namespace Axe.Windows.RulesTest.Library
             int[] expectedTypes = { ControlType.Calendar, ControlType.Table };
             var unexpectedTypes = ControlType.All.Difference(expectedTypes);
             
-                var e = new MockA11yElement();
+            var e = new MockA11yElement();
 
             foreach (var type in expectedTypes)
             {

--- a/src/RulesTest/Library/ControlShouldSupportTablePatternInEdge.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTablePatternInEdge.cs
@@ -11,9 +11,9 @@ using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 namespace Axe.Windows.RulesTest.Library
 {
     [TestClass]
-    public class ControlShouldSupportTablePattern
+    public class ControlShouldSupportTablePatternInEdge
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportTablePattern();
+        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportTablePatternInEdge();
 
         [TestMethod]
         public void HasTablePattern_Pass()
@@ -25,11 +25,11 @@ namespace Axe.Windows.RulesTest.Library
         }
 
         [TestMethod]
-        public void NoTablePattern_Error()
+        public void NoTablePattern_Warning()
         {
             var e = new MockA11yElement();
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.AreEqual(EvaluationCode.Warning, Rule.Evaluate(e));
         }
 
         [TestMethod]
@@ -52,6 +52,7 @@ namespace Axe.Windows.RulesTest.Library
             var unexpectedTypes = ControlType.All.Difference(expectedTypes);
             
                 var e = new MockA11yElement();
+            e.Framework = Framework.Edge;
 
             foreach (var type in expectedTypes)
             {
@@ -66,7 +67,7 @@ namespace Axe.Windows.RulesTest.Library
             }
 
             e.ControlTypeId = expectedTypes[0];
-            e.Framework = Framework.Edge;
+            e.Framework = null;
 
             Assert.IsFalse(Rule.Condition.Matches(e));
         }

--- a/src/RulesTest/Library/ControlShouldSupportTablePatternInEdge.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTablePatternInEdge.cs
@@ -51,7 +51,7 @@ namespace Axe.Windows.RulesTest.Library
             int[] expectedTypes = { ControlType.Calendar, ControlType.Table };
             var unexpectedTypes = ControlType.All.Difference(expectedTypes);
             
-                var e = new MockA11yElement();
+            var e = new MockA11yElement();
             e.Framework = Framework.Edge;
 
             foreach (var type in expectedTypes)


### PR DESCRIPTION
#### Describe the change

The old rule returned two possible `ErrorCode` values (in addition to `ErrorCode.Pass`), whereas each of the new separate rules only returns one. This makes it possible for us to specify the failure error code as part of the `RuleInfo` data, which will allow us to automate documentation for the rules regarding which error codes are returned by which rules.


<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
