### PR TITLE
Fix: Issue #441

### DIFF
--- a/src/Core/Enums/RuleId.cs
+++ b/src/Core/Enums/RuleId.cs
@@ -244,6 +244,7 @@ namespace Axe.Windows.Core.Enums
         LocalizedControlTypeNotEmpty,
         LocalizedControlTypeNotNull,
         LocalizedControlTypeNotCustom,
+        LocalizedControlTypeNotCustomWPFGridCell,
 
         ParentChildShouldNotHaveSameNameAndLocalizedControlType,
 

--- a/src/Rules/Library/LocalizedControlTypeIsNotCustom.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotCustom.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;

--- a/src/Rules/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
@@ -4,22 +4,23 @@ using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
-using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
+using static Axe.Windows.Rules.PropertyConditions.ElementGroups;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
+using System.Globalization;
 
 namespace Axe.Windows.Rules.Library
 {
-    [RuleInfo(ID = RuleId.LocalizedControlTypeNotCustom)]
-    class LocalizedControlTypeIsNotCustom : Rule
+    [RuleInfo(ID = RuleId.LocalizedControlTypeNotCustomWPFGridCell)]
+    class LocalizedControlTypeIsNotCustomWPFGridCell : Rule
     {
-        public LocalizedControlTypeIsNotCustom()
+        public LocalizedControlTypeIsNotCustomWPFGridCell()
         {
             this.Info.Description = Descriptions.LocalizedControlTypeNotCustom;
-            this.Info.HowToFix = HowToFix.LocalizedControlTypeNotCustom;
+            this.Info.HowToFix = String.Format(CultureInfo.CurrentCulture, HowToFix.LocalizedControlTypeNotCustomWPFGridCell, HowToFix.LocalizedControlTypeNotCustom);
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
         }
@@ -33,13 +34,10 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            var dataGridDetailsPresenter = ClassName.Is("DataGridDetailsPresenter") & Parent(DataItem);
-
             return Custom
                 & IsKeyboardFocusable
                 & LocalizedControlType.NotNullOrEmpty
-                & ~dataGridDetailsPresenter
-                & ~ElementGroups.WPFDataGridCell;
+                & WPFDataGridCell;
         }
     } // class
 } // namespace

--- a/src/Rules/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
@@ -1,16 +1,15 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
-using static Axe.Windows.Rules.PropertyConditions.Relationships;
 using static Axe.Windows.Rules.PropertyConditions.ElementGroups;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
