### PR TITLE
Chore: Add unit test for Rule.Evaluate not implemented

### DIFF
--- a/src/Rules/Rule.cs
+++ b/src/Rules/Rule.cs
@@ -51,9 +51,14 @@ namespace Axe.Windows.Rules
             return null;
         }
 
-        public abstract EvaluationCode Evaluate(IA11yElement element);
+        public virtual EvaluationCode Evaluate(IA11yElement element)
+        {
+            // This base class function should never be called
+            // once all rules have been converted to use RuleInfo.EvaluationCode, this function will be removed
+            throw new NotImplementedException();
+        }
 
-        public bool PassesTest(IA11yElement element)
+        public virtual bool PassesTest(IA11yElement element)
         {
             // This base class function should never be called
             // once all rules have been converted to use RuleInfo.EvaluationCode, this function will be designated abstract

--- a/src/RulesTest/RuleImplementations/RuleWithEvaluateNotImplemented.cs
+++ b/src/RulesTest/RuleImplementations/RuleWithEvaluateNotImplemented.cs
@@ -7,6 +7,9 @@ using System;
 
 namespace RulesTests
 {
+    /*
+    This class can be removed once every rule in the assembly has been converted to calling PassesTest instead of Evaluate
+    */
     [RuleInfo(ID = default(RuleId))]
     class RuleWithEvaluateNotImplemented : Rule
     {

--- a/src/RulesTest/RuleImplementations/RuleWithEvaluateNotImplemented.cs
+++ b/src/RulesTest/RuleImplementations/RuleWithEvaluateNotImplemented.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Rules;
+using System;
+
+namespace RulesTests
+{
+    [RuleInfo(ID = default(RuleId))]
+    class RuleWithEvaluateNotImplemented : Rule
+    {
+        protected override Condition CreateCondition()
+        {
+            return Condition.True;
+        }
+
+        public override bool PassesTest(IA11yElement element)
+        {
+            // Don't throw an exception here so we can be sure the only exception thrown is in Rule.Evaluate
+            return true;
+        }
+    } // class
+} // namespace

--- a/src/RulesTest/RuleImplementations/RuleWithPassesTestNotImplemented.cs
+++ b/src/RulesTest/RuleImplementations/RuleWithPassesTestNotImplemented.cs
@@ -7,6 +7,9 @@ using System;
 
 namespace RulesTests.RuleImplementations
 {
+    /*
+    This class can be removed once every rule in the assembly has been converted to calling PassesTest instead of Evaluate
+    */
     [RuleInfo(ID = default(RuleId))]
     class RuleWithPassesTestNotImplemented : Rule
     {

--- a/src/RulesTest/RuleImplementations/RuleWithPassesTestNotImplemented.cs
+++ b/src/RulesTest/RuleImplementations/RuleWithPassesTestNotImplemented.cs
@@ -18,7 +18,8 @@ namespace RulesTests.RuleImplementations
 
         public override EvaluationCode Evaluate(IA11yElement element)
         {
-            throw new NotImplementedException();
+            // Don't throw an exception here so we can be sure the only exception thrown is in Rule.PassesTest
+            return EvaluationCode.Pass;
         }
 
         protected override Condition CreateCondition()

--- a/src/RulesTest/RuleRunnerTests.cs
+++ b/src/RulesTest/RuleRunnerTests.cs
@@ -184,6 +184,45 @@ namespace RulesTests
         }
 
         [TestMethod]
+        public void RunRuleByID_ReturnsExecutionErrorWhenEvaluateNotImplemented()
+        {
+            var e = new MockA11yElement();
+
+            var rule = new RuleWithEvaluateNotImplemented();
+
+            var providerMock = new Mock<IRuleProvider>(MockBehavior.Strict);
+            providerMock.Setup(m => m.GetRule(It.IsAny<RuleId>())).Returns(() => rule);
+
+            var runner = new RuleRunner(providerMock.Object);
+            var result = runner.RunRuleByID(default(RuleId), e);
+
+            Assert.AreEqual(EvaluationCode.RuleExecutionError, result.EvaluationCode);
+            Assert.AreEqual(rule.Info, result.RuleInfo);
+
+            providerMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void RuleWithPassesTestNotImplemented_HasExpectedImplementation()
+        {
+            var rule = new RuleWithPassesTestNotImplemented();
+            Assert.IsTrue(rule.Info.ErrorCode.HasValue);
+            Assert.IsTrue(rule.Condition.Matches(null));
+            Assert.AreEqual(EvaluationCode.Pass, rule.Evaluate(null));
+            Assert.ThrowsException<NotImplementedException>(() => rule.PassesTest(null));
+        }
+
+        [TestMethod]
+        public void RuleWithEvaluateNotImplemented_HasExpectedImplementation()
+        {
+            var rule = new RuleWithEvaluateNotImplemented();
+            Assert.IsFalse(rule.Info.ErrorCode.HasValue);
+            Assert.IsTrue(rule.Condition.Matches(null));
+            Assert.IsTrue(rule.PassesTest(null));
+            Assert.ThrowsException<NotImplementedException>(() => rule.Evaluate(null));
+        }
+
+        [TestMethod]
         public void RunRuleByID_ReturnsExecutionErrorWhenEvaluateThrowsException()
         {
             var e = new MockA11yElement();


### PR DESCRIPTION
#### Describe the change

The new test ensures that if `Rule.Info.ErrorCode` has no value, `Rule.Evaluate` is expected to be overridden. This is the converse of the existing test where if `Rule.Info.ErrorCode` has a value, `Rule.PassesTest` is expected to be overridden.

Also added tests to confirm the test rule implementations match expectations for the other tests.

Made `Rule.Evaluate` and `Rule.PassesTest` `virtual` so they could be overridden by subclasses.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
