### PR TITLE
docs: add instructions for silent installation

### DIFF
--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -2,6 +2,15 @@
 
 This tool allows you to scan your application for accessibility issues from your currently existing scripting system.
 
+## Installing the CLI
+
+You can install the CLI by executing the MSI installer on the [releases](https://github.com/microsoft/axe-windows/releases/) page. If you prefer to install silently, open a command prompt as administrator, change to the directory containing the file, and include the `/quiet` flag:
+
+```
+cd %HOMEPATH%\Downloads
+msiexec.exe /i AxeWindowsCLI-1.0.6.msi /quiet
+```
+
 ## Running the tool
 You invoke the scanner by running `AxeWindowsCLI.exe`. By default, this tool gets installed to `c:\users\Program Files (x86)\AxeWindowsCLI\1.0\AxeWindowsCLI.exe`, although you can install it into other locations if you wish.
 

--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -4,11 +4,10 @@ This tool allows you to scan your application for accessibility issues from your
 
 ## Installing the CLI
 
-You can install the CLI by executing the MSI installer on the [releases](https://github.com/microsoft/axe-windows/releases/) page. If you prefer to install silently, open a command prompt as administrator, change to the directory containing the file, and include the `/quiet` flag:
+If you prefer to install silently, open a command prompt as administrator, change to the directory containing the file (typically your downloads folder), and execute the MSI file directly with the /quiet flag. Be sure to use the appropriate version number:
 
 ```
-cd %HOMEPATH%\Downloads
-msiexec.exe /i AxeWindowsCLI-1.0.6.msi /quiet
+msiexec.exe /i AxeWindowsCLI-X.Y.Z.msi /quiet
 ```
 
 ## Running the tool


### PR DESCRIPTION
This PR adds information about how to install the MSI installer silently. We're adding docs like this for several of our Windows installers (AI-Windows, AI-Unified, etc) so users who wish to avoid the graphical interface can do so.
