### PR TITLE
Fix: Issue #471

### DIFF
--- a/src/Rules/Library/NameExcludesLocalizedControlType.cs
+++ b/src/Rules/Library/NameExcludesLocalizedControlType.cs
@@ -38,7 +38,7 @@ namespace Axe.Windows.Rules.Library
         {
             return ~ElementGroups.AllowSameNameAndControlType
                 & Name.NotNullOrEmpty & Name.NotWhiteSpace
-                & StringProperties.LocalizedControlType.NotNullOrEmpty & StringProperties.LocalizedControlType.NotWhiteSpace;
+                & LocalizedControlType.NotNullOrEmpty & LocalizedControlType.NotWhiteSpace;
         }
     } // class
 } // namespace

--- a/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
+++ b/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
@@ -63,6 +63,42 @@ namespace Axe.Windows.RulesTest.PropertyConditions
         }
 
         [TestMethod]
+        public void AllowSameNameAndControlType_True_EdgeEdit()
+        {
+            var e = new MockA11yElement();
+            e.ControlTypeId = Edit;
+            e.Framework = Core.Enums.Framework.Edge;
+
+            Assert.IsFalse(ElementGroups.AllowSameNameAndControlType.Matches(e));
+
+            string[] allowedLocalizedControlTypes = { "password", "email" };
+
+            foreach (var lct in allowedLocalizedControlTypes)
+            {
+                e.LocalizedControlType = lct;
+                Assert.IsTrue(ElementGroups.AllowSameNameAndControlType.Matches(e));
+            } // for each type
+        }
+
+        [TestMethod]
+        public void AllowSameNameAndControlType_False_EditButNotEdge()
+        {
+            var e = new MockA11yElement();
+            e.ControlTypeId = Edit;
+            e.LocalizedControlType = "password";
+            Assert.IsFalse(ElementGroups.AllowSameNameAndControlType.Matches(e));
+        }
+
+        [TestMethod]
+        public void AllowSameNameAndControlType_False_EdgeButNotEdit()
+        {
+            var e = new MockA11yElement();
+            e.Framework = Core.Enums.Framework.Edge;
+            e.LocalizedControlType = "password";
+            Assert.IsFalse(ElementGroups.AllowSameNameAndControlType.Matches(e));
+        }
+
+        [TestMethod]
         public void WPFScrollBarPageUpButton_True()
         {
             using (var e = new MockA11yElement())


### PR DESCRIPTION
#### Describe the change

The change is to allow edit controls in older versions of Edge (before Anaheim) to have the same name and localized control type when the LCT is either "password" or "email". Note: "email" is not specifically called out in the bug, but it is a similar issue we've received through support channels.

Also, Updated the existing unit tests for `NameExcludesLocalizedControlType` just a touch to be a little more robust.

