### PR TITLE
chore(deps): Update nuspec file to reflect updated dependencies

### DIFF
--- a/src/CI/Axe.Windows.nuspec
+++ b/src/CI/Axe.Windows.nuspec
@@ -17,9 +17,9 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="Newtonsoft.Json" version="12.0.3" />
-        <dependency id="Microsoft.Win32.Registry" version="4.7.0" />
-        <dependency id="System.Drawing.Common" version="4.7.0" />
-        <dependency id="System.IO.Packaging" version="4.7.0" />
+        <dependency id="Microsoft.Win32.Registry" version="5.0.0" />
+        <dependency id="System.Drawing.Common" version="5.0.0" />
+        <dependency id="System.IO.Packaging" version="5.0.0" />
       </group>
     </dependencies>
     <releaseNotes>https://github.com/microsoft/axe-windows/releases</releaseNotes>


### PR DESCRIPTION
#### Describe the change

We failed to update the nuspec file to reflect the following changes:
- Microsoft.Win32.Registry was bumped to version 5.0.0 in #465 
- System.Drawing.Common was bumped to version 5.0.0 in #466 
- System.IO.Packaging was bumped to version 5.0.0 in #467 

When we consume Axe.Windows 1.0.5, the transitive dependencies get lost, which generates build warnings (and potential for more significant bugs).

This PR updates the nuspec file. I've already consumed it into AIWin and confirmed that this fixes the build warnings. My recommendation would be to release this as 1.0.6, even though we have no code changes between the builds.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
