### PR TITLE
Chore: Rename Core.Enums.Framework to Core.Enums.FrameworkId

### DIFF
--- a/src/Core/Enums/FrameworkId.cs
+++ b/src/Core/Enums/FrameworkId.cs
@@ -1,8 +1,9 @@
+
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 namespace Axe.Windows.Core.Enums
 {
-    public static class Framework
+    public static class FrameworkId
     {
         public const string DirectUI = "DirectUI";
         public const string Edge = "MicrosoftEdge";

--- a/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
+++ b/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
@@ -542,7 +542,7 @@ namespace Axe.Windows.Desktop.UIAutomation
 
         private static bool IsEdgeElement(this IA11yElement e)
         {
-            return e.Framework == Axe.Windows.Core.Enums.Framework.Edge;
+            return e.Framework == Axe.Windows.Core.Enums.FrameworkId.Edge;
         }
     }
 }

--- a/src/Rules/Extensions/ExtensionMethods.cs
+++ b/src/Rules/Extensions/ExtensionMethods.cs
@@ -29,9 +29,9 @@ namespace Axe.Windows.Rules.Extensions
             if (e.ControlTypeId != Axe.Windows.Core.Types.ControlType.UIA_TabItemControlTypeId)
                 return false;
 
-            var framework = e.GetUIFramework();
-            return framework == Framework.WPF
-                || framework == Framework.XAML;
+            var frameworkId = e.GetUIFramework();
+            return frameworkId == FrameworkId.WPF
+                || frameworkId == FrameworkId.XAML;
         }
 
         public static T GetPropertyValueOrDefault<T>(this IA11yElement e, int propertyId)

--- a/src/Rules/Library/BoundingRectangleNotNull.cs
+++ b/src/Rules/Library/BoundingRectangleNotNull.cs
@@ -31,7 +31,7 @@ namespace Axe.Windows.Rules.Library
             var sysmenuitem = ControlType.MenuItem & Relationships.Parent(sysmenubar);
 
             // This exception is meant to apply to the non-Chromium version of Edge
-            var edgeGroups = ControlType.Group & StringProperties.Framework.Is(Framework.Edge);
+            var edgeGroups = ControlType.Group & StringProperties.Framework.Is(FrameworkId.Edge);
 
             // the Bounding rectangle property might be empty due to
             // a non-existent property, or an invalid data format.

--- a/src/Rules/Library/BoundingRectangleOnWPFTextParent.cs
+++ b/src/Rules/Library/BoundingRectangleOnWPFTextParent.cs
@@ -28,7 +28,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return Parent(Text) & StringProperties.Framework.Is(Core.Enums.Framework.WPF);
+            return Parent(Text) & StringProperties.Framework.Is(Core.Enums.FrameworkId.WPF);
         }
     } // class
 } // namespace

--- a/src/Rules/Library/ControlShouldNotSupportInvokePattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportInvokePattern.cs
@@ -28,7 +28,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return AppBar | (TabItem & ~StringProperties.Framework.Is(Framework.Edge));
+            return AppBar | (TabItem & ~StringProperties.Framework.Is(FrameworkId.Edge));
         }
     } // class
 } // namespace

--- a/src/Rules/Library/ControlShouldSupportSetInfoWPF.cs
+++ b/src/Rules/Library/ControlShouldSupportSetInfoWPF.cs
@@ -33,7 +33,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return PropertyConditions.StringProperties.Framework.Is(Core.Enums.Framework.WPF) & (ListItem | TreeItem);
+            return PropertyConditions.StringProperties.Framework.Is(Core.Enums.FrameworkId.WPF) & (ListItem | TreeItem);
         }
     }
 }

--- a/src/Rules/Library/ControlShouldSupportSetInfoXAML.cs
+++ b/src/Rules/Library/ControlShouldSupportSetInfoXAML.cs
@@ -33,7 +33,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return PropertyConditions.StringProperties.Framework.Is(Core.Enums.Framework.XAML) & (ListItem | TreeItem);
+            return PropertyConditions.StringProperties.Framework.Is(Core.Enums.FrameworkId.XAML) & (ListItem | TreeItem);
         }
     }
 }

--- a/src/Rules/Library/ControlShouldSupportTablePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTablePattern.cs
@@ -30,7 +30,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return (Calendar | Table) & ~StringProperties.Framework.Is(Framework.Edge);
+            return (Calendar | Table) & ~StringProperties.Framework.Is(FrameworkId.Edge);
         }
     } // class
 } // namespace

