### PR TITLE
    Chore: Update rules to use the new PassesTest method instead of Evaluate

### DIFF
--- a/src/Rules/Library/ChildrenNotAllowedInContentView.cs
+++ b/src/Rules/Library/ChildrenNotAllowedInContentView.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ChildrenNotAllowedInContentView;
             this.Info.HowToFix = HowToFix.ChildrenNotAllowedInContentView;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return NoChild(IsContentElement).Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return NoChild(IsContentElement).Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ClickablePointOffScreen.cs
+++ b/src/Rules/Library/ClickablePointOffScreen.cs
@@ -19,13 +19,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.ClickablePointOffScreen;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_IsOffscreenPropertyId;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return IsOffScreen.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Warning;
+            return IsOffScreen.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ClickablePointOnScreen.cs
+++ b/src/Rules/Library/ClickablePointOnScreen.cs
@@ -19,13 +19,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.ClickablePointOnScreen;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_IsOffscreenPropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return IsNotOffScreen.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return IsNotOffScreen.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ComboBoxShouldNotSupportScrollPattern.cs
+++ b/src/Rules/Library/ComboBoxShouldNotSupportScrollPattern.cs
@@ -17,13 +17,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ComboBoxShouldNotSupportScrollPattern;
             this.Info.HowToFix = HowToFix.ComboBoxShouldNotSupportScrollPattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.Scroll.Matches(e) ? EvaluationCode.Warning: EvaluationCode.Pass;
+            return !Patterns.Scroll.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/RulesTest/Library/ClickablePointOffScreen.cs
+++ b/src/RulesTest/Library/ClickablePointOffScreen.cs
@@ -5,7 +5,6 @@ using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System.Drawing;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -36,7 +35,7 @@ namespace Axe.Windows.RulesTest.Library
         public void ClickablePointOffScreen_OnScreen_Warning()
         {
             mockElement.Setup(m => m.IsOffScreen).Returns(false);
-            Assert.AreEqual(EvaluationCode.Warning, Rule.Evaluate(mockElement.Object));
+            Assert.IsFalse(Rule.PassesTest(mockElement.Object));
             mockElement.VerifyAll();
         }
 
@@ -44,7 +43,7 @@ namespace Axe.Windows.RulesTest.Library
         public void ClickablePointOffScreen_OffScreen_Pass()
         {
             mockElement.Setup(m => m.IsOffScreen).Returns(true);
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(mockElement.Object));
+            Assert.IsTrue(Rule.PassesTest(mockElement.Object));
             mockElement.VerifyAll();
         }
 

--- a/src/RulesTest/Library/ClickablePointOnScreen.cs
+++ b/src/RulesTest/Library/ClickablePointOnScreen.cs
@@ -5,7 +5,6 @@ using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System.Drawing;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -36,7 +35,7 @@ namespace Axe.Windows.RulesTest.Library
         public void ClickablePointOnScreen_OffScreen_Error()
         {
             mockElement.Setup(m => m.IsOffScreen).Returns(true);
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(mockElement.Object));
+            Assert.IsFalse(Rule.PassesTest(mockElement.Object));
             mockElement.VerifyAll();
         }
 
@@ -44,7 +43,7 @@ namespace Axe.Windows.RulesTest.Library
         public void ClickablePointOnScreen_OnScreen_Pass()
         {
             mockElement.Setup(m => m.IsOffScreen).Returns(false);
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(mockElement.Object));
+            Assert.IsTrue(Rule.PassesTest(mockElement.Object));
             mockElement.VerifyAll();
         }
 

--- a/src/RulesTest/Library/ComboBoxShouldNotSupportScrollPatternTests.cs
+++ b/src/RulesTest/Library/ComboBoxShouldNotSupportScrollPatternTests.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -47,7 +46,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ScrollPatternId));
 
-            Assert.AreEqual(EvaluationCode.Warning, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -55,7 +54,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
     } // class
 } // namespace


### PR DESCRIPTION
Adding the evaluation code to the rule's info will allow us to automatically generate documentation which provides the rule's expected error code.
