### PR TITLE
fix: Update behavior for no output file to not interact with file system

### DIFF
--- a/src/Automation/ScanTools.cs
+++ b/src/Automation/ScanTools.cs
@@ -14,7 +14,6 @@ namespace Axe.Windows.Automation
 
         public ScanTools(IOutputFileHelper outputFileHelper, IScanResultsAssembler resultsAssembler, ITargetElementLocator targetElementLocator, IAxeWindowsActions actions, INativeMethods nativeMethods)
         {
-            if (outputFileHelper == null) throw new ArgumentNullException(nameof(outputFileHelper));
             if (resultsAssembler == null) throw new ArgumentNullException(nameof(resultsAssembler));
             if (targetElementLocator == null) throw new ArgumentNullException(nameof(targetElementLocator));
             if (actions == null) throw new ArgumentNullException(nameof(actions));

--- a/src/Automation/ScanToolsBuilder.cs
+++ b/src/Automation/ScanToolsBuilder.cs
@@ -24,8 +24,9 @@ namespace Axe.Windows.Automation
 
         public IScanTools Build()
         {
+            // A null file helper indicates no writing to file and as such is allowed.
             return new ScanTools(
-                _outputFileHelper ?? _factory.CreateOutputFileHelper(null),
+                    _outputFileHelper,
                     _factory.CreateResultsAssembler(),
                     _factory.CreateTargetElementLocator(),
                     _factory.CreateAxeWindowsActions(),

--- a/src/Automation/Scanner.cs
+++ b/src/Automation/Scanner.cs
@@ -17,7 +17,6 @@ namespace Axe.Windows.Automation
         {
             if (config == null) throw new ArgumentNullException(nameof(config));
             if (scanTools == null) throw new ArgumentNullException(nameof(scanTools));
-            if (scanTools.OutputFileHelper == null) throw new ArgumentException(ErrorMessages.ScanToolsOutputFileHelperNull, nameof(scanTools));
 
             _config = config;
             _scanTools = scanTools;
@@ -45,7 +44,7 @@ namespace Axe.Windows.Automation
         {
             return ExecutionWrapper.ExecuteCommand<ScanResults>(() =>
             {
-                _scanTools.OutputFileHelper.SetScanId(scanId);
+                _scanTools.OutputFileHelper?.SetScanId(scanId);
 
                 return SnapshotCommand.Execute(_config, _scanTools);
             });

--- a/src/Automation/ScannerFactory.cs
+++ b/src/Automation/ScannerFactory.cs
@@ -19,7 +19,15 @@ namespace Axe.Windows.Automation
             if (config == null) throw new ArgumentNullException(nameof(config));
 
             var scanToolsBuilder = Factory.CreateScanToolsBuilder();
-            var scanTools = scanToolsBuilder.WithOutputDirectory(config.OutputDirectory).Build();
+            IScanTools scanTools;
+            if(config.OutputFileFormat != OutputFileFormat.None)
+            {
+                scanTools = scanToolsBuilder.WithOutputDirectory(config.OutputDirectory).Build();
+            }
+            else
+            {
+                scanTools = scanToolsBuilder.Build();
+            }
             return new Scanner(config, scanTools);
         }
     } // class

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -45,7 +45,8 @@ namespace Axe.Windows.Automation
 
             var results = scanTools.ResultsAssembler.AssembleScanResultsFromElement(element);
 
-            if (results.ErrorCount > 0)
+            // Only try to create file if we have an OutputFileHelper.
+            if (results.ErrorCount > 0 && scanTools.OutputFileHelper != null)
                 results.OutputFile = WriteOutputFiles(config.OutputFileFormat, scanTools, element, elementId);
 
             return results;

--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -68,7 +68,10 @@ namespace Axe.Windows.AutomationTests
         {
             StopTestApp();
 
-            CleanupTestOutput();
+            if(Directory.Exists(OutputDir))
+            {
+                CleanupTestOutput();
+            }
         }
 
         [TestMethod]
@@ -81,25 +84,42 @@ namespace Axe.Windows.AutomationTests
 
         // [TestMethod]
         [Timeout(30000)]
-        public void Scan_Integration_Win32ControlSampler()
+        public void Scan_Integration_Win32ControlSamplerFile()
         {
             Scan_IntegrationWithFile_Core(Win32ControlSamplerAppPath, Win32ControlSamplerKnownErrorCount);
+        }
+        // [TestMethod]
+        [Timeout(30000)]
+        public void Scan_Integration_Win32ControlSamplerNoFile()
+        {
             Scan_IntegrationNoFile_Core(Win32ControlSamplerAppPath, Win32ControlSamplerKnownErrorCount);
         }
 
         [TestMethod]
         [Timeout(30000)]
-        public void Scan_Integration_WindowsFormsControlSampler()
+        public void Scan_Integration_WindowsFormsControlSamplerFile()
         {
             Scan_IntegrationWithFile_Core(WindowsFormsControlSamplerAppPath, WindowsFormsControlSamplerKnownErrorCount);
+        }
+
+        [TestMethod]
+        [Timeout(30000)]
+        public void Scan_Integration_WindowsFormsControlSamplerNoFile()
+        {
             Scan_IntegrationNoFile_Core(WindowsFormsControlSamplerAppPath, WindowsFormsControlSamplerKnownErrorCount);
         }
 
         [TestMethod]
         [Timeout(30000)]
-        public void Scan_Integration_WpfControlSampler()
+        public void Scan_Integration_WpfControlSamplerFile()
         {
             Scan_IntegrationWithFile_Core(WpfControlSamplerAppPath, WpfControlSamplerKnownErrorCount);
+        }
+
+        [TestMethod]
+        [Timeout(30000)]
+        public void Scan_Integration_WpfControlSamplerNoFile()
+        {
             Scan_IntegrationNoFile_Core(WpfControlSamplerAppPath, WpfControlSamplerKnownErrorCount);
         }
 

--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -75,7 +75,7 @@ namespace Axe.Windows.AutomationTests
         [Timeout(30000)]
         public void Scan_Integration_WildlifeManager()
         {
-            ScanResults results = Scan_Integration_Core(WildlifeManagerAppPath, WildlifeManagerKnownErrorCount);
+            ScanResults results = Scan_IntegrationWithFile_Core(WildlifeManagerAppPath, WildlifeManagerKnownErrorCount);
             EnsureGeneratedFileIsReadableByOldVersionsOfAxeWindows(results, TestProcess.Id);
         }
 
@@ -83,24 +83,27 @@ namespace Axe.Windows.AutomationTests
         [Timeout(30000)]
         public void Scan_Integration_Win32ControlSampler()
         {
-            Scan_Integration_Core(Win32ControlSamplerAppPath, Win32ControlSamplerKnownErrorCount);
+            Scan_IntegrationWithFile_Core(Win32ControlSamplerAppPath, Win32ControlSamplerKnownErrorCount);
+            Scan_IntegrationNoFile_Core(Win32ControlSamplerAppPath, Win32ControlSamplerKnownErrorCount);
         }
 
         [TestMethod]
         [Timeout(30000)]
         public void Scan_Integration_WindowsFormsControlSampler()
         {
-            Scan_Integration_Core(WindowsFormsControlSamplerAppPath, WindowsFormsControlSamplerKnownErrorCount);
+            Scan_IntegrationWithFile_Core(WindowsFormsControlSamplerAppPath, WindowsFormsControlSamplerKnownErrorCount);
+            Scan_IntegrationNoFile_Core(WindowsFormsControlSamplerAppPath, WindowsFormsControlSamplerKnownErrorCount);
         }
 
         [TestMethod]
         [Timeout(30000)]
         public void Scan_Integration_WpfControlSampler()
         {
-            Scan_Integration_Core(WpfControlSamplerAppPath, WpfControlSamplerKnownErrorCount);
+            Scan_IntegrationWithFile_Core(WpfControlSamplerAppPath, WpfControlSamplerKnownErrorCount);
+            Scan_IntegrationNoFile_Core(WpfControlSamplerAppPath, WpfControlSamplerKnownErrorCount);
         }
 
-        private ScanResults Scan_Integration_Core(string testAppPath, int expectedErrorCount)
+        private ScanResults Scan_IntegrationWithFile_Core(string testAppPath, int expectedErrorCount)
         {
             LaunchTestApp(testAppPath);
             var config = Config.Builder.ForProcessId(TestProcess.Id)
@@ -132,6 +135,23 @@ namespace Axe.Windows.AutomationTests
             {
                 Assert.IsNull(output.OutputFile.A11yTest);
             }
+
+            return output;
+        }
+        private ScanResults Scan_IntegrationNoFile_Core(string testAppPath, int expectedErrorCount)
+        {
+            LaunchTestApp(testAppPath);
+            var config = Config.Builder.ForProcessId(TestProcess.Id).WithOutputFileFormat(OutputFileFormat.None).Build();
+
+            var scanner = ScannerFactory.CreateScanner(config);
+
+            var output = ScanWithProvisionForBuildAgents(scanner);
+
+            // Validate for consistency
+            Assert.AreEqual(expectedErrorCount, output.ErrorCount);
+            Assert.AreEqual(expectedErrorCount, output.Errors.Count());
+            Assert.IsNull(output.OutputFile.A11yTest);
+            Assert.IsNull(output.OutputFile.Sarif);
 
             return output;
         }

--- a/src/AutomationTests/SnapshotCommandUnitTests.cs
+++ b/src/AutomationTests/SnapshotCommandUnitTests.cs
@@ -254,7 +254,7 @@ namespace Axe.Windows.AutomationTests
 
         [TestMethod]
         [Timeout(1000)]
-        public void Execute_NullOutputFileHelper_ThrowsException()
+        public void Execute_NullOutputFileHelper_ThrowsNoException()
         {
             _scanToolsMock.Setup(x => x.TargetElementLocator).Returns(_targetElementLocatorMock.Object);
             _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
@@ -265,9 +265,7 @@ namespace Axe.Windows.AutomationTests
             var expectedResults = new ScanResults();
             expectedResults.ErrorCount = 1;
             InitResultsCallback(expectedResults);
-            var action = new Action(() => SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object));
-            var ex = Assert.ThrowsException<ArgumentException>(action);
-            Assert.IsTrue(ex.Message.Contains("OutputFileHelper"));
+            SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object);
             _scanToolsMock.VerifyAll();
             _nativeMethodsMock.VerifyAll();
             _targetElementLocatorMock.VerifyAll();


### PR DESCRIPTION
#### Describe the change
I updated the behavior for the creation of scanner tools to also allow a null OutputfileHelper. That way, we skip creating a folder which can break if a path is not valid.

To verify that changes, I updated existing tests to also scan with no file specified and check if the scans run the same as file runs (error results wise).

Fixes #460 

Open question(s):
- Should there be a UWP test app that creates scanners?
- More generally, should there be a UWP app to scan against?