### PR TITLE
Chore: Add unit tests for the code which runs all rules

### DIFF
--- a/src/Rules/RuleProvider.cs
+++ b/src/Rules/RuleProvider.cs
@@ -7,10 +7,16 @@ using Axe.Windows.Core.Enums;
 
 namespace Axe.Windows.Rules
 {
+    interface IRuleProvider
+    {
+        IRule GetRule(RuleId id);
+        IEnumerable<IRule> All { get; }
+    }
+
     /// <summary>
     /// Supplies rules, ensuring that each rule is created only once, and only when requested.
     /// </summary>
-    class RuleProvider
+    class RuleProvider : IRuleProvider
     {
         private readonly IRuleFactory RuleFactory;
         private readonly ConcurrentDictionary<RuleId, IRule> AllRules = new ConcurrentDictionary<RuleId, IRule>();

--- a/src/Rules/RuleRunner.cs
+++ b/src/Rules/RuleRunner.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Telemetry;
+using System;
+using System.Collections.Generic;
+using static System.FormattableString;
+
+namespace Axe.Windows.Rules
+{
+    class RuleRunner
+    {
+        private readonly IRuleProvider _provider;
+
+        public RuleRunner(IRuleProvider provider)
+        {
+            if (provider == null) throw new ArgumentNullException(nameof(provider));
+
+            _provider = provider;
+        }
+
+        public RunResult RunRuleByID(RuleId id, IA11yElement element)
+        {
+            var rule = _provider.GetRule(id);
+            if (rule == null)
+            {
+                return new RunResult
+                {
+                    EvaluationCode = EvaluationCode.RuleExecutionError,
+                    element = element,
+                    ErrorMessage = Invariant($"No rule matching the ID '{id}' was found.")
+                };
+            }
+
+            var retVal = RunRule(rule, element);
+
+            return retVal;
+        }
+
+        public IEnumerable<RunResult> RunAll(IA11yElement element)
+        {
+            var results = new List<RunResult>();
+
+            foreach (var rule in _provider.All)
+            {
+                var result = RunRule(rule, element);
+                results.Add(result);
+            } // for all rules
+
+            return results;
+        }
+
+        private static RunResult RunRule(IRule rule, IA11yElement element)
+        {
+            try
+            {
+                return RunRuleWorker(rule, element);
+            }
+#pragma warning disable CA1031
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                ex.ReportException();
+                if (System.Diagnostics.Debugger.IsLogging())
+                    System.Diagnostics.Debug.WriteLine(ex.ToString());
+
+                return new RunResult
+                {
+                    RuleInfo = rule.Info,
+                    element = element,
+                    EvaluationCode = EvaluationCode.RuleExecutionError,
+                    ErrorMessage = ex.ToString()
+                };
+            } // catch
+        }
+
+        private static RunResult RunRuleWorker(IRule rule, IA11yElement element)
+        {
+            var result = new RunResult
+            {
+                RuleInfo = rule.Info,
+                element = element,
+                EvaluationCode = EvaluationCode.NotApplicable
+            };
+
+            if (!ShouldRun(rule.Condition, element))
+                return result;
+
+            result.EvaluationCode = rule.Evaluate(element);
+
+            return result;
+        }
+
+        private static bool ShouldRun(Condition condition, IA11yElement element)
+        {
+            if (condition == null) return true;
+
+            return condition.Matches(element);
+        }
+    } // class
+} // namespace

--- a/src/Rules/Rules.cs
+++ b/src/Rules/Rules.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Collections.Generic;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
-using Axe.Windows.Telemetry;
-using static System.FormattableString;
+using System;
+using System.Collections.Generic;
 
 namespace Axe.Windows.Rules
 {
@@ -16,7 +14,8 @@ namespace Axe.Windows.Rules
     public static class Rules
 #pragma warning restore CA1724
     {
-        private static readonly RuleProvider Provider = new RuleProvider(new RuleFactory());
+        private static readonly IRuleProvider Provider = new RuleProvider(new RuleFactory());
+        private static readonly RuleRunner Runner = new RuleRunner(Provider);
 
         // the following is rarely used because its purpose is just to contain metadata about the rules
         private static readonly Lazy<IReadOnlyDictionary<RuleId, RuleInfo>> AllInfo = new Lazy<IReadOnlyDictionary<RuleId, RuleInfo>>(CreateRuleInfo);
@@ -43,19 +42,7 @@ namespace Axe.Windows.Rules
         /// <returns></returns>
         public static RunResult RunRuleByID(RuleId id, IA11yElement element)
         {
-            var rule = Provider.GetRule(id);
-            if (rule == null)
-            {
-                return new RunResult
-                {
-                    EvaluationCode = EvaluationCode.RuleExecutionError,
-                    ErrorMessage = Invariant($"No rule matching the ID '{id}' was found.")
-                };
-            }
-
-            var retVal = Rules.RunRule(rule, element);
-
-            return retVal;
+            return Runner.RunRuleByID(id, element);
         }
 
         /// <summary>
@@ -65,62 +52,7 @@ namespace Axe.Windows.Rules
         /// <returns></returns>
         public static IEnumerable<RunResult> RunAll(IA11yElement element)
         {
-            var results = new List<RunResult>();
-
-            foreach (var rule in Provider.All)
-            {
-                var result = RunRule(rule, element);
-                results.Add(result);
-            } // for all rules
-
-            return results;
-        }
-
-        private static RunResult RunRule(IRule rule, IA11yElement element)
-        {
-            try
-            {
-                return RunRuleWorker(rule, element);
-            }
-#pragma warning disable CA1031
-            catch (Exception ex)
-#pragma warning restore CA1031
-            {
-                ex.ReportException();
-                if (System.Diagnostics.Debugger.IsLogging())
-                    System.Diagnostics.Debug.WriteLine(ex.ToString());
-
-                return new RunResult
-                {
-                    RuleInfo = rule.Info,
-                    EvaluationCode = EvaluationCode.RuleExecutionError,
-                    ErrorMessage = ex.ToString()
-                };
-            } // catch
-        }
-
-        private static RunResult RunRuleWorker(IRule rule, IA11yElement element)
-        {
-            var result = new RunResult
-            {
-                RuleInfo = rule.Info,
-                element = element,
-                EvaluationCode = EvaluationCode.NotApplicable
-            };
-
-            if (!ShouldRun(rule.Condition, element))
-                return result;
-
-            result.EvaluationCode = rule.Evaluate(element);
-
-            return result;
-        }
-
-        private static bool ShouldRun(Condition condition, IA11yElement element)
-        {
-            if (condition == null) return true;
-
-            return condition.Matches(element);
+            return Runner.RunAll(element);
         }
     } // class
 } // namespace

--- a/src/RulesTest/RuleRunnerTests.cs
+++ b/src/RulesTest/RuleRunnerTests.cs
@@ -1,0 +1,229 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Rules;
+using Axe.Windows.RulesTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RulesTests
+{
+    [TestClass]
+    public class RuleRunnerTests
+    {
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ConstructorThrowsForNullProvider()
+        {
+            new RuleRunner(null);
+        }
+
+        [TestMethod]
+        public void RunRuleByID_ReturnsExecutionErrorForUnknownRuleID()
+        {
+            var providerMock = new Mock<IRuleProvider>(MockBehavior.Strict);
+            providerMock.Setup(m => m.GetRule(It.IsAny<RuleId>())).Returns(() => null).Verifiable();
+
+            var e = new MockA11yElement();
+
+            var runner = new RuleRunner(providerMock.Object);
+            var result = runner.RunRuleByID(default(RuleId), e);
+
+            Assert.AreEqual(EvaluationCode.RuleExecutionError, result.EvaluationCode);
+            Assert.AreEqual(e, result.element);
+            Assert.IsNull(result.RuleInfo);
+
+            providerMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void RunRuleByID_RuleNotApplicableForNonMatchingCondition()
+        {
+            // This test has the side effect of ensuring IRule.Evaluate is not called
+            // when the condition is not matched.
+
+            var e = new MockA11yElement();
+
+            var conditionMock = new Mock<Condition>(MockBehavior.Strict);
+            conditionMock.Setup(m => m.Matches(e)).Returns(false).Verifiable();
+
+            var infoStub = new RuleInfo();
+
+            var ruleMock = new Mock<IRule>(MockBehavior.Strict);
+            ruleMock.Setup(m => m.Condition).Returns(conditionMock.Object).Verifiable();
+            ruleMock.Setup(m => m.Info).Returns(() => infoStub).Verifiable();
+
+            var providerMock = new Mock<IRuleProvider>(MockBehavior.Strict);
+            providerMock.Setup(m => m.GetRule(It.IsAny<RuleId>())).Returns(() => ruleMock.Object).Verifiable();
+
+            var runner = new RuleRunner(providerMock.Object);
+            var result = runner.RunRuleByID(default(RuleId), e);
+
+            Assert.AreEqual(EvaluationCode.NotApplicable, result.EvaluationCode);
+            Assert.AreEqual(e, result.element);
+            Assert.AreEqual(infoStub, result.RuleInfo);
+
+            conditionMock.VerifyAll();
+            ruleMock.VerifyAll();
+            providerMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void RunRuleByID_ReturnsExpectedEvaluationCodeWhenSuccessful()
+        {
+            var e = new MockA11yElement();
+
+            var conditionMock = new Mock<Condition>(MockBehavior.Strict);
+            conditionMock.Setup(m => m.Matches(e)).Returns(true).Verifiable();
+
+            var ruleMock = CreateRuleMock(conditionMock.Object, EvaluationCode.Open, e);
+
+            var providerMock = new Mock<IRuleProvider>(MockBehavior.Strict);
+            providerMock.Setup(m => m.GetRule(It.IsAny<RuleId>())).Returns(() => ruleMock.Object).Verifiable();
+
+            var runner = new RuleRunner(providerMock.Object);
+            var result = runner.RunRuleByID(default(RuleId), e);
+
+            Assert.AreEqual(EvaluationCode.Open, result.EvaluationCode);
+            Assert.AreEqual(e, result.element);
+            Assert.AreEqual(ruleMock.Object.Info, result.RuleInfo);
+
+            conditionMock.VerifyAll();
+            ruleMock.VerifyAll();
+            providerMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void RunRuleByID_ReturnsExecutionErrorWhenEvaluateThrowsException()
+        {
+            var e = new MockA11yElement();
+
+            var conditionMock = new Mock<Condition>(MockBehavior.Strict);
+            conditionMock.Setup(m => m.Matches(e)).Returns(true).Verifiable();
+
+            var infoStub = new RuleInfo();
+
+            var ruleMock = new Mock<IRule>(MockBehavior.Strict);
+            ruleMock.Setup(m => m.Condition).Returns(conditionMock.Object).Verifiable();
+            ruleMock.Setup(m => m.Evaluate(e)).Throws<Exception>().Verifiable();
+            ruleMock.Setup(m => m.Info).Returns(() => infoStub).Verifiable();
+
+            var providerMock = new Mock<IRuleProvider>(MockBehavior.Strict);
+            providerMock.Setup(m => m.GetRule(It.IsAny<RuleId>())).Returns(() => ruleMock.Object).Verifiable();
+
+            var runner = new RuleRunner(providerMock.Object);
+            var result = runner.RunRuleByID(default(RuleId), e);
+
+            Assert.AreEqual(EvaluationCode.RuleExecutionError, result.EvaluationCode);
+            Assert.AreEqual(e, result.element);
+            Assert.AreEqual(infoStub, result.RuleInfo);
+
+            conditionMock.VerifyAll();
+            ruleMock.VerifyAll();
+            providerMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void RunRuleByID_ReturnsExecutionErrorWhenConditionMatchesThrowsException()
+        {
+            var e = new MockA11yElement();
+
+            var conditionMock = new Mock<Condition>(MockBehavior.Strict);
+            conditionMock.Setup(m => m.Matches(e)).Throws<Exception>().Verifiable();
+
+            var infoStub = new RuleInfo();
+
+            var ruleMock = new Mock<IRule>(MockBehavior.Strict);
+            ruleMock.Setup(m => m.Condition).Returns(conditionMock.Object).Verifiable();
+            ruleMock.Setup(m => m.Info).Returns(() => infoStub).Verifiable();
+
+            var providerMock = new Mock<IRuleProvider>(MockBehavior.Strict);
+            providerMock.Setup(m => m.GetRule(It.IsAny<RuleId>())).Returns(() => ruleMock.Object).Verifiable();
+
+            var runner = new RuleRunner(providerMock.Object);
+            var result = runner.RunRuleByID(default(RuleId), e);
+
+            Assert.AreEqual(EvaluationCode.RuleExecutionError, result.EvaluationCode);
+            Assert.AreEqual(e, result.element);
+            Assert.AreEqual(infoStub, result.RuleInfo);
+
+            conditionMock.VerifyAll();
+            ruleMock.VerifyAll();
+            providerMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void RunRuleByID_CallsEvaluateWhenConditionIsNull()
+        {
+            var e = new MockA11yElement();
+
+            var ruleMock = CreateRuleMock(null, EvaluationCode.Pass, e);
+
+            var providerMock = new Mock<IRuleProvider>(MockBehavior.Strict);
+            providerMock.Setup(m => m.GetRule(It.IsAny<RuleId>())).Returns(() => ruleMock.Object).Verifiable();
+
+            var runner = new RuleRunner(providerMock.Object);
+            var result = runner.RunRuleByID(default(RuleId), e);
+
+            Assert.AreEqual(EvaluationCode.Pass, result.EvaluationCode);
+            Assert.AreEqual(e, result.element);
+            Assert.AreEqual(ruleMock.Object.Info, result.RuleInfo);
+
+            ruleMock.VerifyAll();
+            providerMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void RunAll_ReturnsExpectedResults()
+        {
+            var e = new MockA11yElement();
+
+            var ruleMocks = new List<Mock<IRule>>();
+            var codes = Enum.GetValues(typeof(EvaluationCode)) as IEnumerable<EvaluationCode>;
+
+            foreach (var code in codes)
+                ruleMocks.Add(CreateRuleMock(Condition.True, code, e));
+
+            var rules = from m in ruleMocks select (m.Object);
+
+            var providerMock = new Mock<IRuleProvider>(MockBehavior.Strict);
+            providerMock.Setup(m => m.All).Returns(() => rules).Verifiable();
+
+            var runner = new RuleRunner(providerMock.Object);
+            var results = runner.RunAll(e);
+
+            Assert.AreEqual(codes.Count(), results.Count());
+
+            for (var i = 0; i < results.Count(); ++i)
+            {
+                var result = results.ElementAt(i);
+                var expectedCode = codes.ElementAt(i);
+                var ruleMock = ruleMocks[i];
+
+                Assert.AreEqual(expectedCode, result.EvaluationCode);
+                Assert.AreEqual(e, result.element);
+                Assert.AreEqual(ruleMock.Object.Info, result.RuleInfo);
+
+                ruleMock.VerifyAll();
+            }
+
+            providerMock.VerifyAll();
+        }
+
+        private static Mock<IRule> CreateRuleMock(Condition condition, EvaluationCode code, A11yElement e)
+        {
+            var infoStub = new RuleInfo();
+
+            var ruleMock = new Mock<IRule>(MockBehavior.Strict);
+            ruleMock.Setup(m => m.Condition).Returns(() => condition).Verifiable();
+            ruleMock.Setup(m => m.Evaluate(e)).Returns(() => code).Verifiable();
+            ruleMock.Setup(m => m.Info).Returns(() => infoStub).Verifiable();
+
+            return ruleMock;
+        }
+    } // class
+} // namespace


### PR DESCRIPTION
#### Describe the change

Extracted code from `Rules` into `RuleRunner` in order to test the rule running logic. The extraction was essentially a cut and paste operation.

The idea is to have rule running logic thoroughly unit tested before an upcoming modification which will add another mechanism for evaluating rules and returning `EvaluationCode` values.
