### PR TITLE
Chore: Update more rules to use the new PassesTest method instead of Evaluate

### DIFF
--- a/src/Rules/Library/ButtonInvokeAndExpandeCollapsePatterns.cs
+++ b/src/Rules/Library/ButtonInvokeAndExpandeCollapsePatterns.cs
@@ -16,13 +16,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ButtonInvokeAndExpandCollapsePatterns;
             this.Info.HowToFix = HowToFix.ButtonInvokeAndExpandCollapsePatterns;
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             var rule = Relationships.All(Patterns.Invoke, Patterns.ExpandCollapse);
 
-            return rule.Matches(e) ? EvaluationCode.Warning : EvaluationCode.Pass;
+            return !rule.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ButtonInvokeAndTogglePatterns.cs
+++ b/src/Rules/Library/ButtonInvokeAndTogglePatterns.cs
@@ -16,13 +16,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ButtonInvokeAndTogglePatterns;
             this.Info.HowToFix = HowToFix.ButtonInvokeAndTogglePatterns;
             this.Info.Standard = A11yCriteriaId.NameRoleValue;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            var rule = Relationships.All(Patterns.Invoke, Patterns.Toggle);
+            var rule = ~(Relationships.All(Patterns.Invoke, Patterns.Toggle));
 
-            return rule.Matches(e) ? EvaluationCode.Error : EvaluationCode.Pass;
+            return rule.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ButtonShouldHavePatterns.cs
+++ b/src/Rules/Library/ButtonShouldHavePatterns.cs
@@ -17,15 +17,16 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ButtonShouldHavePatterns;
             this.Info.HowToFix = HowToFix.ButtonShouldHavePatterns;
             this.Info.Standard = A11yCriteriaId.NameRoleValue;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var condition = Relationships.Any(Patterns.ExpandCollapse, Patterns.Invoke, Patterns.Toggle);
 
-            return condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return condition.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ButtonToggleAndExpandeCollapsePatterns.cs
+++ b/src/Rules/Library/ButtonToggleAndExpandeCollapsePatterns.cs
@@ -16,13 +16,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ButtonToggleAndExpandCollapsePatterns;
             this.Info.HowToFix = HowToFix.ButtonToggleAndExpandCollapsePatterns;
             this.Info.Standard = A11yCriteriaId.NameRoleValue;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            var rule = Relationships.All(Patterns.Toggle, Patterns.ExpandCollapse);
+            var rule = ~(Relationships.All(Patterns.Toggle, Patterns.ExpandCollapse));
 
-            return rule.Matches(e) ? EvaluationCode.Error : EvaluationCode.Pass;
+            return rule.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/RulesTest/Library/ButtonInvokeAndExpandCollapsePatterns.cs
+++ b/src/RulesTest/Library/ButtonInvokeAndExpandCollapsePatterns.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 using Axe.Windows.Core.Types;
 
 namespace Axe.Windows.RulesTest.Library
@@ -39,7 +38,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         /// <summary>
@@ -56,7 +55,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_InvokePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         /// <summary>
@@ -73,7 +72,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_TogglePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         /// <summary>
@@ -91,7 +90,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_InvokePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Warning, this.Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
     }
 } 

--- a/src/RulesTest/Library/ButtonInvokeAndTogglePatterns.cs
+++ b/src/RulesTest/Library/ButtonInvokeAndTogglePatterns.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 using Axe.Windows.Core.Types;
 
 namespace Axe.Windows.RulesTest.Library
@@ -39,7 +38,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         /// <summary>
@@ -56,7 +55,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_InvokePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         /// <summary>
@@ -73,7 +72,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_TogglePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         /// <summary>
@@ -91,7 +90,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_InvokePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Error, this.Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
     }
 } 

--- a/src/RulesTest/Library/ButtonPatterns.cs
+++ b/src/RulesTest/Library/ButtonPatterns.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 using Axe.Windows.Core.Types;
 
 namespace Axe.Windows.RulesTest.Library
@@ -25,7 +24,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         /// <summary>
@@ -42,7 +41,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_InvokePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         /// <summary>
@@ -59,7 +58,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_TogglePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         /// <summary>
@@ -77,7 +76,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_InvokePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
     }
 } 

--- a/src/RulesTest/Library/ButtonToggleAndExpandCollapsePatterns.cs
+++ b/src/RulesTest/Library/ButtonToggleAndExpandCollapsePatterns.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 using Axe.Windows.Core.Types;
 
 namespace Axe.Windows.RulesTest.Library
@@ -39,7 +38,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         /// <summary>
@@ -56,7 +55,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_InvokePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         /// <summary>
@@ -73,7 +72,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_TogglePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         /// <summary>
@@ -91,7 +90,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_TogglePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Error, this.Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
     }
 } 


### PR DESCRIPTION
#### Describe the change

Adding the evaluation code to the rule's info will allow us to automatically generate documentation which provides the rule's expected error code.