--- a/src/Rules/Library/ControlShouldSupportTablePatternInEdge.cs
+++ b/src/Rules/Library/ControlShouldSupportTablePatternInEdge.cs
@@ -30,7 +30,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return (Calendar | Table) & StringProperties.Framework.Is(Framework.Edge);
+            return (Calendar | Table) & StringProperties.Framework.Is(FrameworkId.Edge);
         }
     } // class
 } // namespace

--- a/src/Rules/Library/ControlShouldSupportTextPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTextPattern.cs
@@ -29,8 +29,8 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            var win32Edit = Edit & StringProperties.Framework.Is(Framework.Win32);
-            var nonfocusableDirectUIEdit = Edit & ~IsKeyboardFocusable & StringProperties.Framework.Is(Framework.DirectUI);
+            var win32Edit = Edit & StringProperties.Framework.Is(FrameworkId.Win32);
+            var nonfocusableDirectUIEdit = Edit & ~IsKeyboardFocusable & StringProperties.Framework.Is(FrameworkId.DirectUI);
 
             return Document
                 | (Edit

--- a/src/Rules/Library/IsKeyboardFocusableTopLevelTextPattern.cs
+++ b/src/Rules/Library/IsKeyboardFocusableTopLevelTextPattern.cs
@@ -35,7 +35,7 @@ namespace Axe.Windows.Rules.Library
                 & Patterns.Text 
                 & Patterns.TextSelectionSupported
                 & NoAncestor(Patterns.Text)
-                & ~(StringProperties.Framework.Is(Core.Enums.Framework.XAML) & ControlType.Text); // UWP case, Text control may have Text pattern without keyboard focus.
+                & ~(StringProperties.Framework.Is(Core.Enums.FrameworkId.XAML) & ControlType.Text); // UWP case, Text control may have Text pattern without keyboard focus.
         }
     } // class
 } // namespace

--- a/src/Rules/Library/LandmarkNoDuplicateBanner.cs
+++ b/src/Rules/Library/LandmarkNoDuplicateBanner.cs
@@ -25,7 +25,7 @@ namespace Axe.Windows.Rules.Library
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            var edge = StringProperties.Framework.Is(Core.Enums.Framework.Edge);
+            var edge = StringProperties.Framework.Is(Core.Enums.FrameworkId.Edge);
             var landmark = Landmarks.Banner & (edge | IsNotOffScreen);
             var condition = DescendantCount(landmark) <= 1;
             return  condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;

--- a/src/Rules/Library/LandmarkNoDuplicateContentInfo.cs
+++ b/src/Rules/Library/LandmarkNoDuplicateContentInfo.cs
@@ -25,7 +25,7 @@ namespace Axe.Windows.Rules.Library
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            var edge = StringProperties.Framework.Is(Core.Enums.Framework.Edge);
+            var edge = StringProperties.Framework.Is(Core.Enums.FrameworkId.Edge);
             var landmark = Landmarks.ContentInfo & (edge | IsNotOffScreen);
             var condition = DescendantCount(landmark) <= 1;
             return condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;

--- a/src/Rules/Library/LandmarkOneMain.cs
+++ b/src/Rules/Library/LandmarkOneMain.cs
@@ -30,7 +30,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return Pane & StringProperties.Framework.Is(Core.Enums.Framework.Edge) & NotParent(StringProperties.Framework.Is(Core.Enums.Framework.Edge));
+            return Pane & StringProperties.Framework.Is(Core.Enums.FrameworkId.Edge) & NotParent(StringProperties.Framework.Is(Core.Enums.FrameworkId.Edge));
         }
     } // class
 } // namespace

--- a/src/Rules/Library/SelectionPatternSelectionRequired.cs
+++ b/src/Rules/Library/SelectionPatternSelectionRequired.cs
@@ -39,7 +39,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return Tab & Patterns.Selection & ~StringProperties.Framework.Is(Framework.Edge);
+            return Tab & Patterns.Selection & ~StringProperties.Framework.Is(FrameworkId.Edge);
         }
     } // class
 } // namespace

