### PR TITLE
Fix: #485 NameIsInformative false positive in Win32 apps

### DIFF
--- a/src/Rules/Library/NameIsInformative.cs
+++ b/src/Rules/Library/NameIsInformative.cs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Text.RegularExpressions;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System.Text.RegularExpressions;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.Rules.Library
@@ -41,6 +42,7 @@ namespace Axe.Windows.Rules.Library
         protected override Condition CreateCondition()
         {
             return Name.NotNullOrEmpty & Name.NotWhiteSpace & BoundingRectangle.Valid
+                & ~Win32Framework
                 & ( ElementGroups.NameRequired | ElementGroups.NameOptional);
         }
     } // class

--- a/src/RulesTest/Library/NameIsInformative.cs
+++ b/src/RulesTest/Library/NameIsInformative.cs
@@ -10,6 +10,16 @@ namespace Axe.Windows.RulesTest.Library
     {
         private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.NameIsInformative();
 
+        private static MockA11yElement CreateMatchingElement()
+        {
+            var e = new MockA11yElement();
+            e.ControlTypeId = ControlType.ListItem;
+            e.Name = "Mando";
+            e.BoundingRectangle = new System.Drawing.Rectangle(0, 0, 25, 25);
+
+            return e;
+        }
+
         [TestMethod]
         public void NameMatchesDotNetType()
         {
@@ -52,6 +62,53 @@ namespace Axe.Windows.RulesTest.Library
                     Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
                 }
             } // using
+        }
+
+        [TestMethod]
+        public void MatchesExpectedElement()
+        {
+            var e = CreateMatchingElement();
+            Assert.IsTrue(Rule.Condition.Matches(e));
+        }
+
+        [TestMethod]
+        public void NameNull_DoesNotMatch()
+        {
+            var e = CreateMatchingElement();
+            e.Name = null;
+            Assert.IsFalse(Rule.Condition.Matches(e));
+        }
+
+        [TestMethod]
+        public void NameEmpty_DoesNotMatch()
+        {
+            var e = CreateMatchingElement();
+            e.Name = string.Empty;
+            Assert.IsFalse(Rule.Condition.Matches(e));
+        }
+
+        [TestMethod]
+        public void NameWhiteSpace_DoesNotMatch()
+        {
+            var e = CreateMatchingElement();
+            e.Name = "   ";
+            Assert.IsFalse(Rule.Condition.Matches(e));
+        }
+
+        [TestMethod]
+        public void BoundingRectInvalid_DoesNotMatch()
+        {
+            var e = CreateMatchingElement();
+            e.BoundingRectangle = new System.Drawing.Rectangle();
+            Assert.IsFalse(Rule.Condition.Matches(e));
+        }
+
+        [TestMethod]
+        public void FrameworkWind32_DoesNotMatch()
+        {
+            var e = CreateMatchingElement();
+            e.Framework = Core.Enums.FrameworkId.Win32;
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
     } // class
 } // namespace


### PR DESCRIPTION
#### Describe the change

Fixes issue #485.

This rule is intended to catch an accessibility error in older versions of .Net frameworks where controls such as lists would have there item names automatically generated and they would be given the name of their .Net class, such as "Microsoft.Controls.ListItem", instead of an informative accessible name.

It is possible to have legitimate names for controls which violate this rule. Because this is rare, we consider occasionally having a possible false positive for this rule acceptable. However, the accessibility problem described above never happened in the Win32 framework. Therefore, we're disabling this rule for Win32.

The astute observer will notice that while I added unit tests for most of the properties used to match the rule, I did not add unit tests for `ElementGroups.NameRequired | ElementGroups.NameOptional`. The reason is these two conditions are quite large and deserve their own separate unit tests. And while such tests unfortunately do not exist at this time, it seemed beyond the scope of this change to add them.

