### PR TITLE
Chore: Update some rules to use the new PassesTest method instead of Evaluate

### DIFF
--- a/src/Rules/Library/BoundingRectangleCompletelyObscuresContainer.cs
+++ b/src/Rules/Library/BoundingRectangleCompletelyObscuresContainer.cs
@@ -21,13 +21,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.BoundingRectangleCompletelyObscuresContainer;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return BoundingRectangle.CompletelyObscuresContainer.Matches(e) ? EvaluationCode.Error : EvaluationCode.Pass;
+            return !BoundingRectangle.CompletelyObscuresContainer.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/BoundingRectangleContainedInParent.cs
+++ b/src/Rules/Library/BoundingRectangleContainedInParent.cs
@@ -26,9 +26,10 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.BoundingRectangleContainedInParent;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
@@ -37,10 +38,10 @@ namespace Axe.Windows.Rules.Library
                 // if the element is not contained in the parent element, go further 
                 var container = e.FindContainerElement();
 
-                return IsBoundingRectangleContained(container, e) ? EvaluationCode.Pass : EvaluationCode.Warning;
+                return IsBoundingRectangleContained(container, e);
             }
 
-            return EvaluationCode.Pass;
+            return true;
         }
 
         private static bool IsBoundingRectangleContained(IA11yElement container, IA11yElement containee)

--- a/src/Rules/Library/BoundingRectangleDataFormatCorrect.cs
+++ b/src/Rules/Library/BoundingRectangleDataFormatCorrect.cs
@@ -18,11 +18,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.BoundingRectangleDataFormatCorrect;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return BoundingRectangle.CorrectDataFormat.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return BoundingRectangle.CorrectDataFormat.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/BoundingRectangleNotAllZeros.cs
+++ b/src/Rules/Library/BoundingRectangleNotAllZeros.cs
@@ -18,11 +18,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.BoundingRectangleNotAllZeros;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return BoundingRectangle.Empty.Matches(e) ? EvaluationCode.Error : EvaluationCode.Pass;
+            return !BoundingRectangle.Empty.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/BoundingRectangleNotNull.cs
+++ b/src/Rules/Library/BoundingRectangleNotNull.cs
@@ -19,11 +19,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.PropertyID = Axe.Windows.Core.Types.PropertyType.UIA_BoundingRectanglePropertyId;
             this.Info.Description = Descriptions.BoundingRectangleNotNull;
             this.Info.HowToFix = HowToFix.BoundingRectangleNotNull;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return BoundingRectangle.NotNull.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return BoundingRectangle.NotNull.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/BoundingRectangleNotValidButOffScreen.cs