--- a/src/Rules/Library/SiblingUniqueAndFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndFocusable.cs
@@ -55,7 +55,7 @@ namespace Axe.Windows.Rules.Library
         protected override Condition CreateCondition()
         {
             var wpfDataItem = DataItem
-                & StringProperties.Framework.Is(Core.Enums.Framework.WPF)
+                & StringProperties.Framework.Is(Core.Enums.FrameworkId.WPF)
                 & NoChild(Custom | Name.NullOrEmpty);
 
             return EligibleChild & NotParent(wpfDataItem);

--- a/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
@@ -54,7 +54,7 @@ namespace Axe.Windows.Rules.Library
         protected override Condition CreateCondition()
         {
             var wpfDataItem = DataItem
-                & StringProperties.Framework.Is(Core.Enums.Framework.WPF)
+                & StringProperties.Framework.Is(Core.Enums.FrameworkId.WPF)
                 & NoChild(Custom | Name.NullOrEmpty);
 
             return EligibleChild & NotParent(wpfDataItem);

--- a/src/Rules/PropertyConditions/ElementGroups.cs
+++ b/src/Rules/PropertyConditions/ElementGroups.cs
@@ -17,10 +17,10 @@ namespace Axe.Windows.Rules.PropertyConditions
     static class ElementGroups
     {
         // the following occurs for xaml expand/collapse controls
-        private static Condition FocusableGroup = Group & IsKeyboardFocusable & (StringProperties.Framework.Is(Core.Enums.Framework.WPF) | StringProperties.Framework.Is(Core.Enums.Framework.XAML));
+        private static Condition FocusableGroup = Group & IsKeyboardFocusable & (StringProperties.Framework.Is(Core.Enums.FrameworkId.WPF) | StringProperties.Framework.Is(Core.Enums.FrameworkId.XAML));
 
-        private static Condition WPF = Framework.Is(Core.Enums.Framework.WPF);
-        private static Condition Edge = Framework.Is(Core.Enums.Framework.Edge);
+        private static Condition WPF = StringProperties.Framework.Is(Core.Enums.FrameworkId.WPF);
+        private static Condition Edge = StringProperties.Framework.Is(Core.Enums.FrameworkId.Edge);
         public static Condition MinMaxCloseButton = CreateMinMaxCloseButtonCondition();
         public static Condition FocusableButton = CreateFocusableButtonCondition();
         private static Condition UnfocusableControlsBasedOnExplorer = CreateUnfocusableControlsBasedOnExplorerCondition();
@@ -169,7 +169,7 @@ namespace Axe.Windows.Rules.PropertyConditions
 
         private static bool IsParentWPFDataItem(IA11yElement e)
         {
-            return e.GetUIFramework() == Core.Enums.Framework.WPF
+            return e.GetUIFramework() == Core.Enums.FrameworkId.WPF
                 && e.Parent != null
                 && e.Parent.ControlTypeId == Axe.Windows.Core.Types.ControlType.UIA_DataItemControlTypeId;
         }
@@ -191,7 +191,7 @@ namespace Axe.Windows.Rules.PropertyConditions
 
         private static bool IsPlatformWinForms(IA11yElement e)
         {
-            return e?.Framework == Core.Enums.Framework.WinForm;
+            return e?.Framework == Core.Enums.FrameworkId.WinForm;
         }
 
         private static Condition CreateIsControlRequiredCondition()

--- a/src/Rules/PropertyConditions/UWP.cs
+++ b/src/Rules/PropertyConditions/UWP.cs
@@ -7,7 +7,7 @@ namespace Axe.Windows.Rules.PropertyConditions
 {
     static class UWP
     {
-        public static Condition TopLevelElement = StringProperties.Framework.Is(Core.Enums.Framework.XAML) & NotParent(StringProperties.Framework.Is(Core.Enums.Framework.XAML));
+        public static Condition TopLevelElement = StringProperties.Framework.Is(Core.Enums.FrameworkId.XAML) & NotParent(StringProperties.Framework.Is(Core.Enums.FrameworkId.XAML));
         public static Condition TitleBar = CreateTitleBarCondition();
         public static Condition MenuBar = CreateMenuBarCondition();
 
@@ -15,14 +15,14 @@ namespace Axe.Windows.Rules.PropertyConditions
         {
             var automationID = AutomationID.Is("TitleBar") | AutomationID.Is("TitleBarLeftButtons");
             var className = ClassName.Is("ApplicationFrameTitleBarWindow");
-            var framework = StringProperties.Framework.Is(Core.Enums.Framework.Win32);
+            var framework = StringProperties.Framework.Is(Core.Enums.FrameworkId.Win32);
             return automationID & className & framework;
         }
 
         private static Condition CreateMenuBarCondition()
         {
             var automationID = AutomationID.Is("SystemMenuBar");
-            var parentFramework = Relationships.Parent(StringProperties.Framework.Is(Core.Enums.Framework.Win32));
+            var parentFramework = Relationships.Parent(StringProperties.Framework.Is(Core.Enums.FrameworkId.Win32));
             return automationID & parentFramework;
         }
     } // class

--- a/src/RulesTest/Library/BoundingRectangleContainedInParentTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleContainedInParentTest.cs
@@ -78,7 +78,7 @@ namespace Axe.Windows.RulesTest.Library
 
                 grandParent.BoundingRectangle = e.BoundingRectangle;
                 grandParent.ControlTypeId = Tab;
-                grandParent.Framework = Framework.WPF;
+                grandParent.Framework = FrameworkId.WPF;
 
                 e.Parent = parent;
                 parent.Parent = grandParent;

--- a/src/RulesTest/Library/BoundingRectangleNotNullTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotNullTest.cs
@@ -108,7 +108,7 @@ namespace Axe.Windows.RulesTest.Library
             using (var parent = new MockA11yElement())
             {
                 parent.ControlTypeId = ControlType.Slider;
-                e.Framework = Framework.Edge;
+                e.Framework = FrameworkId.Edge;
                 e.ControlTypeId = ControlType.Group;
                 parent.Children.Add(e);
                 e.Parent = parent;

--- a/src/RulesTest/Library/ControlShouldNotSupportInvokePattern.cs
+++ b/src/RulesTest/Library/ControlShouldNotSupportInvokePattern.cs
@@ -16,7 +16,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_TabItemControlTypeId;
-            e.Framework = Framework.Win32;
+            e.Framework = FrameworkId.Win32;
 
             Assert.IsTrue(Rule.Condition.Matches(e));
         }
@@ -26,7 +26,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_TabControlTypeId;
-            e.Framework = Framework.Edge;
+            e.Framework = FrameworkId.Edge;
 
             Assert.IsFalse(Rule.Condition.Matches(e));
         }

--- a/src/RulesTest/Library/ControlShouldSupportSetInfoWPFTest.cs
+++ b/src/RulesTest/Library/ControlShouldSupportSetInfoWPFTest.cs
@@ -52,7 +52,7 @@ namespace Axe.Windows.RulesTest.Library
             IEnumerable<int> unexpectedControlTypes = ControlType.All.Difference(expectedControlTypes);
 
             var e = new MockA11yElement();
-            e.Framework = Framework.WPF;
+            e.Framework = FrameworkId.WPF;
 
             foreach (var ct in expectedControlTypes)
             {
@@ -70,8 +70,8 @@ namespace Axe.Windows.RulesTest.Library
         [TestMethod]
         public void TestControlShouldSupportSetInfoWPFExpectedPlatform()
         {
-            string[] expectedFrameworks = { Framework.WPF };
-            string[] unexpectedFrameworks = { Framework.DirectUI, Framework.Edge, Framework.InternetExplorer, Framework.Win32, Framework.WinForm, Framework.XAML };
+            string[] expectedFrameworks = { FrameworkId.WPF };
+            string[] unexpectedFrameworks = { FrameworkId.DirectUI, FrameworkId.Edge, FrameworkId.InternetExplorer, FrameworkId.Win32, FrameworkId.WinForm, FrameworkId.XAML };
 
             var e = new MockA11yElement();
             e.ControlTypeId = ControlType.ListItem;

--- a/src/RulesTest/Library/ControlShouldSupportSetInfoXAMLTest.cs
+++ b/src/RulesTest/Library/ControlShouldSupportSetInfoXAMLTest.cs
@@ -52,7 +52,7 @@ namespace Axe.Windows.RulesTest.Library
             IEnumerable<int> unexpectedControlTypes = ControlType.All.Difference(expectedControlTypes);
 
             var e = new MockA11yElement();
-            e.Framework = Framework.XAML;
+            e.Framework = FrameworkId.XAML;
 
             foreach (var ct in expectedControlTypes)
             {
@@ -70,8 +70,8 @@ namespace Axe.Windows.RulesTest.Library
         [TestMethod]
         public void TestControlShouldSupportSetInfoXAMLExpectedPlatform()
         {
-            string[] expectedFrameworks = { Framework.XAML };
-            string[] unexpectedFrameworks = { Framework.DirectUI, Framework.Edge, Framework.InternetExplorer, Framework.Win32, Framework.WinForm, Framework.WPF };
+            string[] expectedFrameworks = { FrameworkId.XAML };
+            string[] unexpectedFrameworks = { FrameworkId.DirectUI, FrameworkId.Edge, FrameworkId.InternetExplorer, FrameworkId.Win32, FrameworkId.WinForm, FrameworkId.WPF };
 
             var e = new MockA11yElement();
             e.ControlTypeId = ControlType.ListItem;

--- a/src/RulesTest/Library/ControlShouldSupportTablePattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTablePattern.cs
@@ -66,7 +66,7 @@ namespace Axe.Windows.RulesTest.Library
             }
 
             e.ControlTypeId = expectedTypes[0];
-            e.Framework = Framework.Edge;
+            e.Framework = FrameworkId.Edge;
 
             Assert.IsFalse(Rule.Condition.Matches(e));
         }

--- a/src/RulesTest/Library/ControlShouldSupportTablePatternInEdge.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTablePatternInEdge.cs
@@ -52,7 +52,7 @@ namespace Axe.Windows.RulesTest.Library
             var unexpectedTypes = ControlType.All.Difference(expectedTypes);
             
             var e = new MockA11yElement();
-            e.Framework = Framework.Edge;
+            e.Framework = FrameworkId.Edge;
 
             foreach (var type in expectedTypes)
             {

--- a/src/RulesTest/Library/ControlShouldSupportTextPatternUnitTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTextPatternUnitTests.cs
@@ -54,7 +54,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.ControlTypeId = ControlType.Edit;
-            e.Framework = Framework.Win32;
+            e.Framework = FrameworkId.Win32;
 
             Assert.IsFalse(Rule.Condition.Matches(e));
         }
@@ -64,7 +64,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.ControlTypeId = ControlType.Edit;
-            e.Framework = Framework.DirectUI;
+            e.Framework = FrameworkId.DirectUI;
             e.IsKeyboardFocusable = false;
 
             Assert.IsFalse(Rule.Condition.Matches(e));

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotCustom.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotCustom.cs
@@ -88,7 +88,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = CreateElementExpectedToMatchCondition();
             e.ClassName = "DataGridCell";
-            e.Framework = Core.Enums.Framework.WPF;
+            e.Framework = Core.Enums.FrameworkId.WPF;
 
             Assert.IsFalse(this.Rule.Condition.Matches(e));
         }

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
@@ -17,7 +17,7 @@ namespace Axe.Windows.RulesTest.Library
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_CustomControlTypeId;
             e.LocalizedControlType = "non-empty string";
             e.IsKeyboardFocusable = true;
-            e.Framework = Core.Enums.Framework.WPF;
+            e.Framework = Core.Enums.FrameworkId.WPF;
             e.ClassName = "DataGridCell";
 
             return e;

--- a/src/RulesTest/Library/NameExcludesLocalizedControlType.cs
+++ b/src/RulesTest/Library/NameExcludesLocalizedControlType.cs
@@ -107,7 +107,7 @@ namespace Axe.Windows.RulesTest.Library
             e.LocalizedControlType = "not empty";
 
             e.ControlTypeId = ControlType.Edit;
-            e.Framework = Core.Enums.Framework.Edge;
+            e.Framework = Core.Enums.FrameworkId.Edge;
 
             Assert.IsTrue(Rule.Condition.Matches(e));
 
@@ -138,7 +138,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Name = "not empty";
 
-            e.Framework = Core.Enums.Framework.Edge;
+            e.Framework = Core.Enums.FrameworkId.Edge;
             e.LocalizedControlType = "password";
 
             Assert.IsTrue(Rule.Condition.Matches(e));

--- a/src/RulesTest/Library/SelectionPatternSelectionRequired.cs
+++ b/src/RulesTest/Library/SelectionPatternSelectionRequired.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_TabControlTypeId;
             e.Patterns.Add(new A11yPattern(e, PatternType.UIA_SelectionPatternId));
-            e.Framework = Framework.Win32;
+            e.Framework = FrameworkId.Win32;
 
             Assert.IsTrue(Rule.Condition.Matches(e));
         }
@@ -30,7 +30,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_TabControlTypeId;
             e.Patterns.Add(new A11yPattern(e, PatternType.UIA_SelectionPatternId));
-            e.Framework = Framework.Edge;
+            e.Framework = FrameworkId.Edge;
 
             Assert.IsFalse(Rule.Condition.Matches(e));
         }

--- a/src/RulesTest/Library/UWPTest.cs
+++ b/src/RulesTest/Library/UWPTest.cs
@@ -16,7 +16,7 @@ namespace Axe.Windows.RulesTest.Library
             {
                 e.AutomationId = "TitleBarLeftButtons";
                 e.ClassName = "ApplicationFrameTitleBarWindow";
-                e.Framework = Framework.Win32;
+                e.Framework = FrameworkId.Win32;
 
                 Assert.IsTrue(UWP.TitleBar.Matches(e));
             } // using
@@ -29,7 +29,7 @@ namespace Axe.Windows.RulesTest.Library
             {
                 // e.AutomationID = "TitleBarLeftButtons";
                 e.ClassName = "ApplicationFrameTitleBarWindow";
-                e.Framework = Framework.Win32;
+                e.Framework = FrameworkId.Win32;
 
                 Assert.IsFalse(UWP.TitleBar.Matches(e));
             } // using
@@ -42,7 +42,7 @@ namespace Axe.Windows.RulesTest.Library
             {
                 e.AutomationId = "TitleBarLeftButtons";
                 // e.ClassName = "ApplicationFrameTitleBarWindow";
-                e.Framework = Framework.Win32;
+                e.Framework = FrameworkId.Win32;
 
                 Assert.IsFalse(UWP.TitleBar.Matches(e));
             } // using
@@ -70,7 +70,7 @@ namespace Axe.Windows.RulesTest.Library
                 e.Parent = parent;
 
                 e.AutomationId = "SystemMenuBar";
-                parent.Framework = Framework.Win32;
+                parent.Framework = FrameworkId.Win32;
 
                 Assert.IsTrue(UWP.MenuBar.Matches(e));
             } // using
@@ -85,7 +85,7 @@ namespace Axe.Windows.RulesTest.Library
                 e.Parent = parent;
 
                 // e.AutomationID = "SystemMenuBar";
-                parent.Framework = Framework.Win32;
+                parent.Framework = FrameworkId.Win32;
 
                 Assert.IsFalse(UWP.MenuBar.Matches(e));
             } // using

