### PR TITLE
Chore: Replace lengthy framework conditions with shorter ones

### DIFF
--- a/src/Rules/Library/BoundingRectangleNotNull.cs
+++ b/src/Rules/Library/BoundingRectangleNotNull.cs
@@ -6,6 +6,7 @@ using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ElementGroups;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 
 namespace Axe.Windows.Rules.Library
 {
@@ -31,7 +32,7 @@ namespace Axe.Windows.Rules.Library
             var sysmenuitem = ControlType.MenuItem & Relationships.Parent(sysmenubar);
 
             // This exception is meant to apply to the non-Chromium version of Edge
-            var edgeGroups = ControlType.Group & StringProperties.Framework.Is(FrameworkId.Edge);
+            var edgeGroups = ControlType.Group & Edge;
 
             // the Bounding rectangle property might be empty due to
             // a non-existent property, or an invalid data format.

--- a/src/Rules/Library/BoundingRectangleOnWPFTextParent.cs
+++ b/src/Rules/Library/BoundingRectangleOnWPFTextParent.cs
@@ -6,6 +6,7 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 
 namespace Axe.Windows.Rules.Library
@@ -28,7 +29,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return Parent(Text) & StringProperties.Framework.Is(Core.Enums.FrameworkId.WPF);
+            return Parent(Text) & WPF;
         }
     } // class
 } // namespace

--- a/src/Rules/Library/ControlShouldNotSupportInvokePattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportInvokePattern.cs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 
 namespace Axe.Windows.Rules.Library
 {
@@ -28,7 +29,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return AppBar | (TabItem & ~StringProperties.Framework.Is(FrameworkId.Edge));
+            return AppBar | (TabItem & ~Edge);
         }
     } // class
 } // namespace

--- a/src/Rules/Library/ControlShouldSupportSetInfoWPF.cs
+++ b/src/Rules/Library/ControlShouldSupportSetInfoWPF.cs
@@ -4,8 +4,9 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;
 using System;
-using static Axe.Windows.Rules.PropertyConditions.IntProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
+using static Axe.Windows.Rules.PropertyConditions.IntProperties;
 
 namespace Axe.Windows.Rules.Library
 {
@@ -33,7 +34,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return PropertyConditions.StringProperties.Framework.Is(Core.Enums.FrameworkId.WPF) & (ListItem | TreeItem);
+            return WPF & (ListItem | TreeItem);
         }
     }
 }

--- a/src/Rules/Library/ControlShouldSupportSetInfoXAML.cs
+++ b/src/Rules/Library/ControlShouldSupportSetInfoXAML.cs
@@ -4,8 +4,9 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;
 using System;
-using static Axe.Windows.Rules.PropertyConditions.IntProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
+using static Axe.Windows.Rules.PropertyConditions.IntProperties;
 
 namespace Axe.Windows.Rules.Library
 {
@@ -33,7 +34,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return PropertyConditions.StringProperties.Framework.Is(Core.Enums.FrameworkId.XAML) & (ListItem | TreeItem);
+            return XAML & (ListItem | TreeItem);
         }
     }
 }

--- a/src/Rules/Library/ControlShouldSupportTablePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTablePattern.cs
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 
 namespace Axe.Windows.Rules.Library
 {
@@ -30,7 +31,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return (Calendar | Table) & ~StringProperties.Framework.Is(FrameworkId.Edge);
+            return (Calendar | Table) & ~Edge;
         }
     } // class
 } // namespace

--- a/src/Rules/Library/ControlShouldSupportTablePatternInEdge.cs
+++ b/src/Rules/Library/ControlShouldSupportTablePatternInEdge.cs
@@ -7,6 +7,7 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 
 namespace Axe.Windows.Rules.Library
 {
@@ -30,7 +31,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return (Calendar | Table) & StringProperties.Framework.Is(FrameworkId.Edge);
+            return (Calendar | Table) & Edge;
         }
     } // class
 } // namespace

--- a/src/Rules/Library/ControlShouldSupportTextPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTextPattern.cs
@@ -7,6 +7,7 @@ using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 
 namespace Axe.Windows.Rules.Library
 {
@@ -29,8 +30,8 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            var win32Edit = Edit & StringProperties.Framework.Is(FrameworkId.Win32);
-            var nonfocusableDirectUIEdit = Edit & ~IsKeyboardFocusable & StringProperties.Framework.Is(FrameworkId.DirectUI);
+            var win32Edit = Edit & Win32Framework;
+            var nonfocusableDirectUIEdit = Edit & ~IsKeyboardFocusable & DirectUI;
 
             return Document
                 | (Edit

--- a/src/Rules/Library/IsKeyboardFocusableTopLevelTextPattern.cs
+++ b/src/Rules/Library/IsKeyboardFocusableTopLevelTextPattern.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
+using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 
 namespace Axe.Windows.Rules.Library
@@ -35,7 +37,7 @@ namespace Axe.Windows.Rules.Library
                 & Patterns.Text 
                 & Patterns.TextSelectionSupported
                 & NoAncestor(Patterns.Text)
-                & ~(StringProperties.Framework.Is(Core.Enums.FrameworkId.XAML) & ControlType.Text); // UWP case, Text control may have Text pattern without keyboard focus.
+                & ~(XAML & Text); // UWP case, Text control may have Text pattern without keyboard focus.
         }
     } // class
 } // namespace

