### PR TITLE
Fix: Create directory for output files only when files are requested

### DIFF
--- a/src/Automation/Interfaces/IOutputFileHelper.cs
+++ b/src/Automation/Interfaces/IOutputFileHelper.cs
@@ -6,6 +6,7 @@ namespace Axe.Windows.Automation
 {
     internal interface IOutputFileHelper
     {
+        void EnsureOutputDirectoryExists();
         string GetNewA11yTestFilePath();
         void SetScanId(string scanId);
     } // interface

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -62,6 +62,8 @@ namespace Axe.Windows.Automation
             {
                 scanTools.Actions.CaptureScreenshot(elementId);
 
+                scanTools.OutputFileHelper.EnsureOutputDirectoryExists();
+
                 a11yTestOutputFile = scanTools.OutputFileHelper.GetNewA11yTestFilePath();
                 if (a11yTestOutputFile == null) throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ErrorMessages.VariableNull, nameof(a11yTestOutputFile)));
                 

--- a/src/AutomationTests/OutputFileHelperUnitTests.cs
+++ b/src/AutomationTests/OutputFileHelperUnitTests.cs
@@ -181,6 +181,31 @@ string expectedDirectory = Path.Combine(testParam, OutputFileHelper.DefaultOutpu
 
         [TestMethod]
         [Timeout(1000)]
+        public void OutputFileHelper_EnsureOutputDirectoryExists_DoesNotCreateExistingDirectory()
+        {
+            var mockSystem = new Mock<ISystem>(MockBehavior.Strict);
+            var mockIO = new Mock<ISystemIO>(MockBehavior.Strict);
+            var mockDirectory = new Mock<ISystemIODirectory>(MockBehavior.Strict);
+            mockSystem.Setup(x => x.DateTime).Returns(InertDateTime);
+            mockSystem.Setup(x => x.Environment).Returns(InertEnvironment);
+            mockSystem.Setup(x => x.IO).Returns(mockIO.Object);
+            mockIO.Setup(x => x.Directory).Returns(mockDirectory.Object);
+
+            string directory = @"c:\NonexistentDirectory";
+            mockDirectory.Setup(x => x.Exists(directory)).Returns(true);
+
+            var outputFileHelper = new OutputFileHelper(directory, mockSystem.Object);
+            outputFileHelper.EnsureOutputDirectoryExists();
+
+            // the folowing verifies that CreateDirectory was not called
+
+            mockSystem.VerifyAll();
+            mockIO.VerifyAll();
+            mockDirectory.VerifyAll();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
         public void OutputFileHelper_EnsureOutputDirectoryExists_DoesNotCatchExceptions()
         {
             var mockSystem = new Mock<ISystem>(MockBehavior.Strict);

--- a/src/AutomationTests/OutputFileHelperUnitTests.cs
+++ b/src/AutomationTests/OutputFileHelperUnitTests.cs
@@ -111,8 +111,7 @@ namespace Axe.Windows.AutomationTests
             string testParam = @"c:\TestDir";
             mockEnvironment.Setup(x => x.CurrentDirectory).Returns(testParam);
 
-            string expectedDirectory = Path.Combine(testParam, OutputFileHelper.DefaultOutputDirectoryName);
-            mockDirectory.Setup(x => x.Exists(expectedDirectory)).Returns(true);
+string expectedDirectory = Path.Combine(testParam, OutputFileHelper.DefaultOutputDirectoryName);
 
             var outputFileHelper = new OutputFileHelper(outputDirectory: null, system: mockSystem.Object);
             string result = outputFileHelper.GetNewA11yTestFilePath();
@@ -142,7 +141,6 @@ namespace Axe.Windows.AutomationTests
             mockDateTime.Setup(x => x.Now).Returns(DateTime.Now);
 
             string expectedDirectory = @"c:\TestDir";
-            mockDirectory.Setup(x => x.Exists(expectedDirectory)).Returns(true);
 
             var outputFileHelper = new OutputFileHelper(expectedDirectory, mockSystem.Object);
             string result = outputFileHelper.GetNewA11yTestFilePath();
@@ -157,7 +155,7 @@ namespace Axe.Windows.AutomationTests
 
         [TestMethod]
         [Timeout(1000)]
-        public void OutputFileHelperCtor_CreatesNonexistentDirectory()
+        public void OutputFileHelper_EnsureOutputDirectoryExists_CreatesNonexistentDirectory()
         {
             var mockSystem = new Mock<ISystem>(MockBehavior.Strict);
             var mockIO = new Mock<ISystemIO>(MockBehavior.Strict);
@@ -172,8 +170,33 @@ namespace Axe.Windows.AutomationTests
             mockDirectory.Setup(x => x.CreateDirectory(directory)).Returns<System.IO.DirectoryInfo>(null);
 
             var outputFileHelper = new OutputFileHelper(directory, mockSystem.Object);
+            outputFileHelper.EnsureOutputDirectoryExists();
 
             // the folowing verifies that Exists was called
+
+            mockSystem.VerifyAll();
+            mockIO.VerifyAll();
+            mockDirectory.VerifyAll();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void OutputFileHelper_EnsureOutputDirectoryExists_DoesNotCatchExceptions()
+        {
+            var mockSystem = new Mock<ISystem>(MockBehavior.Strict);
+            var mockIO = new Mock<ISystemIO>(MockBehavior.Strict);
+            var mockDirectory = new Mock<ISystemIODirectory>(MockBehavior.Strict);
+            mockSystem.Setup(x => x.DateTime).Returns(InertDateTime);
+            mockSystem.Setup(x => x.Environment).Returns(InertEnvironment);
+            mockSystem.Setup(x => x.IO).Returns(mockIO.Object);
+            mockIO.Setup(x => x.Directory).Returns(mockDirectory.Object);
+
+            string directory = @"c:\NonexistentDirectory";
+            mockDirectory.Setup(x => x.Exists(directory)).Returns(false);
+            mockDirectory.Setup(x => x.CreateDirectory(directory)).Throws<Exception>();
+
+            var outputFileHelper = new OutputFileHelper(directory, mockSystem.Object);
+            Assert.ThrowsException<Exception>(() => outputFileHelper.EnsureOutputDirectoryExists());
 
             mockSystem.VerifyAll();
             mockIO.VerifyAll();
@@ -195,7 +218,6 @@ namespace Axe.Windows.AutomationTests
             mockIO.Setup(x => x.Directory).Returns(mockDirectory.Object);
 
             string directory = @"c:\TestDir";
-            mockDirectory.Setup(x => x.Exists(directory)).Returns(true);
 
             var dateTime = new DateTime(
                 year: 2019,
@@ -236,7 +258,6 @@ namespace Axe.Windows.AutomationTests
             mockIO.Setup(x => x.Directory).Returns(mockDirectory.Object);
 
             string directory = @"c:\TestDir2";
-            mockDirectory.Setup(x => x.Exists(directory)).Returns(true);
 
             var outputFileHelper = new OutputFileHelper(directory, mockSystem.Object);
             outputFileHelper.SetScanId("myScanId");

--- a/src/AutomationTests/SnapshotCommandUnitTests.cs
+++ b/src/AutomationTests/SnapshotCommandUnitTests.cs
@@ -293,6 +293,7 @@ namespace Axe.Windows.AutomationTests
 
             _actionsMock.Setup(x => x.CaptureScreenshot(It.IsAny<Guid>()));
 
+            _outputFileHelperMock.Setup(m => m.EnsureOutputDirectoryExists());
             _outputFileHelperMock.Setup(x => x.GetNewA11yTestFilePath()).Returns<string>(null);
 
             var config = Config.Builder
@@ -333,6 +334,7 @@ namespace Axe.Windows.AutomationTests
             _actionsMock.Setup(x => x.CaptureScreenshot(It.IsAny<Guid>()));
             _actionsMock.Setup(x => x.SaveA11yTestFile(expectedPath, It.IsAny<A11yElement>(), It.IsAny<Guid>()));
 
+            _outputFileHelperMock.Setup(m => m.EnsureOutputDirectoryExists());
             _outputFileHelperMock.Setup(x => x.GetNewA11yTestFilePath()).Returns(expectedPath);
 
             var config = Config.Builder


### PR DESCRIPTION
#### Describe the change

Fixes #460

This fix still allows the exception mentioned in the bug to be propagated to the user. However, the user will not encounter the exception if no output file is requested.

The OutputFileHelper class must still exist as part of the IScanTools interface even though it will not be used if no output files are requested. This helps to keep the change small and to  keep the code concise.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