--- a/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
+++ b/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
@@ -67,7 +67,7 @@ namespace Axe.Windows.RulesTest.PropertyConditions
         {
             var e = new MockA11yElement();
             e.ControlTypeId = Edit;
-            e.Framework = Core.Enums.Framework.Edge;
+            e.Framework = Core.Enums.FrameworkId.Edge;
 
             Assert.IsFalse(ElementGroups.AllowSameNameAndControlType.Matches(e));
 
@@ -93,7 +93,7 @@ namespace Axe.Windows.RulesTest.PropertyConditions
         public void AllowSameNameAndControlType_False_EdgeButNotEdit()
         {
             var e = new MockA11yElement();
-            e.Framework = Core.Enums.Framework.Edge;
+            e.Framework = Core.Enums.FrameworkId.Edge;
             e.LocalizedControlType = "password";
             Assert.IsFalse(ElementGroups.AllowSameNameAndControlType.Matches(e));
         }

--- a/src/RulesTest/PropertyConditions/NameTest.cs
+++ b/src/RulesTest/PropertyConditions/NameTest.cs
@@ -160,7 +160,7 @@ public void TestCustomWithDisallowedParents()
     using (var e = new MockA11yElement())
     {
         e.ControlTypeId = Custom;
-        e.Framework = Framework.WPF;
+        e.Framework = FrameworkId.WPF;
         e.Parent = parent;
         parent.ControlTypeId = DataItem;
 
@@ -268,7 +268,7 @@ public void TestElementsWithNoSiblingsOfSameControlType()
             using (var e = new MockA11yElement())
             {
                 e.ControlTypeId = Text;
-                e.Framework = Framework.WinForm;
+                e.Framework = FrameworkId.WinForm;
                 Assert.IsTrue(Misc.NameRequired.Matches(e));
 
                 var prop = new A11yProperty(PlatformPropertyType.Platform_WindowsExtendedStylePropertyId, WS_EX_STATICEDGE);


### PR DESCRIPTION
#### Describe the change

This rename is a precursor to a refactor which will replace code like

`StringProperties.Framework.Is(Core.Enums.Framework.XAML)`

with code like

`XAML`

The intent is to place prefabricated conditions such as `XAML` and `WPF` in a static class called `Framework`. You'll notice that this new class' name clashes with the existing `Core.Enums.Framework`. Trying to add aliases for both classes in many files turned out to be difficult and confusing. Hence the rename.