--- a/src/Rules/Library/LandmarkNoDuplicateBanner.cs
+++ b/src/Rules/Library/LandmarkNoDuplicateBanner.cs
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ElementGroups;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 
 namespace Axe.Windows.Rules.Library
@@ -25,8 +26,7 @@ namespace Axe.Windows.Rules.Library
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            var edge = StringProperties.Framework.Is(Core.Enums.FrameworkId.Edge);
-            var landmark = Landmarks.Banner & (edge | IsNotOffScreen);
+            var landmark = Landmarks.Banner & (Edge | IsNotOffScreen);
             var condition = DescendantCount(landmark) <= 1;
             return  condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
         }

--- a/src/Rules/Library/LandmarkNoDuplicateContentInfo.cs
+++ b/src/Rules/Library/LandmarkNoDuplicateContentInfo.cs
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ElementGroups;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 
 namespace Axe.Windows.Rules.Library
@@ -25,8 +26,7 @@ namespace Axe.Windows.Rules.Library
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            var edge = StringProperties.Framework.Is(Core.Enums.FrameworkId.Edge);
-            var landmark = Landmarks.ContentInfo & (edge | IsNotOffScreen);
+            var landmark = Landmarks.ContentInfo & (Edge | IsNotOffScreen);
             var condition = DescendantCount(landmark) <= 1;
             return condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
         }

--- a/src/Rules/Library/LandmarkOneMain.cs
+++ b/src/Rules/Library/LandmarkOneMain.cs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 
 namespace Axe.Windows.Rules.Library
@@ -30,7 +31,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return Pane & StringProperties.Framework.Is(Core.Enums.FrameworkId.Edge) & NotParent(StringProperties.Framework.Is(Core.Enums.FrameworkId.Edge));
+            return Pane & Edge & NotParent(Edge);
         }
     } // class
 } // namespace

--- a/src/Rules/Library/SelectionPatternSelectionRequired.cs
+++ b/src/Rules/Library/SelectionPatternSelectionRequired.cs
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 
 namespace Axe.Windows.Rules.Library
 {
@@ -39,7 +40,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return Tab & Patterns.Selection & ~StringProperties.Framework.Is(FrameworkId.Edge);
+            return Tab & Patterns.Selection & ~Edge;
         }
     } // class
 } // namespace

--- a/src/Rules/Library/SiblingUniqueAndFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndFocusable.cs
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
-using Axe.Windows.Rules.Resources;
 using Axe.Windows.Rules.PropertyConditions;
