### PR TITLE
fix: Correct the description for the NameIsInformative rule

### DIFF
--- a/src/Rules/Resources/Descriptions.Designer.cs
+++ b/src/Rules/Resources/Descriptions.Designer.cs
@@ -799,7 +799,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Name property must not include its class name..
+        ///   Looks up a localized string similar to The name property of an element should not contain class names like &apos;Microsoft.*.*&apos; or &apos;Windows.*.*&apos; as these are not usually informative..
         /// </summary>
         internal static string NameIsInformative {
             get {

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -397,7 +397,7 @@
     <value>The Name must not include the same text as the LocalizedControlType.</value>
   </data>
   <data name="NameIsInformative" xml:space="preserve">
-    <value>The Name property must not include its class name.</value>
+    <value>The name property of an element should not contain class names like 'Microsoft.*.*' or 'Windows.*.*' as these are not usually informative.</value>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">
     <value>The Name property of a focusable element must not be an empty string.</value>


### PR DESCRIPTION
#### Describe the change

In https://github.com/Microsoft/accessibility-insights-windows/commit/c2cc94dd2cf596dfd4324891572514a80508394f, the `NameIsInformative` description was incorrectly modified as follows:

Original Value | Modified Value
--- | ---
The name property of an element should not contain class names like 'Microsoft.*.*' or 'Windows.*.*' as these are not usually informative. | The Name property must not include its class name.

This PR restores the description to its original value.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
