### PR TITLE
Chore: Add RuleInfo.ErrorCode and IRule.PassesTests

### DIFF
--- a/src/Rules/Rule.cs
+++ b/src/Rules/Rule.cs
@@ -10,6 +10,7 @@ namespace Axe.Windows.Rules
         RuleInfo Info { get;  }
         Condition Condition { get; }
         EvaluationCode Evaluate(IA11yElement element);
+        bool PassesTest(IA11yElement element);
     }
 
     abstract class Rule : IRule
@@ -51,6 +52,14 @@ namespace Axe.Windows.Rules
         }
 
         public abstract EvaluationCode Evaluate(IA11yElement element);
+
+        public bool PassesTest(IA11yElement element)
+        {
+            // This base class function should never be called
+            // once all rules have been converted to use RuleInfo.EvaluationCode, this function will be designated abstract
+            throw new NotImplementedException();
+        }
+
         protected abstract Condition CreateCondition();
     }
 } // namespace

--- a/src/Rules/RuleInfo.cs
+++ b/src/Rules/RuleInfo.cs
@@ -50,7 +50,13 @@ namespace Axe.Windows.Rules
         /// This information is generated programatically when a rule inherits the Rule base class
         /// and is not meant to be changed.
         /// </summary>
-        public string Condition { get; set;  }
+        public string Condition { get; set; }
+
+        /// <summary>
+        /// The <see cref="EvaluationCode"/> to be returned
+        /// in the case the test does not pass
+        /// </summary>
+        public EvaluationCode? ErrorCode { get; set; }
 
         /// <summary>
         /// Provides a string summary of the information contained in the RuleInfo object.

--- a/src/Rules/RuleRunner.cs
+++ b/src/Rules/RuleRunner.cs
@@ -87,7 +87,12 @@ namespace Axe.Windows.Rules
             if (!ShouldRun(rule.Condition, element))
                 return result;
 
-            result.EvaluationCode = rule.Evaluate(element);
+            // The PassesTest call is the method we want to convert all rules to use
+            // Using RuleInfo.ErrorCode will allow us to use reflection to document the result of each rule
+            if (rule.Info.ErrorCode.HasValue)
+                result.EvaluationCode = rule.PassesTest(element) ? EvaluationCode.Pass : rule.Info.ErrorCode.Value;
+            else
+                result.EvaluationCode = rule.Evaluate(element);
 
             return result;
         }

--- a/src/RulesTest/RuleImplementations/RuleWithPassesTestNotImplemented.cs
+++ b/src/RulesTest/RuleImplementations/RuleWithPassesTestNotImplemented.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Rules;
+using System;
+
+namespace RulesTests.RuleImplementations
+{
+    [RuleInfo(ID = default(RuleId))]
+    class RuleWithPassesTestNotImplemented : Rule
+    {
+        public RuleWithPassesTestNotImplemented() : base()
+        {
+            // We have to set the following field so that PassesTest in the base class will be called
+            Info.ErrorCode = EvaluationCode.Error;
+        }
+
+        public override EvaluationCode Evaluate(IA11yElement element)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override Condition CreateCondition()
+        {
+            return Condition.True;
+        }
+    } // class
+} // namespace


### PR DESCRIPTION
#### Describe the change

This change makes it so that if `IRule.Info.ErrorCode` exists for a givenRule`, `IRule.PassesTest` will be called instead of `IRule.Evaluate` to determine if the rule passes its test. In addition, if the rule fails its test, the value of `IRule.Info.ErrorCode` will be returned.

This means that each rule can now specify in its info the `EvaluationCode` to be returned if the rule's test does not pass. And that, in turn, allows us to get the error code for each rule via reflection and display it in our documentation.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