+++ b/src/Rules/Library/BoundingRectangleNotValidButOffScreen.cs
@@ -18,11 +18,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.BoundingRectangleNotValidButOffScreen;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return EvaluationCode.Note;
+            return false;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/BoundingRectangleOnUWPMenuBar.cs
+++ b/src/Rules/Library/BoundingRectangleOnUWPMenuBar.cs
@@ -18,11 +18,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.BoundingRectangleOnUWPMenuBar;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Open;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return BoundingRectangle.NotEmpty.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Open;
+            return BoundingRectangle.NotEmpty.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/BoundingRectangleOnUWPMenuItem.cs
+++ b/src/Rules/Library/BoundingRectangleOnUWPMenuItem.cs
@@ -20,11 +20,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.BoundingRectangleOnUWPMenuItem;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Open;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return BoundingRectangle.NotEmpty.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Open;
+            return BoundingRectangle.NotEmpty.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/BoundingRectangleOnWPFTextParent.cs
+++ b/src/Rules/Library/BoundingRectangleOnWPFTextParent.cs
@@ -20,11 +20,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.BoundingRectangleOnWPFTextParent;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Open;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return BoundingRectangle.NotEmpty.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Open;
+            return BoundingRectangle.NotEmpty.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/BoundingRectangleSizeReasonable.cs
+++ b/src/Rules/Library/BoundingRectangleSizeReasonable.cs
@@ -21,11 +21,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.BoundingRectangleSizeReasonable;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return BoundingRectangle.Valid.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return BoundingRectangle.Valid.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/RulesTest/Library/BoundingRectangleCompletelyObscuresContainerTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleCompletelyObscuresContainerTest.cs
@@ -5,7 +5,6 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -38,7 +37,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Parent = parent;
 
             Assert.IsTrue(Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -56,7 +55,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Parent = parent;
 
             Assert.IsTrue(Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -74,7 +73,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Parent = parent;
 
             Assert.IsTrue(Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -92,7 +91,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Parent = parent;
 
             Assert.IsTrue(Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -110,7 +109,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Parent = parent;
 
             Assert.IsTrue(Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -128,7 +127,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Parent = parent;
 
             Assert.IsTrue(Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -146,7 +145,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Parent = parent;
 
             Assert.IsTrue(Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -164,7 +163,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Parent = parent;
 
             Assert.IsTrue(Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/BoundingRectangleContainedInParentTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleContainedInParentTest.cs
@@ -7,7 +7,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 using static Axe.Windows.RulesTest.ControlType;
 
 
@@ -34,7 +33,7 @@ namespace Axe.Windows.RulesTest.Library
 
                 e.Parent = parent;
 
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -58,7 +57,7 @@ namespace Axe.Windows.RulesTest.Library
                 e.Parent = parent;
                 parent.Parent = grandParent;
 
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -83,7 +82,7 @@ namespace Axe.Windows.RulesTest.Library
                 e.Parent = parent;
                 parent.Parent = grandParent;
 
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -108,7 +107,7 @@ namespace Axe.Windows.RulesTest.Library
                 e.Parent = parent;
                 parent.Parent = grandparent;
 
-                Assert.AreEqual(EvaluationCode.Warning, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
 
@@ -132,7 +131,7 @@ namespace Axe.Windows.RulesTest.Library
                 e.Parent = parent;
                 parent.Parent = grandParent;
 
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -154,7 +153,7 @@ namespace Axe.Windows.RulesTest.Library
 
                 e.Parent = parent;
 
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -173,7 +172,7 @@ namespace Axe.Windows.RulesTest.Library
 
                 e.Parent = parent;
 
-                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
 
@@ -192,7 +191,7 @@ namespace Axe.Windows.RulesTest.Library
 
                 e.Parent = parent;
 
-                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
 
@@ -211,7 +210,7 @@ namespace Axe.Windows.RulesTest.Library
 
                 e.Parent = parent;
 
-                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
 
@@ -230,14 +229,14 @@ namespace Axe.Windows.RulesTest.Library
 
                 e.Parent = parent;
 
-                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
 
         [TestMethod]
         public void TestBoundingRectangleContainedInParentElementNullFail()
         {
-            Action action = () => Rule.Evaluate(null);
+            Action action = () => Rule.PassesTest(null);
             Assert.ThrowsException<ArgumentNullException>(action);
         }
 
@@ -246,7 +245,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             using (var e = new MockA11yElement())
             {
-                Action action = () => Rule.Evaluate(e);
+                Action action = () => Rule.PassesTest(e);
                 Assert.ThrowsException<ArgumentNullException>(action);
             } // using
         }
@@ -270,7 +269,7 @@ namespace Axe.Windows.RulesTest.Library
             parent.Patterns.Add(pattern);
             e.Parent = parent;
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -292,7 +291,7 @@ namespace Axe.Windows.RulesTest.Library
             parent.Patterns.Add(pattern);
             e.Parent = parent;
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/BoundingRectangleDataFormatCorrectTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleDataFormatCorrectTest.cs
@@ -3,7 +3,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -19,7 +18,7 @@ namespace Axe.Windows.RulesTest.Library
             {
                 var p = new A11yProperty(PropertyType.UIA_BoundingRectanglePropertyId, new double[] {  1, 2, 3, 4 });
                 e.Properties.Add(PropertyType.UIA_BoundingRectanglePropertyId, p);
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -30,7 +29,7 @@ namespace Axe.Windows.RulesTest.Library
             {
                 var p = new A11yProperty(PropertyType.UIA_BoundingRectanglePropertyId, new double[] { 1, 2, 3 });
                 e.Properties.Add(PropertyType.UIA_BoundingRectanglePropertyId, p);
-                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
 
@@ -41,7 +40,7 @@ namespace Axe.Windows.RulesTest.Library
             {
                 var p = new A11yProperty(PropertyType.UIA_BoundingRectanglePropertyId, new int[] { 1, 2, 3, 4 });
                 e.Properties.Add(PropertyType.UIA_BoundingRectanglePropertyId, p);
-                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
 
@@ -50,7 +49,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             using (var e = new MockA11yElement())
             {
-                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
     } // class

--- a/src/RulesTest/Library/BoundingRectangleNotAllZerosTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotAllZerosTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -16,7 +15,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.BoundingRectangle = new Rectangle(0, 0, 0, 1);
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -24,7 +23,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.BoundingRectangle = new Rectangle(0, 0, 0, 0);
-            Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/BoundingRectangleNotNullTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotNullTest.cs
@@ -3,7 +3,6 @@
 using Axe.Windows.Core.Enums;
 using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -18,7 +17,7 @@ namespace Axe.Windows.RulesTest.Library
             using (var e = new MockA11yElement())
             {
                 e.BoundingRectangle = Rectangle.Empty;
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -27,7 +26,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             using (var e = new MockA11yElement())
             {
-                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
 

--- a/src/RulesTest/Library/BoundingRectangleNotValidButOffScreenTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotValidButOffScreenTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -13,7 +12,7 @@ namespace Axe.Windows.RulesTest.Library
         [TestMethod]
         public void TestBoundingRectangleNotValidButOffScreenInformation()
         {
-            Assert.AreEqual(EvaluationCode.Note, Rule.Evaluate(null));
+            Assert.IsFalse(Rule.PassesTest(null));
         }
     }
 }

--- a/src/RulesTest/Library/BoundingRectangleOnUWPMenuBarTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleOnUWPMenuBarTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -18,7 +17,7 @@ namespace Axe.Windows.RulesTest.Library
             {
                 e.BoundingRectangle = new Rectangle(0, 0, 2, 2);
 
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -27,7 +26,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             using (var e = new MockA11yElement())
             {
-                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
     } // class

--- a/src/RulesTest/Library/BoundingRectangleOnUWPMenuItemTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleOnUWPMenuItemTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -17,7 +16,7 @@ namespace Axe.Windows.RulesTest.Library
             {
                 e.BoundingRectangle = new Rectangle(0, 0, 2, 2);
 
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -26,7 +25,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             using (var e = new MockA11yElement())
             {
-                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
     } // class

--- a/src/RulesTest/Library/BoundingRectangleOnWPFTextParentTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleOnWPFTextParentTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -18,7 +17,7 @@ namespace Axe.Windows.RulesTest.Library
             {
                 e.BoundingRectangle = new Rectangle(0, 0, 2, 2);
 
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -27,7 +26,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             using (var e = new MockA11yElement())
             {
-                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
     } // class

--- a/src/RulesTest/Library/BoundingRectangleSizeReasonableTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleSizeReasonableTest.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -20,7 +19,7 @@ namespace Axe.Windows.RulesTest.Library
             using (var e = new MockA11yElement())
             {
                 e.BoundingRectangle = rect;
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -30,7 +29,7 @@ namespace Axe.Windows.RulesTest.Library
             using (var e = new MockA11yElement())
             {
                 e.BoundingRectangle = Rectangle.Empty;
-                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
 
@@ -40,14 +39,14 @@ namespace Axe.Windows.RulesTest.Library
             using (var e = new MockA11yElement())
             {
                 e.BoundingRectangle = new Rectangle(0, 0, 12, 2);
-                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
 
         [TestMethod]
         public void TestBoundingRectangleSizeReasonableArgumentException()
         {
-            Action action = () => Rule.Evaluate(null);
+            Action action = () => Rule.PassesTest(null);
             Assert.ThrowsException<ArgumentNullException>(action);
         }
 


### PR DESCRIPTION
#### Describe the change

Adding the evaluation code to the rule's info will allow us to automatically generate documentation which provides the rule's expected error code.