-using System.Globalization;
 
 namespace Axe.Windows.Rules.Library
 {

--- a/src/Rules/PropertyConditions/ElementGroups.cs
+++ b/src/Rules/PropertyConditions/ElementGroups.cs
@@ -36,12 +36,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         public static Condition IsControlElementTrueRequired = CreateIsControlRequiredCondition();
         public static Condition IsControlElementTrueOptional = CreateIsControlOptionalCondition();
         public static Condition EdgeDocument = Pane & StringProperties.Framework.Is(Core.Enums.Framework.Edge) & NotParent(StringProperties.Framework.Is(Core.Enums.Framework.Edge));
-        public static Condition WPFDataGridCell = CreateWPFDataGridCellCondition();
-
-        private static Condition CreateWPFDataGridCellCondition()
-        {
-            return WPF & StringProperties.ClassName.Is("DataGridCell");
-        }
+        public static Condition WPFDataGridCell = WPF & StringProperties.ClassName.Is("DataGridCell");
 
         public static Condition AllowSameNameAndControlType = CreateAllowSameNameAndControlTypeCondition();
 

--- a/src/Rules/PropertyConditions/ElementGroups.cs
+++ b/src/Rules/PropertyConditions/ElementGroups.cs
@@ -19,6 +19,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         // the following occurs for xaml expand/collapse controls
         private static Condition FocusableGroup = Group & IsKeyboardFocusable & (StringProperties.Framework.Is(Core.Enums.Framework.WPF) | StringProperties.Framework.Is(Core.Enums.Framework.XAML));
 
+        private static Condition WPF = Framework.Is(Core.Enums.Framework.WPF);
         public static Condition MinMaxCloseButton = CreateMinMaxCloseButtonCondition();
         public static Condition FocusableButton = CreateFocusableButtonCondition();
         private static Condition UnfocusableControlsBasedOnExplorer = CreateUnfocusableControlsBasedOnExplorerCondition();
@@ -35,6 +36,12 @@ namespace Axe.Windows.Rules.PropertyConditions
         public static Condition IsControlElementTrueRequired = CreateIsControlRequiredCondition();
         public static Condition IsControlElementTrueOptional = CreateIsControlOptionalCondition();
         public static Condition EdgeDocument = Pane & StringProperties.Framework.Is(Core.Enums.Framework.Edge) & NotParent(StringProperties.Framework.Is(Core.Enums.Framework.Edge));
+        public static Condition WPFDataGridCell = CreateWPFDataGridCellCondition();
+
+        private static Condition CreateWPFDataGridCellCondition()
+        {
+            return WPF & StringProperties.ClassName.Is("DataGridCell");
+        }
 
         public static Condition AllowSameNameAndControlType = CreateAllowSameNameAndControlTypeCondition();
 
@@ -150,7 +157,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         {
             return Button
                 & Parent(ScrollBar)
-                & Framework.Is(Axe.Windows.Core.Enums.Framework.WPF)
+                & WPF
                 & (AutomationID.Is("PageUp")
                 | AutomationID.Is("PageDown")
                 | AutomationID.Is("PageLeft")
@@ -201,7 +208,7 @@ namespace Axe.Windows.Rules.PropertyConditions
                 | ProgressBar | RadioButton | ScrollBar | SemanticZoom
                 | Separator | Slider | Spinner | SplitButton
                 | Tab | TabItem | Table
-                | (Text & ~StringProperties.Framework.Is(Core.Enums.Framework.WPF)) 
+                | (Text & ~WPF) 
                 | Thumb | TitleBar | ToolBar
                 | ToolTip | Tree | TreeItem | Window;
         }

--- a/src/Rules/Resources/HowToFix.Designer.cs
+++ b/src/Rules/Resources/HowToFix.Designer.cs
@@ -740,6 +740,17 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0}
+        ///    
+        ///If your application targets a version of .Net Framework before 4.7.1, but is running on a .Net version of 4.7.1 or higher, you may be able to address this issue by taking advantage of accessibility enhancements in .Net 4.7.1. To do this, you will need to enable accessibility switches as described on the following page: https://docs.microsoft.com/en-us/dotnet/framework/whats-new/whats-new-in-accessibility#accessibility-switches.
+        /// </summary>
+        internal static string LocalizedControlTypeNotCustomWPFGridCell {
+            get {
+                return ResourceManager.GetString("LocalizedControlTypeNotCustomWPFGridCell", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Provide a string for the LocalizedControlType property that concisely describes the control&apos;s type..
         /// </summary>
         internal static string LocalizedControlTypeNotEmpty {

--- a/src/Rules/Resources/HowToFix.Designer.cs
+++ b/src/Rules/Resources/HowToFix.Designer.cs
@@ -742,7 +742,7 @@ namespace Axe.Windows.Rules.Resources {
         /// <summary>
         ///   Looks up a localized string similar to {0}
         ///    
-        ///If your application targets a version of .Net Framework before 4.7.1, but is running on a .Net version of 4.7.1 or higher, you may be able to address this issue by taking advantage of accessibility enhancements in .Net 4.7.1. To do this, you will need to enable accessibility switches as described on the following page: https://docs.microsoft.com/en-us/dotnet/framework/whats-new/whats-new-in-accessibility#accessibility-switches.
+        ///If your application targets a version of .NET Framework before 4.7.1, but is running on a system where .NET version 4.7.1 or higher is installed, you may be able to address this issue by taking advantage of accessibility enhancements in .NET 4.7.1. To do this, you will need to enable accessibility switches as described on the following page: https://docs.microsoft.com/en-us/dotnet/framework/whats-new/whats-new-in-accessibility#accessibility-switches.
         /// </summary>
         internal static string LocalizedControlTypeNotCustomWPFGridCell {
             get {

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -482,7 +482,7 @@ If possible, use a predefined (non-custom) control type and the default localize
   <data name="LocalizedControlTypeNotCustomWPFGridCell" xml:space="preserve">
     <value>{0}
     
-If your application targets a version of .NET Framework before 4.7.1, but is running on a .NET version of 4.7.1 or higher, you may be able to address this issue by taking advantage of accessibility enhancements in .NET 4.7.1. To do this, you will need to enable accessibility switches as described on the following page: https://docs.microsoft.com/en-us/dotnet/framework/whats-new/whats-new-in-accessibility#accessibility-switches</value>
+If your application targets a version of .NET Framework before 4.7.1, but is running on a system where .NET version 4.7.1 or higher is installed, you may be able to address this issue by taking advantage of accessibility enhancements in .NET 4.7.1. To do this, you will need to enable accessibility switches as described on the following page: https://docs.microsoft.com/en-us/dotnet/framework/whats-new/whats-new-in-accessibility#accessibility-switches</value>
   </data>
   <data name="LocalizedControlTypeNotEmpty" xml:space="preserve">
     <value>Provide a string for the LocalizedControlType property that concisely describes the control's type.</value>

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -482,7 +482,7 @@ If possible, use a predefined (non-custom) control type and the default localize
   <data name="LocalizedControlTypeNotCustomWPFGridCell" xml:space="preserve">
     <value>{0}
     
-If your application targets a version of .Net Framework before 4.7.1, but is running on a .Net version of 4.7.1 or higher, you may be able to address this issue by taking advantage of accessibility enhancements in .Net 4.7.1. To do this, you will need to enable accessibility switches as described on the following page: https://docs.microsoft.com/en-us/dotnet/framework/whats-new/whats-new-in-accessibility#accessibility-switches</value>
+If your application targets a version of .NET Framework before 4.7.1, but is running on a .NET version of 4.7.1 or higher, you may be able to address this issue by taking advantage of accessibility enhancements in .NET 4.7.1. To do this, you will need to enable accessibility switches as described on the following page: https://docs.microsoft.com/en-us/dotnet/framework/whats-new/whats-new-in-accessibility#accessibility-switches</value>
   </data>
   <data name="LocalizedControlTypeNotEmpty" xml:space="preserve">
     <value>Provide a string for the LocalizedControlType property that concisely describes the control's type.</value>

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -479,6 +479,11 @@ Provide a string for the LocalizedControlType property that concisely describes 
 Better:
 If possible, use a predefined (non-custom) control type and the default localized control type. The UIA framework will provide the correct localized control type automatically.</value>
   </data>
+  <data name="LocalizedControlTypeNotCustomWPFGridCell" xml:space="preserve">
+    <value>{0}
+    
+If your application targets a version of .Net Framework before 4.7.1, but is running on a .Net version of 4.7.1 or higher, you may be able to address this issue by taking advantage of accessibility enhancements in .Net 4.7.1. To do this, you will need to enable accessibility switches as described on the following page: https://docs.microsoft.com/en-us/dotnet/framework/whats-new/whats-new-in-accessibility#accessibility-switches</value>
+  </data>
   <data name="LocalizedControlTypeNotEmpty" xml:space="preserve">
     <value>Provide a string for the LocalizedControlType property that concisely describes the control's type.</value>
   </data>

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
@@ -7,9 +7,9 @@ using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 namespace Axe.Windows.RulesTest.Library
 {
     [TestClass]
-    public class LocalizedControlTypeIsNotCustom
+    public class LocalizedControlTypeIsNotCustomWPFGridCell
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.LocalizedControlTypeIsNotCustom();
+        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.LocalizedControlTypeIsNotCustomWPFGridCell();
 
         private MockA11yElement CreateElementExpectedToMatchCondition()
         {
@@ -17,6 +17,8 @@ namespace Axe.Windows.RulesTest.Library
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_CustomControlTypeId;
             e.LocalizedControlType = "non-empty string";
             e.IsKeyboardFocusable = true;
+            e.Framework = Core.Enums.Framework.WPF;
+            e.ClassName = "DataGridCell";
 
             return e;
         }
@@ -35,8 +37,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = CreateElementExpectedToMatchCondition();
 
             int[] custom = { ControlType.Custom };
-            foreach (var ct in ControlType.All.
-                Except(custom))
+            foreach (var ct in ControlType.All.Except(custom))
             {
                 e.ControlTypeId = ct;
                 Assert.IsFalse(this.Rule.Condition.Matches(e));
@@ -71,24 +72,19 @@ namespace Axe.Windows.RulesTest.Library
         }
 
         [TestMethod]
-        public void ElementIsDataGridDetailsPresenter()
+        public void ElementClassNameDoesNotMatch()
         {
-            var parent = new MockA11yElement();
-            parent.ControlTypeId = ControlType.DataItem;
-
             var e = CreateElementExpectedToMatchCondition();
-            e.ClassName = "DataGridDetailsPresenter";
-            e.Parent = parent;
+            e.ClassName = string.Empty;
 
             Assert.IsFalse(this.Rule.Condition.Matches(e));
         }
 
         [TestMethod]
-        public void ElementIsWPFDataGridCell()
+        public void ElementFrameworkDoesNotMatch()
         {
             var e = CreateElementExpectedToMatchCondition();
-            e.ClassName = "DataGridCell";
-            e.Framework = Core.Enums.Framework.WPF;
+            e.Framework = string.Empty;
 
             Assert.IsFalse(this.Rule.Condition.Matches(e));
         }
@@ -103,7 +99,7 @@ namespace Axe.Windows.RulesTest.Library
         }
 
         [TestMethod]
-        public void LocalizedControlTypeIsNotCustomTest()
+        public void LocalizedControlTypeIsNotCustom()
         {
             var e = new MockA11yElement();
             e.LocalizedControlType = "not custom";

--- a/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
+++ b/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
@@ -16,7 +16,7 @@ namespace Axe.Windows.RulesTest.PropertyConditions
 
         public ElementGroupsTests()
         {
-            this.AllowSameNameAndControlTypeTypes = new int[]{ AppBar, Custom, Header, MenuBar, SemanticZoom, StatusBar, TitleBar, Text };
+            this.AllowSameNameAndControlTypeTypes = new int[] { AppBar, Custom, Header, MenuBar, SemanticZoom, StatusBar, TitleBar, Text };
             this.DisallowSameNameAndControlTypeTypes = ControlType.All.Difference(AllowSameNameAndControlTypeTypes);
         }
 
@@ -198,6 +198,24 @@ namespace Axe.Windows.RulesTest.PropertyConditions
                 e.Parent = parent;
 
                 Assert.IsFalse(ElementGroups.WPFScrollBarPageButtons.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void WPFDataGridCell_MatcheAsExpected()
+        {
+            using (var e = new MockA11yElement())
+            {
+                Assert.IsFalse(ElementGroups.WPFDataGridCell.Matches(e));
+
+                e.Framework = "WPF";
+                Assert.IsFalse(ElementGroups.WPFDataGridCell.Matches(e));
+
+                e.ClassName = "DataGridCell";
+                Assert.IsTrue(ElementGroups.WPFDataGridCell.Matches(e));
+
+                e.Framework = string.Empty;
+                Assert.IsFalse(ElementGroups.WPFDataGridCell.Matches(e));
             } // using
         }
     } // class

--- a/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
+++ b/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
@@ -202,7 +202,7 @@ namespace Axe.Windows.RulesTest.PropertyConditions
         }
 
         [TestMethod]
-        public void WPFDataGridCell_MatcheAsExpected()
+        public void WPFDataGridCell_MatchExpected()
         {
             using (var e = new MockA11yElement())
             {


### PR DESCRIPTION
#### Describe the change

Add extra how-to-fix information about accessibility switches in the case where the `ControlType` property is `Custom`, the `Framework` is "WPF", and the `ClassName` is "DataGridCell". The how-to-fix information in question applies to .Net versions older than 4.7.1.

To do this, I created a new rule: `LocalizedControlTypeIsNotCustomWPFGridCell`. The new rule should apply in the same cases as `LocalizedControlTypeIsNotCustom`, but only if the platform is `WPF` and the `ClassName` is `DataGridCell`. The existing rule, `LocalizedControlTypeIsNotCustom`, should not be run in the case of a WPF DataGridCell.

I used string formatting for the htf info to avoid duplicating text in documentation which could become mismatched.

I reworked the unit tests in LocalizedControlTypeIsNotCustom.cs a bit to (hopefully) make them a little more robust and a little easier to understand.