+using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
@@ -55,7 +56,7 @@ namespace Axe.Windows.Rules.Library
         protected override Condition CreateCondition()
         {
             var wpfDataItem = DataItem
-                & StringProperties.Framework.Is(Core.Enums.FrameworkId.WPF)
+                & WPF
                 & NoChild(Custom | Name.NullOrEmpty);
 
             return EligibleChild & NotParent(wpfDataItem);

--- a/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
-using Axe.Windows.Rules.Resources;
 using Axe.Windows.Rules.PropertyConditions;
+using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
@@ -54,7 +55,7 @@ namespace Axe.Windows.Rules.Library
         protected override Condition CreateCondition()
         {
             var wpfDataItem = DataItem
-                & StringProperties.Framework.Is(Core.Enums.FrameworkId.WPF)
+                & WPF
                 & NoChild(Custom | Name.NullOrEmpty);
 
             return EligibleChild & NotParent(wpfDataItem);

--- a/src/Rules/PropertyConditions/ElementGroups.cs
+++ b/src/Rules/PropertyConditions/ElementGroups.cs
@@ -168,7 +168,6 @@ namespace Axe.Windows.Rules.PropertyConditions
 
         private static bool IsParentWPFDataItem(IA11yElement e)
         {
-
             // GetUIFramework searches the ancestors for a valid framework value in addition to checking the element itself
             return e.GetUIFramework() == Core.Enums.FrameworkId.WPF
                 && e.Parent != null

--- a/src/Rules/PropertyConditions/ElementGroups.cs
+++ b/src/Rules/PropertyConditions/ElementGroups.cs
@@ -5,6 +5,7 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
@@ -17,10 +18,8 @@ namespace Axe.Windows.Rules.PropertyConditions
     static class ElementGroups
     {
         // the following occurs for xaml expand/collapse controls
-        private static Condition FocusableGroup = Group & IsKeyboardFocusable & (StringProperties.Framework.Is(Core.Enums.FrameworkId.WPF) | StringProperties.Framework.Is(Core.Enums.FrameworkId.XAML));
+        private static Condition FocusableGroup = Group & IsKeyboardFocusable & (WPF | XAML);
 
-        private static Condition WPF = StringProperties.Framework.Is(Core.Enums.FrameworkId.WPF);
-        private static Condition Edge = StringProperties.Framework.Is(Core.Enums.FrameworkId.Edge);
         public static Condition MinMaxCloseButton = CreateMinMaxCloseButtonCondition();
         public static Condition FocusableButton = CreateFocusableButtonCondition();
         private static Condition UnfocusableControlsBasedOnExplorer = CreateUnfocusableControlsBasedOnExplorerCondition();
@@ -169,6 +168,8 @@ namespace Axe.Windows.Rules.PropertyConditions
 
         private static bool IsParentWPFDataItem(IA11yElement e)
         {
+
+            // GetUIFramework searches the ancestors for a valid framework value in addition to checking the element itself
             return e.GetUIFramework() == Core.Enums.FrameworkId.WPF
                 && e.Parent != null
                 && e.Parent.ControlTypeId == Axe.Windows.Core.Types.ControlType.UIA_DataItemControlTypeId;
@@ -176,7 +177,7 @@ namespace Axe.Windows.Rules.PropertyConditions
 
         private static bool HasAllowedPlatformPropertiesForText(IA11yElement e)
         {
-            return !IsPlatformWinForms(e)
+            return !WinForms.Matches(e)
                 || !HasStaticEdgeExtendedStyle(e);
         }
 
@@ -187,11 +188,6 @@ namespace Axe.Windows.Rules.PropertyConditions
             const uint WS_EX_STATICEDGE = 0x00020000;
 
             return (platformProperty & WS_EX_STATICEDGE) != 0;
-        }
-
-        private static bool IsPlatformWinForms(IA11yElement e)
-        {
-            return e?.Framework == Core.Enums.FrameworkId.WinForm;
         }
 
         private static Condition CreateIsControlRequiredCondition()

--- a/src/Rules/PropertyConditions/Framework.cs
+++ b/src/Rules/PropertyConditions/Framework.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Enums;
+
+namespace Axe.Windows.Rules.PropertyConditions
+{
+    static class Framework
+    {
+        public static readonly Condition DirectUI = StringProperties.Framework.Is(FrameworkId.DirectUI);
+        public static readonly Condition Edge = StringProperties.Framework.Is(FrameworkId.Edge);
+        // The following name includes "Framework" to avoid clashing with the Win32 namespace
+        public static readonly Condition Win32Framework = StringProperties.Framework.Is(FrameworkId.Win32);
+        public static readonly Condition WinForms = StringProperties.Framework.Is(FrameworkId.WinForm);
+        public static readonly Condition WPF = StringProperties.Framework.Is(FrameworkId.WPF);
+        public static readonly Condition XAML = StringProperties.Framework.Is(FrameworkId.XAML);
+    } // class
+} // namespace

--- a/src/Rules/PropertyConditions/UWP.cs
+++ b/src/Rules/PropertyConditions/UWP.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
@@ -7,7 +8,7 @@ namespace Axe.Windows.Rules.PropertyConditions
 {
     static class UWP
     {
-        public static Condition TopLevelElement = StringProperties.Framework.Is(Core.Enums.FrameworkId.XAML) & NotParent(StringProperties.Framework.Is(Core.Enums.FrameworkId.XAML));
+        public static Condition TopLevelElement = XAML & NotParent(XAML);
         public static Condition TitleBar = CreateTitleBarCondition();
         public static Condition MenuBar = CreateMenuBarCondition();
 
@@ -15,15 +16,13 @@ namespace Axe.Windows.Rules.PropertyConditions
         {
             var automationID = AutomationID.Is("TitleBar") | AutomationID.Is("TitleBarLeftButtons");
             var className = ClassName.Is("ApplicationFrameTitleBarWindow");
-            var framework = StringProperties.Framework.Is(Core.Enums.FrameworkId.Win32);
-            return automationID & className & framework;
+            return automationID & className & Win32Framework;
         }
 
         private static Condition CreateMenuBarCondition()
         {
             var automationID = AutomationID.Is("SystemMenuBar");
-            var parentFramework = Relationships.Parent(StringProperties.Framework.Is(Core.Enums.FrameworkId.Win32));
-            return automationID & parentFramework;
+            return automationID & Parent(Win32Framework);
         }
     } // class
 } // namespace


### PR DESCRIPTION
#### Describe the change

This replaces a `Condition` statement in a rule like

`StringProperties.Framework.Is(FrameworkId.Edge)`

with

`Edge`

This makes the code easier to comprehend.

<!-- Please provide an overview of the change in this PR -->

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
