### PR TITLE
Chore: Update rules to use the new PassesTest method instead of Evaluate

### DIFF
--- a/src/Rules/Library/ControlShouldNotSupportInvokePattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportInvokePattern.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldNotSupportInvokePattern;
             this.Info.HowToFix = HowToFix.ControlShouldNotSupportInvokePattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.Invoke.Matches(e) ? EvaluationCode.Error : EvaluationCode.Pass;
+            return !Patterns.Invoke.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldNotSupportScrollPattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportScrollPattern.cs
@@ -17,13 +17,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldNotSupportScrollPattern;
             this.Info.HowToFix = HowToFix.ControlShouldNotSupportScrollPattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.Scroll.Matches(e) ? EvaluationCode.Error : EvaluationCode.Pass;
+            return !Patterns.Scroll.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldNotSupportTablePattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportTablePattern.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldNotSupportTablePattern;
             this.Info.HowToFix = HowToFix.ControlShouldNotSupportTablePattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.Table.Matches(e) ? EvaluationCode.Error : EvaluationCode.Pass;
+            return !Patterns.Table.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldNotSupportTogglePattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportTogglePattern.cs
@@ -17,13 +17,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldNotSupportTogglePattern;
             this.Info.HowToFix = HowToFix.ControlShouldNotSupportTogglePattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.Toggle.Matches(e) ? EvaluationCode.Error : EvaluationCode.Pass;
+            return !Patterns.Toggle.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldNotSupportValuePattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportValuePattern.cs
@@ -17,13 +17,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldNotSupportValuePattern;
             this.Info.HowToFix = HowToFix.ControlShouldNotSupportValuePattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.Value.Matches(e) ? EvaluationCode.Warning : EvaluationCode.Pass;
+            return !Patterns.Value.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldNotSupportWindowPattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportWindowPattern.cs
@@ -17,13 +17,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldNotSupportWindowPattern;
             this.Info.HowToFix = HowToFix.ControlShouldNotSupportWindowPattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.Window.Matches(e) ? EvaluationCode.Warning : EvaluationCode.Pass;
+            return !Patterns.Window.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/RulesTest/Library/ControlShouldNotSupportScrollPatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldNotSupportScrollPatternTests.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -47,7 +46,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ScrollPatternId));
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -55,7 +54,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/ControlShouldNotSupportTablePattern.cs
+++ b/src/RulesTest/Library/ControlShouldNotSupportTablePattern.cs
@@ -5,7 +5,6 @@ using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -19,7 +18,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -28,14 +27,14 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Patterns.Add(new A11yPattern(e, PatternType.UIA_TablePatternId));
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void ArgumentNull_Exception()
         {
-            Rule.Evaluate(null);
+            Rule.PassesTest(null);
         }
 
         [TestMethod]


### PR DESCRIPTION
#### Describe the change

    Adding the evaluation code to the rule's info will allow us to automatically generate documentation which provides the rule's expected error code.