### PR TITLE
fix: Update www.access-board.gov links with current URL

### DIFF
--- a/src/RuleSelection/Resources/DefaultGuidelineUrls.Designer.cs
+++ b/src/RuleSelection/Resources/DefaultGuidelineUrls.Designer.cs
@@ -61,7 +61,7 @@ namespace Axe.Windows.RuleSelection.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/final-rule/single-file-version#502-interoperability-assistive-technology.
+        ///   Looks up a localized string similar to https://www.access-board.gov/ict/#502-interoperability-assistive-technology.
         /// </summary>
         internal static string AvailableActions {
             get {
@@ -97,7 +97,7 @@ namespace Axe.Windows.RuleSelection.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/final-rule/single-file-version#502-interoperability-assistive-technology.
+        ///   Looks up a localized string similar to https://www.access-board.gov/ict/#502-interoperability-assistive-technology.
         /// </summary>
         internal static string ObjectInformation {
             get {

--- a/src/RuleSelection/Resources/DefaultGuidelineUrls.resx
+++ b/src/RuleSelection/Resources/DefaultGuidelineUrls.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AvailableActions" xml:space="preserve">
-    <value>https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/final-rule/single-file-version#502-interoperability-assistive-technology</value>
+    <value>https://www.access-board.gov/ict/#502-interoperability-assistive-technology</value>
   </data>
   <data name="InfoAndRelationships" xml:space="preserve">
     <value>https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html</value>
@@ -130,6 +130,6 @@
     <value>https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-rsv.html</value>
   </data>
   <data name="ObjectInformation" xml:space="preserve">
-    <value>https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/final-rule/single-file-version#502-interoperability-assistive-technology</value>
+    <value>https://www.access-board.gov/ict/#502-interoperability-assistive-technology</value>
   </data>
 </root>

--- a/src/Rules/A11yCriteriaId.cs
+++ b/src/Rules/A11yCriteriaId.cs
@@ -25,12 +25,12 @@ namespace Axe.Windows.Rules
         NameRoleValue,
 
         /// <summary>
-        /// See <a href="https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/final-rule/single-file-version#502-interoperability-assistive-technology">the Access Board documentation</a>
+        /// See <a href="https://www.access-board.gov/ict/#502-interoperability-assistive-technology">the Access Board documentation</a>
         /// </summary>
         ObjectInformation,
 
         /// <summary>
-        /// See <a href="https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/final-rule/single-file-version#502-interoperability-assistive-technology">the Access Board documentation</a>
+        /// See <a href="https://www.access-board.gov/ict/#502-interoperability-assistive-technology">the Access Board documentation</a>
         /// </summary>
         AvailableActions,
     } // class


### PR DESCRIPTION
#### Describe the change
We noticed in AI-Windows that sometime late last year, the www.access-board.gov site we link to changed. Now, our links are redirected to the correct page, but the fragment bringing you to the right place on the page is lost. You can see the full repro steps in this AI-Win issue: https://github.com/microsoft/accessibility-insights-windows/issues/1017.

This PR fixes the issue by updating the URL. These were the only places in either repo referencing access-board.gov.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
