### PR TITLE
Chore: Update rules to use the new PassesTest method instead of Evaluate

### DIFF
--- a/src/Rules/Library/ControlShouldSupportExpandCollapsePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportExpandCollapsePattern.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldSupportExpandCollapsePattern;
             this.Info.HowToFix = HowToFix.ControlShouldSupportExpandCollapsePattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.ExpandCollapse.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return Patterns.ExpandCollapse.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldSupportGridItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportGridItemPattern.cs
@@ -18,14 +18,15 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldSupportGridItemPattern;
             this.Info.HowToFix = HowToFix.ControlShouldSupportGridItemPattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var condition = Patterns.GridItem | AnyChild(Patterns.GridItem);
-            return condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return condition.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldSupportGridPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportGridPattern.cs
@@ -19,13 +19,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.ControlShouldSupportGridPattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
             this.Info.PropertyID = PropertyType.UIA_IsGridPatternAvailablePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.Grid.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return Patterns.Grid.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldSupportInvokePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportInvokePattern.cs
@@ -17,13 +17,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldSupportInvokePattern;
             this.Info.HowToFix = HowToFix.ControlShouldSupportInvokePattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.Invoke.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return Patterns.Invoke.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldSupportScrollItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportScrollItemPattern.cs
@@ -18,14 +18,15 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldSupportScrollItemPattern;
             this.Info.HowToFix = HowToFix.ControlShouldSupportScrollItemPattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var condition = Patterns.ScrollItem | AnyChild(Patterns.ScrollItem);
-            return condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return condition.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldSupportSelectionItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportSelectionItemPattern.cs
@@ -17,13 +17,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldSupportSelectionItemPattern;
             this.Info.HowToFix = HowToFix.ControlShouldSupportSelectionItemPattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.SelectionItem.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return Patterns.SelectionItem.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldSupportSelectionPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportSelectionPattern.cs
@@ -17,13 +17,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldSupportSelectionPattern;
             this.Info.HowToFix = HowToFix.ControlShouldSupportSelectionPattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.Selection.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return Patterns.Selection.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldSupportSetInfoWPF.cs
+++ b/src/Rules/Library/ControlShouldSupportSetInfoWPF.cs
@@ -18,18 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldSupportSetInfo;
             this.Info.HowToFix = HowToFix.ControlShouldSupportSetInfo;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            if (PositionInSet.Exists.Matches(e) & SizeOfSet.Exists.Matches(e))
-            {
-                return EvaluationCode.Pass;
-            }
-
-            return EvaluationCode.Warning;
+            return PositionInSet.Exists.Matches(e) & SizeOfSet.Exists.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldSupportSetInfoXAML.cs
+++ b/src/Rules/Library/ControlShouldSupportSetInfoXAML.cs
@@ -18,19 +18,15 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldSupportSetInfo;
             this.Info.HowToFix = HowToFix.ControlShouldSupportSetInfo;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            if (PositionInSet.Exists.Matches(e) & SizeOfSet.Exists.Matches(e))
-            {
-                return EvaluationCode.Pass;
-            }
-
-            return EvaluationCode.Error;
-        }
+            return PositionInSet.Exists.Matches(e) & SizeOfSet.Exists.Matches(e);
+}
 
         protected override Condition CreateCondition()
         {

--- a/src/Rules/Library/ControlShouldSupportSpreadsheetItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportSpreadsheetItemPattern.cs
@@ -18,14 +18,15 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldSupportSpreadsheetItemPattern;
             this.Info.HowToFix = HowToFix.ControlShouldSupportSpreadsheetItemPattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var condition = Patterns.SpreadsheetItem | AnyChild(Patterns.SpreadsheetItem);
-            return condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return condition.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldSupportTableItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTableItemPattern.cs
@@ -18,14 +18,15 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldSupportTableItemPattern;
             this.Info.HowToFix = HowToFix.ControlShouldSupportTableItemPattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var condition = Patterns.TableItem | AnyChild(Patterns.TableItem);
-            return condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return condition.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldSupportTablePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTablePattern.cs
@@ -20,13 +20,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.ControlShouldSupportTablePattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
             this.Info.PropertyID = PropertyType.UIA_IsTablePatternAvailablePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.Table.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return Patterns.Table.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldSupportTablePatternInEdge.cs
+++ b/src/Rules/Library/ControlShouldSupportTablePatternInEdge.cs
@@ -20,13 +20,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.ControlShouldSupportTablePattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
             this.Info.PropertyID = PropertyType.UIA_IsTablePatternAvailablePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.Table.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Warning;
+            return Patterns.Table.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldSupportTextPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTextPattern.cs
@@ -19,13 +19,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldSupportTextPattern;
             this.Info.HowToFix = HowToFix.ControlShouldSupportTextPattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.Text.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return Patterns.Text.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldSupportTogglePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTogglePattern.cs
@@ -17,13 +17,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldSupportTogglePattern;
             this.Info.HowToFix = HowToFix.ControlShouldSupportTogglePattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.Toggle.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return Patterns.Toggle.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ControlShouldSupportTransformPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTransformPattern.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldSupportTransformPattern;
             this.Info.HowToFix = HowToFix.ControlShouldSupportTransformPattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Patterns.Transform.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return Patterns.Transform.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/EditSupportsIncorrectRangeValuePattern.cs
+++ b/src/Rules/Library/EditSupportsIncorrectRangeValuePattern.cs
@@ -18,14 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.EditSupportsIncorrectRangeValuePattern;
             this.Info.HowToFix = HowToFix.EditSupportsIncorrectRangeValuePattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return IsLargeChangeValueNull(e)
-                ? EvaluationCode.Pass : EvaluationCode.Error;
+            return IsLargeChangeValueNull(e);
         }
 
         private static bool IsLargeChangeValueNull(IA11yElement e)

--- a/src/Rules/Library/HeadingLevelDescendsWhenNested.cs
+++ b/src/Rules/Library/HeadingLevelDescendsWhenNested.cs
@@ -18,14 +18,15 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.HeadingLevelDescendsWhenNested;
             this.Info.HowToFix = HowToFix.HeadingLevelDescendsWhenNested;
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var condition = HeadingLevel > e.HeadingLevel;
-            return AnyAncestor(condition).Matches(e) ? EvaluationCode.Error : EvaluationCode.Pass;
+            return !AnyAncestor(condition).Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/HelpTextExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/HelpTextExcludesPrivateUnicodeCharacters.cs
@@ -20,14 +20,15 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.PropertyExcludesPrivateUnicodeCharacters, HelpText.PropertyDescription);
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_HelpTextPropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
             if (String.IsNullOrWhiteSpace(e.HelpText)) throw new ArgumentException(ErrorMessages.ElementHelpTextNullOrWhiteSpace, nameof(e));
 
-            return HelpText.ExcludesPrivateUnicodeCharacters.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return HelpText.ExcludesPrivateUnicodeCharacters.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/HelpTextNotEqualToName.cs
+++ b/src/Rules/Library/HelpTextNotEqualToName.cs
@@ -16,14 +16,16 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.HelpTextNotEqualToName;
             this.Info.HowToFix = HowToFix.HelpTextNotEqualToName;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            var condition = Name.IsEqualTo(HelpText);
-            return condition.Matches(e) ? EvaluationCode.Warning : EvaluationCode.Pass;
+            var condition = ~(Name.IsEqualTo(HelpText));
+
+            return condition.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/HyperlinkNameShouldBeUnique.cs
+++ b/src/Rules/Library/HyperlinkNameShouldBeUnique.cs
@@ -22,15 +22,16 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.HyperlinkNameShouldBeUnique;
             this.Info.HowToFix = HowToFix.HyperlinkNameShouldBeUnique;
             this.Info.Standard = A11yCriteriaId.NameRoleValue;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
             if (e.Parent == null) throw new ArgumentException(ErrorMessages.ElementParentNull, nameof(e));
 
             var siblings = SiblingCount(EligibleHyperlink & Name.Is(e.Name)) <= 1;
-            return siblings.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Warning;
+            return siblings.Matches(e);
         }
 
         protected override Condition CreateCondition() => EligibleHyperlink;

--- a/src/Rules/Library/IsContentElementFalseOptional.cs
+++ b/src/Rules/Library/IsContentElementFalseOptional.cs
@@ -20,11 +20,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsContentElementFalseOptional;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_IsContentElementPropertyId;
+            this.Info.ErrorCode = EvaluationCode.Open;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return EvaluationCode.Open;
+            return false;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/IsContentElementPropertyExists.cs
+++ b/src/Rules/Library/IsContentElementPropertyExists.cs
@@ -20,13 +20,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsContentElementPropertyExists;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_IsContentElementPropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return IsContentElementExists.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return IsContentElementExists.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/IsContentElementTrueOptional.cs
+++ b/src/Rules/Library/IsContentElementTrueOptional.cs
@@ -25,7 +25,7 @@ namespace Axe.Windows.Rules.Library
 
         public override bool PassesTest(IA11yElement e)
         {
-            return true;
+            return false;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/IsContentElementTrueOptional.cs
+++ b/src/Rules/Library/IsContentElementTrueOptional.cs
@@ -20,11 +20,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsContentElementTrueOptional;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_IsContentElementPropertyId;
+            this.Info.ErrorCode = EvaluationCode.Open;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return EvaluationCode.Open;
+            return true;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/IsControlElementPropertyExists.cs
+++ b/src/Rules/Library/IsControlElementPropertyExists.cs
@@ -19,13 +19,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsControlElementPropertyExists;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_IsControlElementPropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return IsControlElementExists.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return IsControlElementExists.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/IsControlElementTrueOptional.cs
+++ b/src/Rules/Library/IsControlElementTrueOptional.cs
@@ -18,11 +18,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsControlElementTrueOptional;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_IsControlElementPropertyId;
+            this.Info.ErrorCode = EvaluationCode.Open;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return EvaluationCode.Open;
+            return false;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/IsControlElementTrueRequired.cs
+++ b/src/Rules/Library/IsControlElementTrueRequired.cs
@@ -19,13 +19,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsControlElementTrueRequired;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_IsControlElementPropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return IsControlElement.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return IsControlElement.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/IsKeyboardFocusableDescendantTextPattern.cs
+++ b/src/Rules/Library/IsKeyboardFocusableDescendantTextPattern.cs
@@ -19,11 +19,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsKeyboardFocusableDescendantTextPattern;
             this.Info.Standard = A11yCriteriaId.Keyboard;
             this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return EvaluationCode.Note;
+            return false;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/IsKeyboardFocusableFalseButDisabled.cs
+++ b/src/Rules/Library/IsKeyboardFocusableFalseButDisabled.cs
@@ -18,11 +18,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsKeyboardFocusableFalseButDisabled;
             this.Info.Standard = A11yCriteriaId.Keyboard;
             this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return EvaluationCode.Note;
+            return false;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/IsKeyboardFocusableFalseButOffscreen.cs
+++ b/src/Rules/Library/IsKeyboardFocusableFalseButOffscreen.cs
@@ -18,11 +18,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsKeyboardFocusableFalseButOffscreen;
             this.Info.Standard = A11yCriteriaId.Keyboard;
             this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return EvaluationCode.Note;
+            return false;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/IsKeyboardFocusableForCustomShouldBeTrue.cs
+++ b/src/Rules/Library/IsKeyboardFocusableForCustomShouldBeTrue.cs
@@ -20,13 +20,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsKeyboardFocusableForCustomShouldBeTrue;
             this.Info.Standard = A11yCriteriaId.Keyboard;
             this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return IsKeyboardFocusable.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Warning;
+            return IsKeyboardFocusable.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/IsKeyboardFocusableForListItemShouldBeTrue.cs
+++ b/src/Rules/Library/IsKeyboardFocusableForListItemShouldBeTrue.cs
@@ -21,13 +21,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsKeyboardFocusableForListItemShouldBeTrue;
             this.Info.Standard = A11yCriteriaId.Keyboard;
             this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return AnyChild(IsKeyboardFocusable).Matches(e) ? EvaluationCode.Warning : EvaluationCode.Pass;
+            return !AnyChild(IsKeyboardFocusable).Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/IsKeyboardFocusableOnEmptyContainer.cs
+++ b/src/Rules/Library/IsKeyboardFocusableOnEmptyContainer.cs
@@ -18,11 +18,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsKeyboardFocusableOnEmptyContainer;
             this.Info.Standard = A11yCriteriaId.Keyboard;
             this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Open;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return EvaluationCode.Open;
+            return false;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/IsKeyboardFocusableShouldBeFalse.cs
+++ b/src/Rules/Library/IsKeyboardFocusableShouldBeFalse.cs
@@ -18,11 +18,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsKeyboardFocusableShouldBeFalse;
             this.Info.Standard = A11yCriteriaId.Keyboard;
             this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return IsNotKeyboardFocusable.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Warning;
+            return IsNotKeyboardFocusable.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/IsKeyboardFocusableShouldBeTrue.cs
+++ b/src/Rules/Library/IsKeyboardFocusableShouldBeTrue.cs
@@ -21,13 +21,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsKeyboardFocusableShouldBeTrue;
             this.Info.Standard = A11yCriteriaId.Keyboard;
             this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return IsKeyboardFocusable.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Warning;
+            return IsKeyboardFocusable.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/IsKeyboardFocusableTopLevelTextPattern.cs
+++ b/src/Rules/Library/IsKeyboardFocusableTopLevelTextPattern.cs
@@ -21,13 +21,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsKeyboardFocusableTopLevelTextPattern;
             this.Info.Standard = A11yCriteriaId.Keyboard;
             this.Info.PropertyID = Axe.Windows.Core.Types.PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return IsKeyboardFocusable.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Warning;
+            return IsKeyboardFocusable.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ItemStatusExists.cs
+++ b/src/Rules/Library/ItemStatusExists.cs
@@ -18,11 +18,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.ItemStatusExists;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_ItemStatusPropertyId;
+            this.Info.ErrorCode = EvaluationCode.Open;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return EvaluationCode.Open;
+            return false;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ItemTypeRecommended.cs
+++ b/src/Rules/Library/ItemTypeRecommended.cs
@@ -18,11 +18,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.ItemTypeRecommended;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_ItemTypePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Open;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return EvaluationCode.Open;
+            return false;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LandmarkBannerIsTopLevel.cs
+++ b/src/Rules/Library/LandmarkBannerIsTopLevel.cs
@@ -18,15 +18,16 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.LandmarkBannerIsTopLevel;
             this.Info.HowToFix = HowToFix.LandmarkBannerIsTopLevel;
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var stopCondition = InsideEdge.Matches(e) ? NotInsideEdge : Condition.False;
 
-            return AnyAncestor(Landmarks.Any, stopCondition).Matches(e) ? EvaluationCode.Error : EvaluationCode.Pass;
+            return !AnyAncestor(Landmarks.Any, stopCondition).Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LandmarkComplementaryIsTopLevel.cs
+++ b/src/Rules/Library/LandmarkComplementaryIsTopLevel.cs
@@ -18,15 +18,16 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.LandmarkComplementaryIsTopLevel;
             this.Info.HowToFix = HowToFix.LandmarkComplementaryIsTopLevel;
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var stopCondition = InsideEdge.Matches(e) ? NotInsideEdge : Condition.False;
 
-            return AnyAncestor(Landmarks.Any, stopCondition).Matches(e) ? EvaluationCode.Error : EvaluationCode.Pass;
+            return !AnyAncestor(Landmarks.Any, stopCondition).Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LandmarkContentInfoIsTopLevel.cs
+++ b/src/Rules/Library/LandmarkContentInfoIsTopLevel.cs
@@ -18,15 +18,16 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.LandmarkContentInfoIsTopLevel;
             this.Info.HowToFix = HowToFix.LandmarkContentInfoIsTopLevel;
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var stopCondition = InsideEdge.Matches(e) ? NotInsideEdge : Condition.False;
 
-            return AnyAncestor(Landmarks.Any, stopCondition).Matches(e) ? EvaluationCode.Error : EvaluationCode.Pass;
+            return !AnyAncestor(Landmarks.Any, stopCondition).Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LandmarkMainIsTopLevel.cs
+++ b/src/Rules/Library/LandmarkMainIsTopLevel.cs
@@ -18,15 +18,16 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.LandmarkMainIsTopLevel;
             this.Info.HowToFix = HowToFix.LandmarkMainIsTopLevel;
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var stopCondition = InsideEdge.Matches(e) ? NotInsideEdge : Condition.False;
 
-            return AnyAncestor(Landmarks.Any, stopCondition).Matches(e) ? EvaluationCode.Error : EvaluationCode.Pass;
+            return !AnyAncestor(Landmarks.Any, stopCondition).Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LandmarkNoDuplicateBanner.cs
+++ b/src/Rules/Library/LandmarkNoDuplicateBanner.cs
@@ -20,15 +20,16 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.LandmarkNoDuplicateBanner;
             this.Info.HowToFix = HowToFix.LandmarkNoDuplicateBanner;
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var landmark = Landmarks.Banner & (Edge | IsNotOffScreen);
             var condition = DescendantCount(landmark) <= 1;
-            return  condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return  condition.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LandmarkNoDuplicateContentInfo.cs
+++ b/src/Rules/Library/LandmarkNoDuplicateContentInfo.cs
@@ -20,15 +20,16 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.LandmarkNoDuplicateContentInfo;
             this.Info.HowToFix = HowToFix.LandmarkNoDuplicateContentInfo;
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var landmark = Landmarks.ContentInfo & (Edge | IsNotOffScreen);
             var condition = DescendantCount(landmark) <= 1;
-            return condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return condition.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LandmarkOneMain.cs
+++ b/src/Rules/Library/LandmarkOneMain.cs
@@ -19,14 +19,15 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.LandmarkOneMain;
             this.Info.HowToFix = HowToFix.LandmarkOneMain;
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var condition = DescendantCount(Landmarks.Main) == 1;
-            return condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Warning;
+            return condition.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ListItemSiblingsUnique.cs
+++ b/src/Rules/Library/ListItemSiblingsUnique.cs
@@ -34,7 +34,7 @@ namespace Axe.Windows.Rules.Library
                 & Name.Is(e.Name)
                 & LocalizedControlType.Is(e.LocalizedControlType));
             var count = siblings.GetValue(e);
-            if (count < 1) throw new Exception(String.Format(CultureInfo.CurrentCulture, ErrorMessages.NoElementFound, this.Info.ID));
+            if (count < 1) throw new Exception(String.Format(CultureInfo.InvariantCulture, ErrorMessages.NoElementFound, this.Info.ID));
 
             return count == 1;
         }

--- a/src/Rules/Library/ListItemSiblingsUnique.cs
+++ b/src/Rules/Library/ListItemSiblingsUnique.cs
@@ -5,6 +5,7 @@ using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
@@ -20,9 +21,10 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ListItemSiblingsUnique;
             this.Info.HowToFix = HowToFix.ListItemSiblingsUnique;
             this.Info.Standard = A11yCriteriaId.NameRoleValue;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
             if (e.Parent == null) throw new ArgumentException(ErrorMessages.ElementParentNull, nameof(e));
@@ -32,9 +34,9 @@ namespace Axe.Windows.Rules.Library
                 & Name.Is(e.Name)
                 & LocalizedControlType.Is(e.LocalizedControlType));
             var count = siblings.GetValue(e);
-            if (count < 1) return EvaluationCode.RuleExecutionError;
+            if (count < 1) throw new Exception(String.Format(CultureInfo.CurrentCulture, ErrorMessages.NoElementFound, this.Info.ID));
 
-            return count == 1 ? EvaluationCode.Pass : EvaluationCode.Warning;
+            return count == 1;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LocalizedControlTypeExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/LocalizedControlTypeExcludesPrivateUnicodeCharacters.cs
@@ -20,14 +20,15 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.PropertyExcludesPrivateUnicodeCharacters, LocalizedControlType.PropertyDescription);
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
             if (String.IsNullOrWhiteSpace(e.LocalizedControlType)) throw new ArgumentException(ErrorMessages.ElementLocalizedControlTypeNullOrWhiteSpace, nameof(e));
 
-            return LocalizedControlType.ExcludesPrivateUnicodeCharacters.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return LocalizedControlType.ExcludesPrivateUnicodeCharacters.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LocalizedControlTypeIsNotCustom.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotCustom.cs
@@ -22,13 +22,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.LocalizedControlTypeNotCustom;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return e.LocalizedControlType != LocalizedControlTypeNames.Custom ? EvaluationCode.Pass : EvaluationCode.Error;
+            return e.LocalizedControlType != LocalizedControlTypeNames.Custom;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
@@ -22,13 +22,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = String.Format(CultureInfo.CurrentCulture, HowToFix.LocalizedControlTypeNotCustomWPFGridCell, HowToFix.LocalizedControlTypeNotCustom);
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return e.LocalizedControlType != LocalizedControlTypeNames.Custom ? EvaluationCode.Pass : EvaluationCode.Error;
+            return e.LocalizedControlType != LocalizedControlTypeNames.Custom;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LocalizedControlTypeIsNotEmpty.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotEmpty.cs
@@ -19,7 +19,6 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.LocalizedControlTypeNotEmpty;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
-
             this.Info.ErrorCode = EvaluationCode.Error;
         }
 

--- a/src/Rules/Library/LocalizedControlTypeIsNotEmpty.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotEmpty.cs
@@ -19,13 +19,15 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.LocalizedControlTypeNotEmpty;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
+
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return LocalizedControlType.NotEmpty.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return LocalizedControlType.NotEmpty.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LocalizedControlTypeIsNotNull.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotNull.cs
@@ -19,13 +19,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.LocalizedControlTypeNotNull;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return e.LocalizedControlType != null ? EvaluationCode.Pass : EvaluationCode.Error;
+            return e.LocalizedControlType != null;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LocalizedControlTypeIsNotWhiteSpace.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotWhiteSpace.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.LocalizedControlTypeNotWhiteSpace;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return LocalizedControlType.NotWhiteSpace.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return LocalizedControlType.NotWhiteSpace.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LocalizedControlTypeIsReasonable.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsReasonable.cs
@@ -20,13 +20,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.LocalizedControlTypeReasonable;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return HasReasonableLocalizedControlType(e) ? EvaluationCode.Pass : EvaluationCode.Warning;
+            return HasReasonableLocalizedControlType(e);
         }
 
         private static bool HasReasonableLocalizedControlType(IA11yElement e)

--- a/src/Rules/Library/LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters.cs
@@ -17,13 +17,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.CurrentCulture, Descriptions.PropertyExcludesPrivateUnicodeCharacters, LocalizedLandmarkType.PropertyDescription);
             this.Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.PropertyExcludesPrivateUnicodeCharacters, LocalizedLandmarkType.PropertyDescription);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return LocalizedLandmarkType.ExcludesPrivateUnicodeCharacters.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return LocalizedLandmarkType.ExcludesPrivateUnicodeCharacters.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LocalizedLandmarkTypeIsReasonableLength.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeIsReasonableLength.cs
@@ -19,14 +19,15 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.LocalizedLandmarkTypeIsReasonableLength;
             this.Info.HowToFix = HowToFix.LocalizedLandmarkTypeIsReasonableLength;
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var condition = LocalizedLandmarkType.Length <= ReasonableLength;
-            return condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return condition.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LocalizedLandmarkTypeNotCustom.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeNotCustom.cs
@@ -17,13 +17,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.LocalizedLandmarkTypeNotCustom;
             this.Info.HowToFix = HowToFix.LocalizedLandmarkTypeNotCustom;
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return LocalizedLandmarkType.IsNoCase("custom").Matches(e) ? EvaluationCode.Error : EvaluationCode.Pass;
+            return !LocalizedLandmarkType.IsNoCase("custom").Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LocalizedLandmarkTypeNotEmpty.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeNotEmpty.cs
@@ -17,13 +17,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.LocalizedLandmarkTypeNotEmpty;
             this.Info.HowToFix = HowToFix.LocalizedLandmarkTypeNotEmpty;
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return LocalizedLandmarkType.NotEmpty.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return LocalizedLandmarkType.NotEmpty.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LocalizedLandmarkTypeNotNull.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeNotNull.cs
@@ -17,13 +17,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.LocalizedLandmarkTypeNotNull;
             this.Info.HowToFix = HowToFix.LocalizedLandmarkTypeNotNull;
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return LocalizedLandmarkType.NotNull.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return LocalizedLandmarkType.NotNull.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LocalizedLandmarkTypeNotWhiteSpace.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeNotWhiteSpace.cs
@@ -16,13 +16,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.LocalizedLandmarkTypeNotWhiteSpace;
             this.Info.HowToFix = HowToFix.LocalizedLandmarkTypeNotWhiteSpace;
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return LocalizedLandmarkType.NotWhiteSpace.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return LocalizedLandmarkType.NotWhiteSpace.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/NameExcludesControlType.cs
+++ b/src/Rules/Library/NameExcludesControlType.cs
@@ -21,9 +21,10 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameExcludesControlType;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
             if (String.IsNullOrWhiteSpace(e.Name)) throw new ArgumentException(ErrorMessages.ElementNameNullOrWhiteSpace, nameof(e));
@@ -32,8 +33,7 @@ namespace Axe.Windows.Rules.Library
 
             var r = new Regex($@"\b{controlTypeString}\b", RegexOptions.IgnoreCase);
 
-            return r.IsMatch(e.Name)
-                ? EvaluationCode.Error : EvaluationCode.Pass;
+            return !r.IsMatch(e.Name);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/NameExcludesLocalizedControlType.cs
+++ b/src/Rules/Library/NameExcludesLocalizedControlType.cs
@@ -20,9 +20,10 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameExcludesLocalizedControlType;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
             if (e.Name == null) throw new ArgumentException(ErrorMessages.ElementNameNullOrWhiteSpace, nameof(e));
@@ -30,8 +31,7 @@ namespace Axe.Windows.Rules.Library
 
             var r = new Regex($@"\b{e.LocalizedControlType}\b", RegexOptions.IgnoreCase);
 
-            return r.IsMatch(e.Name)
-                ? EvaluationCode.Error : EvaluationCode.Pass;
+            return !r.IsMatch(e.Name);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/NameExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/NameExcludesPrivateUnicodeCharacters.cs
@@ -19,14 +19,15 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.PropertyExcludesPrivateUnicodeCharacters, Name.PropertyDescription);
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
             if (String.IsNullOrWhiteSpace(e.Name)) throw new ArgumentException(ErrorMessages.ElementNameNullOrWhiteSpace, nameof(e));
 
-            return Name.ExcludesPrivateUnicodeCharacters.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return Name.ExcludesPrivateUnicodeCharacters.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/NameIsEmptyButElementIsNotKeyboardFocusable.cs
+++ b/src/Rules/Library/NameIsEmptyButElementIsNotKeyboardFocusable.cs
@@ -5,6 +5,7 @@ using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
@@ -21,13 +22,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameEmptyButElementNotKeyboardFocusable;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Open;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            if (e == null) return EvaluationCode.RuleExecutionError;
+            if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Name.NotEmpty.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Open;
+            return Name.NotEmpty.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/NameIsInformative.cs
+++ b/src/Rules/Library/NameIsInformative.cs
@@ -20,9 +20,10 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameIsInformative;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             string[] stringsToExclude =
             {
@@ -33,10 +34,10 @@ namespace Axe.Windows.Rules.Library
             foreach (var s in stringsToExclude)
             {
                 if (Regex.IsMatch(e.Name, s, RegexOptions.IgnoreCase))
-                    return EvaluationCode.Error;
+                    return false;
             }
 
-            return EvaluationCode.Pass;
+            return true;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/NameIsNotEmpty.cs
+++ b/src/Rules/Library/NameIsNotEmpty.cs
@@ -20,11 +20,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameNotEmpty;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return e.Name.Length > 0 ? EvaluationCode.Pass : EvaluationCode.Error;
+            return e.Name.Length > 0;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/NameIsNotNull.cs
+++ b/src/Rules/Library/NameIsNotNull.cs
@@ -5,6 +5,7 @@ using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
@@ -20,13 +21,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameNotNull;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            if (e == null) return EvaluationCode.RuleExecutionError;
+            if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return e.Name != null ? EvaluationCode.Pass : EvaluationCode.Error;
+            return e.Name != null;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/NameIsNotWhiteSpace.cs
+++ b/src/Rules/Library/NameIsNotWhiteSpace.cs
@@ -17,11 +17,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameNotWhiteSpace;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return e.Name.Trim().Length > 0 ? EvaluationCode.Pass : EvaluationCode.Error;
+            return e.Name.Trim().Length > 0;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/NameIsNullButElementIsNotKeyboardFocusable.cs
+++ b/src/Rules/Library/NameIsNullButElementIsNotKeyboardFocusable.cs
@@ -5,6 +5,7 @@ using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
@@ -20,13 +21,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameNullButElementNotKeyboardFocusable;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Open;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            if (e == null) return EvaluationCode.RuleExecutionError;
+            if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return e.Name != null ? EvaluationCode.Pass : EvaluationCode.Open;
+            return e.Name != null;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/NameIsReasonableLength.cs
+++ b/src/Rules/Library/NameIsReasonableLength.cs
@@ -23,15 +23,16 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameReasonableLength;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
             if (e.Name == null) throw new ArgumentException(ErrorMessages.ElementNameNullOrWhiteSpace, nameof(e));
 
             var condition = Name.Length <= ReasonableLength;
-            return condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return condition.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/NameNoSiblingsOfSameType.cs
+++ b/src/Rules/Library/NameNoSiblingsOfSameType.cs
@@ -19,11 +19,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameNoSiblingsOfSameType;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return EvaluationCode.Note;
+            return false;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/NameOnCustomWithParentWPFDataItem.cs
+++ b/src/Rules/Library/NameOnCustomWithParentWPFDataItem.cs
@@ -19,11 +19,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameOnCustomWithParentWPFDataItem;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return EvaluationCode.Note;
+            return false;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/NameOnOptionalType.cs
+++ b/src/Rules/Library/NameOnOptionalType.cs
@@ -18,11 +18,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameOnOptionalType;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Open;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return Name.NotNullOrEmpty.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Open;
+            return Name.NotNullOrEmpty.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/NameWithValidBoundingRectangle.cs
+++ b/src/Rules/Library/NameWithValidBoundingRectangle.cs
@@ -18,11 +18,12 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameWithValidBoundingRectangle;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Warning;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            return EvaluationCode.Warning;
+            return false;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/OrientationPropertyExists.cs
+++ b/src/Rules/Library/OrientationPropertyExists.cs
@@ -19,13 +19,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.OrientationPropertyExists;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_OrientationPropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return Orientation.Exists.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return Orientation.Exists.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs
+++ b/src/Rules/Library/ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs
@@ -5,6 +5,7 @@ using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 
 namespace Axe.Windows.Rules.Library
@@ -18,14 +19,15 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.ParentChildShouldNotHaveSameNameAndLocalizedControlType;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
-            if (e == null) return EvaluationCode.RuleExecutionError;
-            if (e.Parent == null) return EvaluationCode.RuleExecutionError;
+            if (e == null) throw new ArgumentNullException(nameof(e));
+            if (e.Parent == null) throw new ArgumentException(ErrorMessages.ElementParentNull, nameof(e));
 
-            return e.Name == e.Parent.Name && e.LocalizedControlType == e.Parent.LocalizedControlType ? EvaluationCode.Error : EvaluationCode.Pass;
+            return e.Name != e.Parent.Name || e.LocalizedControlType != e.Parent.LocalizedControlType;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/ProgressBarRangeValue.cs
+++ b/src/Rules/Library/ProgressBarRangeValue.cs
@@ -19,13 +19,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.ProgressBarRangeValue;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_IsRangeValuePatternAvailablePropertyId;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return AreMinMaxValuesCorrect(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return AreMinMaxValuesCorrect(e);
         }
 
         private static bool AreMinMaxValuesCorrect(IA11yElement e)

--- a/src/Rules/Library/SelectionItemPatternSingleSelection.cs
+++ b/src/Rules/Library/SelectionItemPatternSingleSelection.cs
@@ -18,15 +18,16 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.SelectionItemPatternSingleSelection;
             this.Info.HowToFix = HowToFix.SelectionItemPatternSingleSelection;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
             var controlType = new ControlTypeCondition(e.ControlTypeId);
             var condition = SiblingCount(controlType & SelectionItemPattern.IsSelected) <= 1;
 
-            return condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return condition.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/SelectionPatternSelectionRequired.cs
+++ b/src/Rules/Library/SelectionPatternSelectionRequired.cs
@@ -19,13 +19,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.SelectionPatternSelectionRequired;
             this.Info.HowToFix = HowToFix.SelectionPatternSelectionRequired;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return IsSelectionRequired(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return IsSelectionRequired(e);
         }
 
         private static bool IsSelectionRequired(IA11yElement e)

--- a/src/Rules/Library/SelectionPatternSingleSelection.cs
+++ b/src/Rules/Library/SelectionPatternSingleSelection.cs
@@ -17,13 +17,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.SelectionPatternSingleSelection;
             this.Info.HowToFix = HowToFix.SelectionPatternSingleSelection;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return SelectionPattern.CanSelectMultiple.Matches(e) ? EvaluationCode.Error : EvaluationCode.Pass;
+            return !SelectionPattern.CanSelectMultiple.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/SiblingUniqueAndFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndFocusable.cs
@@ -5,6 +5,7 @@ using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Framework;
@@ -37,9 +38,10 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.SiblingUniqueAndFocusable;
             this.Info.HowToFix = HowToFix.SiblingUniqueAndFocusable;
             this.Info.Standard = A11yCriteriaId.NameRoleValue;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
             if (e.Parent == null) throw new ArgumentException(ErrorMessages.ElementParentNull, nameof(e));
@@ -48,9 +50,9 @@ namespace Axe.Windows.Rules.Library
                 & Name.Is(e.Name)
                 & LocalizedControlType.Is(e.LocalizedControlType));
             var count = siblings.GetValue(e);
-            if (count < 1) return EvaluationCode.RuleExecutionError;
+            if (count < 1) throw new Exception(string.Format(CultureInfo.CurrentCulture, ErrorMessages.NoElementFound, this.Info.ID));
 
-            return count == 1 ? EvaluationCode.Pass : EvaluationCode.Error;
+            return count == 1;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/SiblingUniqueAndFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndFocusable.cs
@@ -50,7 +50,7 @@ namespace Axe.Windows.Rules.Library
                 & Name.Is(e.Name)
                 & LocalizedControlType.Is(e.LocalizedControlType));
             var count = siblings.GetValue(e);
-            if (count < 1) throw new Exception(string.Format(CultureInfo.CurrentCulture, ErrorMessages.NoElementFound, this.Info.ID));
+            if (count < 1) throw new Exception(string.Format(CultureInfo.InvariantCulture, ErrorMessages.NoElementFound, this.Info.ID));
 
             return count == 1;
         }

--- a/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
@@ -5,6 +5,7 @@ using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Framework;
@@ -36,9 +37,10 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.SiblingUniqueAndNotFocusable;
             this.Info.HowToFix = HowToFix.SiblingUniqueAndNotFocusable;
             this.Info.Standard = A11yCriteriaId.NameRoleValue;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
             if (e.Parent == null) throw new ArgumentException(ErrorMessages.ElementParentNull, nameof(e));
@@ -47,9 +49,9 @@ namespace Axe.Windows.Rules.Library
                 & Name.Is(e.Name)
                 & LocalizedControlType.Is(e.LocalizedControlType));
             var count = siblings.GetValue(e);
-            if (count < 1) return EvaluationCode.RuleExecutionError;
+            if (count < 1) throw new Exception(string.Format(CultureInfo.CurrentCulture, ErrorMessages.NoElementFound, this.Info.ID));
 
-            return count == 1 ? EvaluationCode.Pass : EvaluationCode.Note;
+            return count == 1;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
@@ -49,7 +49,7 @@ namespace Axe.Windows.Rules.Library
                 & Name.Is(e.Name)
                 & LocalizedControlType.Is(e.LocalizedControlType));
             var count = siblings.GetValue(e);
-            if (count < 1) throw new Exception(string.Format(CultureInfo.CurrentCulture, ErrorMessages.NoElementFound, this.Info.ID));
+            if (count < 1) throw new Exception(string.Format(CultureInfo.InvariantCulture, ErrorMessages.NoElementFound, this.Info.ID));
 
             return count == 1;
         }

--- a/src/Rules/Library/SplitButtonInvokeAndTogglePatterns.cs
+++ b/src/Rules/Library/SplitButtonInvokeAndTogglePatterns.cs
@@ -17,16 +17,17 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.SplitButtonInvokeAndTogglePatterns;
             this.Info.HowToFix = HowToFix.SplitButtonInvokeAndTogglePatterns;
             this.Info.Standard = A11yCriteriaId.NameRoleValue;
+            this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var condition = (Patterns.Invoke | Patterns.Toggle)
                 & ~(Patterns.Invoke & Patterns.Toggle);
 
-            return condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return condition.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Resources/ErrorMessages.Designer.cs
+++ b/src/Rules/Resources/ErrorMessages.Designer.cs
@@ -160,6 +160,15 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Based on the Rule.Condition match, there should have been at least one element found in the PassesTest method of {0}.
+        /// </summary>
+        internal static string NoElementFound {
+            get {
+                return ResourceManager.GetString("NoElementFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not find potential LocalizedControlType string(s) for the given control type.
         /// </summary>
         internal static string NoLocalizedControlTypeStringFound {

--- a/src/Rules/Resources/ErrorMessages.resx
+++ b/src/Rules/Resources/ErrorMessages.resx
@@ -150,6 +150,9 @@
   <data name="NoControlTypeEntryFound" xml:space="preserve">
     <value>No control type entry was found in dictionary</value>
   </data>
+  <data name="NoElementFound" xml:space="preserve">
+    <value>Based on the Rule.Condition match, there should have been at least one element found in the PassesTest method of {0}</value>
+  </data>
   <data name="NoLocalizedControlTypeStringFound" xml:space="preserve">
     <value>Could not find potential LocalizedControlType string(s) for the given control type</value>
   </data>

--- a/src/RulesTest/Library/ControlShouldSupportExpandCollapsePattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportExpandCollapsePattern.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 using Axe.Windows.Core.Types;
 
 namespace Axe.Windows.RulesTest.Library
@@ -44,7 +43,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Children.Add(ec);
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Error, this.Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         /// <summary>
@@ -64,7 +63,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
 
             Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
     }
 } 

--- a/src/RulesTest/Library/ControlShouldSupportGridPattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportGridPattern.cs
@@ -3,7 +3,6 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Bases;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 using Axe.Windows.Core.Types;
 using System.Diagnostics;
 using UIAutomationClient;
@@ -21,7 +20,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Patterns.Add(new A11yPattern(e, PatternType.UIA_GridPatternId));
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -29,14 +28,14 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void ArgumentNull_Exception()
         {
-            Rule.Evaluate(null);
+            Rule.PassesTest(null);
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/ControlShouldSupportSetInfoWPFTest.cs
+++ b/src/RulesTest/Library/ControlShouldSupportSetInfoWPFTest.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.SizeOfSet = 1;
-            Assert.AreEqual(EvaluationCode.Warning, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -26,14 +26,14 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.PositionInSet = 1;
-            Assert.AreEqual(EvaluationCode.Warning, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
         public void TestControlShouldSupportSetInfoWPFBothNonExistFail()
         {
             var e = new MockA11yElement();
-            Assert.AreEqual(EvaluationCode.Warning, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -42,7 +42,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.PositionInSet = 1;
             e.SizeOfSet = 1;
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/ControlShouldSupportSetInfoXAMLTest.cs
+++ b/src/RulesTest/Library/ControlShouldSupportSetInfoXAMLTest.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.SizeOfSet = 1;
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -26,14 +26,14 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.PositionInSet = 1;
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
         public void TestControlShouldSupportSetInfoXAMLBothNonExistFail()
         {
             var e = new MockA11yElement();
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -42,7 +42,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.PositionInSet = 1;
             e.SizeOfSet = 1;
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/ControlShouldSupportTablePattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTablePattern.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.RulesTest;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -21,7 +20,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Patterns.Add(new A11yPattern(e, PatternType.UIA_TablePatternId));
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -29,14 +28,14 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void ArgumentNull_Exception()
         {
-            Rule.Evaluate(null);
+            Rule.PassesTest(null);
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/ControlShouldSupportTablePatternInEdge.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTablePatternInEdge.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.RulesTest;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -21,7 +20,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Patterns.Add(new A11yPattern(e, PatternType.UIA_TablePatternId));
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -29,14 +28,14 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
 
-            Assert.AreEqual(EvaluationCode.Warning, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void ArgumentNull_Exception()
         {
-            Rule.Evaluate(null);
+            Rule.PassesTest(null);
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/ControlShouldSupportTextPatternUnitTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTextPatternUnitTests.cs
@@ -4,7 +4,6 @@ using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 using Axe.Windows.Core.Types;
 
 namespace Axe.Windows.RulesTest.Library
@@ -20,7 +19,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Patterns.Add(new A11yPattern(e, PatternType.UIA_TextPatternId));
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -28,7 +27,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -74,7 +73,7 @@ namespace Axe.Windows.RulesTest.Library
         [ExpectedException(typeof(ArgumentNullException))]
         public void ArgumentNull_Exception()
         {
-            Rule.Evaluate(null);
+            Rule.PassesTest(null);
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/HeadingLevelDescendsWhenNestedTest.cs
+++ b/src/RulesTest/Library/HeadingLevelDescendsWhenNestedTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Types;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -65,7 +64,7 @@ namespace Axe.Windows.RulesTest.Library
                 parent.HeadingLevel = HeadingLevelType.HeadingLevel1;
                 e.Parent = parent;
 
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -79,7 +78,7 @@ namespace Axe.Windows.RulesTest.Library
                 parent.HeadingLevel = HeadingLevelType.HeadingLevel9;
                 e.Parent = parent;
 
-                Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
     } // class

--- a/src/RulesTest/Library/HelpTextExcludesPrivateUnicodeCharactersUnitTests.cs
+++ b/src/RulesTest/Library/HelpTextExcludesPrivateUnicodeCharactersUnitTests.cs
@@ -3,7 +3,6 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.RulesTest.ControlType;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -18,7 +17,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.HelpText = "Hello";
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -27,14 +26,14 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.HelpText = "Hello \uE000";
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void HelpTextExcludesPrivateUnicodeCharacters_NullElement_ThrowsArgumentNullException()
         {
-            Rule.Evaluate(null);
+            Rule.PassesTest(null);
         }
 
         [TestMethod]
@@ -43,7 +42,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
 
-            Rule.Evaluate(e);
+            Rule.PassesTest(e);
         }
 
         [TestMethod]
@@ -53,7 +52,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.HelpText = string.Empty;
 
-            Rule.Evaluate(e);
+            Rule.PassesTest(e);
         }
 
         [TestMethod]
@@ -63,7 +62,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.HelpText = " ";
 
-            Rule.Evaluate(e);
+            Rule.PassesTest(e);
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/HyperlinkNameShouldBeUniqueTest.cs
+++ b/src/RulesTest/Library/HyperlinkNameShouldBeUniqueTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -30,7 +29,7 @@ namespace Axe.Windows.RulesTest.Library
             parent.Children.Add(child1);
             parent.Children.Add(child2);
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+            Assert.IsTrue(Rule.PassesTest(child2));
         }
 
         [TestMethod]
@@ -52,7 +51,7 @@ namespace Axe.Windows.RulesTest.Library
             parent.Children.Add(child1);
             parent.Children.Add(child2);
 
-            Assert.AreEqual(EvaluationCode.Warning, Rule.Evaluate(child2));
+            Assert.IsFalse(Rule.PassesTest(child2));
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/IsKeyboardFocusableOnEmptyContainer.cs
+++ b/src/RulesTest/Library/IsKeyboardFocusableOnEmptyContainer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -77,7 +76,7 @@ namespace Axe.Windows.RulesTest.Library
             e.IsKeyboardFocusable = false;
             e.BoundingRectangle = new System.Drawing.Rectangle(0, 0, 100, 100);
 
-            Assert.AreEqual(EvaluationCode.Open, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/IsKeyboardFocusableShouldBeTrue.cs
+++ b/src/RulesTest/Library/IsKeyboardFocusableShouldBeTrue.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -17,7 +16,7 @@ namespace Axe.Windows.RulesTest.Library
             using (var e = new MockA11yElement())
             {
                 e.IsKeyboardFocusable = true;
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -26,14 +25,14 @@ namespace Axe.Windows.RulesTest.Library
         {
             using (var e = new MockA11yElement())
             {
-                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
 
         [TestMethod]
         public void TestIsKeyboardFocusableShouldBeTrueArgumentNullException()
         {
-            Action action = () => Rule.Evaluate(null);
+            Action action = () => Rule.PassesTest(null);
             Assert.ThrowsException<ArgumentNullException>(action);
         }
 

--- a/src/RulesTest/Library/LandmarkIsTopLevel.cs
+++ b/src/RulesTest/Library/LandmarkIsTopLevel.cs
@@ -3,7 +3,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Axe.Windows.Core.Bases;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 using Axe.Windows.Core.Types;
 
 namespace Axe.Windows.RulesTest.Library
@@ -31,7 +30,7 @@ namespace Axe.Windows.RulesTest.Library
             e.LocalizedLandmarkType = this.LocalizedLandmarkType;
             e.Parent = parent;
 
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -45,7 +44,7 @@ namespace Axe.Windows.RulesTest.Library
             parent.LandmarkType = this.LandmarkType;
             parent.LocalizedLandmarkType = this.LocalizedLandmarkType;
 
-            Assert.AreEqual(EvaluationCode.Error, this.Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -62,7 +61,7 @@ namespace Axe.Windows.RulesTest.Library
             m.Setup(e => e.Parent).Returns(parent);
 
             // the result below should pass because the parent is not inside Edge like the child.
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(m.Object));
+            Assert.IsTrue(Rule.PassesTest(m.Object));
         }
 
         [TestMethod]
@@ -80,7 +79,7 @@ namespace Axe.Windows.RulesTest.Library
             m.Setup(e => e.Parent).Returns(parent.Object);
 
             // the result below should pass because the parent is not inside Edge like the child.
-            Assert.AreEqual(EvaluationCode.Error, this.Rule.Evaluate(m.Object));
+            Assert.IsFalse(Rule.PassesTest(m.Object));
         }
     } // class
 

--- a/src/RulesTest/Library/ListItemSiblingUniqueTests.cs
+++ b/src/RulesTest/Library/ListItemSiblingUniqueTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -32,7 +31,7 @@ namespace Axe.Windows.RulesTest.Library
             parent.Children.Add(child1);
             parent.Children.Add(child2);
 
-            Assert.AreEqual(EvaluationCode.Warning, Rule.Evaluate(child2));
+            Assert.IsFalse(Rule.PassesTest(child2));
         }
 
         [TestMethod]
@@ -56,7 +55,7 @@ namespace Axe.Windows.RulesTest.Library
             parent.Children.Add(child1);
             parent.Children.Add(child2);
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+            Assert.IsTrue(Rule.PassesTest(child2));
         }
 
         [TestMethod]
@@ -80,7 +79,7 @@ namespace Axe.Windows.RulesTest.Library
             parent.Children.Add(child1);
             parent.Children.Add(child2);
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+            Assert.IsTrue(Rule.PassesTest(child2));
         }
 
         [TestMethod]
@@ -104,7 +103,7 @@ namespace Axe.Windows.RulesTest.Library
             parent.Children.Add(child1);
             parent.Children.Add(child2);
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+            Assert.IsTrue(Rule.PassesTest(child2));
         }
 
         [TestMethod]
@@ -128,7 +127,7 @@ namespace Axe.Windows.RulesTest.Library
             parent.Children.Add(child1);
             parent.Children.Add(child2);
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+            Assert.IsTrue(Rule.PassesTest(child2));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/LocalizedControlTypeExcludesPrivateUnicodeCharactersUnitTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeExcludesPrivateUnicodeCharactersUnitTests.cs
@@ -3,7 +3,6 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.RulesTest.ControlType;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -18,7 +17,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.LocalizedControlType = "Hello";
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -27,14 +26,14 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.LocalizedControlType = "Hello \uE000";
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void LocalizedControlTypeExcludesPrivateUnicodeCharacters_NullElement_ThrowsArgumentNullException()
         {
-            Rule.Evaluate(null);
+            Rule.PassesTest(null);
         }
 
         [TestMethod]
@@ -43,7 +42,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
 
-            Rule.Evaluate(e);
+            Rule.PassesTest(e);
         }
 
         [TestMethod]
@@ -53,7 +52,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.LocalizedControlType = string.Empty;
 
-            Rule.Evaluate(e);
+            Rule.PassesTest(e);
         }
 
         [TestMethod]
@@ -63,7 +62,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.LocalizedControlType = " ";
 
-            Rule.Evaluate(e);
+            Rule.PassesTest(e);
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotCustom.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotCustom.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -99,7 +98,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.LocalizedControlType = "custom";
 
-            Assert.AreEqual(EvaluationCode.Error, this.Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -108,7 +107,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.LocalizedControlType = "not custom";
 
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
     } // class
 } // LocalizedControlTypespace

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -95,7 +94,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.LocalizedControlType = "custom";
 
-            Assert.AreEqual(EvaluationCode.Error, this.Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -104,7 +103,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.LocalizedControlType = "not custom";
 
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
     } // class
 } // LocalizedControlTypespace

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotEmpty.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotEmpty.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -28,7 +27,7 @@ namespace Axe.Windows.RulesTest.Library
             e.IsKeyboardFocusable = true;
 
             Assert.IsTrue(Rule.Condition.Matches(e));
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -38,7 +37,7 @@ namespace Axe.Windows.RulesTest.Library
             e.IsKeyboardFocusable = true;
             e.LocalizedControlType = "abc";
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotNull.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotNull.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -18,7 +17,7 @@ namespace Axe.Windows.RulesTest.Library
             e.LocalizedControlType = null;
             e.IsKeyboardFocusable = true;
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -37,7 +36,7 @@ namespace Axe.Windows.RulesTest.Library
             e.IsKeyboardFocusable = true;
             e.LocalizedControlType = "abc";
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotWhiteSpace.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotWhiteSpace.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -39,7 +38,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.LocalizedControlType = "   ";
-            Assert.AreEqual(EvaluationCode.Error, this.Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -47,7 +46,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.LocalizedControlType = "hello world!";
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
     } // class
 } // LocalizedControlTypespace

--- a/src/RulesTest/Library/LocalizedControlTypeIsReasonable.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsReasonable.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.RulesTest.ControlType;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -18,7 +17,7 @@ namespace Axe.Windows.RulesTest.Library
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_AppBarControlTypeId;
             e.LocalizedControlType = "app bar";
 
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -28,7 +27,7 @@ namespace Axe.Windows.RulesTest.Library
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_AppBarControlTypeId;
             e.LocalizedControlType = "custom";
 
-            Assert.AreEqual(EvaluationCode.Warning, this.Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -45,10 +44,10 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.ControlTypeId = Hyperlink;
             e.LocalizedControlType = "hyperlink"; 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
 
             e.LocalizedControlType = "link";
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -57,7 +56,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.ControlTypeId = Hyperlink;
             e.LocalizedControlType = "Hyperlink";
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
     } // class
 } // LocalizedControlTypespace

--- a/src/RulesTest/Library/LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters.cs
+++ b/src/RulesTest/Library/LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -17,7 +16,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.LocalizedLandmarkType = "Hello";
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -26,14 +25,14 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.LocalizedLandmarkType = "Hello \uE000";
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters_NullElement_ThrowsArgumentNullException()
         {
-            Rule.Evaluate(null);
+            Rule.PassesTest(null);
         }
 
         [TestMethod]
@@ -42,7 +41,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
 
-            Rule.Evaluate(e);
+            Rule.PassesTest(e);
         }
 
         [TestMethod]
@@ -52,7 +51,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.LocalizedLandmarkType = string.Empty;
 
-            Rule.Evaluate(e);
+            Rule.PassesTest(e);
         }
 
         [TestMethod]
@@ -62,7 +61,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.LocalizedLandmarkType = " ";
 
-            Rule.Evaluate(e);
+            Rule.PassesTest(e);
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/LocalizedLandmarkTypeNotCustomTests.cs
+++ b/src/RulesTest/Library/LocalizedLandmarkTypeNotCustomTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Types;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -18,7 +17,7 @@ namespace Axe.Windows.RulesTest.Library
             {
                 e.LandmarkType = LandmarkType.UIA_CustomLandmarkTypeId;
                 e.LocalizedLandmarkType = "not custom";
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -29,7 +28,7 @@ namespace Axe.Windows.RulesTest.Library
             {
                 e.LandmarkType = LandmarkType.UIA_CustomLandmarkTypeId;
                 e.LocalizedLandmarkType = "Custom";
-                Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
     } // class

--- a/src/RulesTest/Library/NameExcludesControlType.cs
+++ b/src/RulesTest/Library/NameExcludesControlType.cs
@@ -3,7 +3,6 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.RulesTest.ControlType;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -19,7 +18,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Name = "This is a button";
             e.ControlTypeId = CheckBox;
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -29,7 +28,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Name = "Customize";
             e.ControlTypeId = Custom;
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -39,7 +38,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Name = "This is a button, yep";
             e.ControlTypeId = Button;
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -49,7 +48,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Name = "Custom";
             e.ControlTypeId = Custom;
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -60,7 +59,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Name = "Button";
             e.ControlTypeId = 0; // invalid
 
-            Rule.Evaluate(e);
+            Rule.PassesTest(e);
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/NameExcludesLocalizedControlType.cs
+++ b/src/RulesTest/Library/NameExcludesLocalizedControlType.cs
@@ -4,7 +4,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
 using static Axe.Windows.RulesTest.ControlType;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -20,7 +19,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Name = "This is a button";
             e.LocalizedControlType = "Checkbox";
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -30,7 +29,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Name = "Comfortable";
             e.LocalizedControlType = "Tab";
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -40,7 +39,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Name = "This is a button, yep";
             e.LocalizedControlType = "Button";
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -50,7 +49,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Name = "Custom";
             e.LocalizedControlType = "Custom";
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -61,7 +60,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Name = null;
             e.LocalizedControlType = "Button";
 
-            Rule.Evaluate(e);
+            Rule.PassesTest(e);
         }
 
         [TestMethod]
@@ -72,7 +71,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Name = "name";
             e.LocalizedControlType = null;
 
-            Rule.Evaluate(e);
+            Rule.PassesTest(e);
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/NameExcludesPrivateUnicodeCharactersUnitTests.cs
+++ b/src/RulesTest/Library/NameExcludesPrivateUnicodeCharactersUnitTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -17,7 +16,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Name = "Hello";
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -26,14 +25,14 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Name = "Hello \uE000";
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void NameExcludesPrivateUnicodeCharacters_NullElement_ThrowsArgumentNullException()
         {
-            Rule.Evaluate(null);
+            Rule.PassesTest(null);
         }
 
         [TestMethod]
@@ -42,7 +41,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
 
-            Rule.Evaluate(e);
+            Rule.PassesTest(e);
         }
 
         [TestMethod]
@@ -52,7 +51,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Name = string.Empty;
 
-            Rule.Evaluate(e);
+            Rule.PassesTest(e);
         }
 
         [TestMethod]
@@ -62,7 +61,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Name = " ";
 
-            Rule.Evaluate(e);
+            Rule.PassesTest(e);
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/NameIsEmptyButElementIsNotKeyboardFocusableTest.cs
+++ b/src/RulesTest/Library/NameIsEmptyButElementIsNotKeyboardFocusableTest.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Drawing;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 using static Axe.Windows.RulesTest.ControlType;
 
 namespace Axe.Windows.RulesTest.Library
@@ -18,7 +18,7 @@ namespace Axe.Windows.RulesTest.Library
             using (var e = new MockA11yElement())
             {
                 e.Name = "Bob";
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -28,14 +28,15 @@ namespace Axe.Windows.RulesTest.Library
             using (var e = new MockA11yElement())
             {
                 e.Name = "";
-                Assert.AreEqual(EvaluationCode.Open, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
 
         [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
         public void TestNameIsEmptyButElementIsNotKeyboardFocusableNullArgument()
         {
-            Assert.AreEqual(EvaluationCode.RuleExecutionError, Rule.Evaluate(null));
+            Rule.PassesTest(null);
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/NameIsInformative.cs
+++ b/src/RulesTest/Library/NameIsInformative.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -36,7 +35,7 @@ namespace Axe.Windows.RulesTest.Library
                 foreach (var s in stringsToTry)
                     {
                     e.Name = s;
-                    Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                    Assert.IsFalse(Rule.PassesTest(e));
                 }
             } // using
         }
@@ -59,7 +58,7 @@ namespace Axe.Windows.RulesTest.Library
                 foreach (var s in stringsToTry)
                 {
                     e.Name = s;
-                    Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                    Assert.IsTrue(Rule.PassesTest(e));
                 }
             } // using
         }

--- a/src/RulesTest/Library/NameIsNotEmpty.cs
+++ b/src/RulesTest/Library/NameIsNotEmpty.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 using static Axe.Windows.RulesTest.ControlType;
 using System.Drawing;
 
@@ -19,7 +18,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Name = "";
 
-            Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -28,7 +27,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Name = " ";
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/NameIsNotNull.cs
+++ b/src/RulesTest/Library/NameIsNotNull.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 using static Axe.Windows.RulesTest.ControlType;
 
 namespace Axe.Windows.RulesTest.Library
@@ -19,7 +18,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Name = null;
 
-            Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -28,7 +27,7 @@ namespace Axe.Windows.RulesTest.Library
             var e = new MockA11yElement();
             e.Name = "";
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/NameIsNotWhiteSpace.cs
+++ b/src/RulesTest/Library/NameIsNotWhiteSpace.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -39,7 +38,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.Name = "   ";
-            Assert.AreNotEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsFalse(this.Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -47,7 +46,7 @@ namespace Axe.Windows.RulesTest.Library
         {
             var e = new MockA11yElement();
             e.Name = "hello world!";
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/NameIsNullButElementIsNotKeyboardFocusableTest.cs
+++ b/src/RulesTest/Library/NameIsNullButElementIsNotKeyboardFocusableTest.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Drawing;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 using static Axe.Windows.RulesTest.ControlType;
 
 namespace Axe.Windows.RulesTest.Library
@@ -18,7 +18,7 @@ namespace Axe.Windows.RulesTest.Library
             using (var e = new MockA11yElement())
             {
                 e.Name = "";
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -27,14 +27,15 @@ namespace Axe.Windows.RulesTest.Library
         {
             using (var e = new MockA11yElement())
             {
-                Assert.AreEqual(EvaluationCode.Open, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
 
         [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
         public void TestNameIsNullButElementIsNotKeyboardFocusableNullArgument()
         {
-            Assert.AreEqual(EvaluationCode.RuleExecutionError, Rule.Evaluate(null));
+            Rule.PassesTest(null);
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/NameIsReasonableLength.cs
+++ b/src/RulesTest/Library/NameIsReasonableLength.cs
@@ -4,7 +4,6 @@ using System;
 using System.Text;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -19,7 +18,7 @@ namespace Axe.Windows.RulesTest.Library
             using (var e = new MockA11yElement())
             {
                 e.Name = "Hello";
-                Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 
@@ -33,14 +32,14 @@ namespace Axe.Windows.RulesTest.Library
                     s.Append(s.ToString() + s.ToString());
 
                 e.Name = s.ToString();
-                Assert.AreNotEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+                Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
 
         [TestMethod]
         public void TestNullElement()
         {
-            Action action = () => { Rule.Evaluate(null); };
+            Action action = () => { Rule.PassesTest(null); };
             Assert.ThrowsException<ArgumentNullException>(action);
         }
 
@@ -50,7 +49,7 @@ namespace Axe.Windows.RulesTest.Library
             using (var e = new MockA11yElement())
             {
                 e.LocalizedControlType = "Button";
-                Action action = () => { Rule.Evaluate(e); };
+                Action action = () => { Rule.PassesTest(e); };
                 Assert.ThrowsException<ArgumentException>(action);
             } // using
         }

--- a/src/RulesTest/Library/ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs
+++ b/src/RulesTest/Library/ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -44,7 +43,7 @@ namespace Axe.Windows.RulesTest.Library
             p.LocalizedControlType = "controltype";
             e.Parent = p;
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -58,7 +57,7 @@ namespace Axe.Windows.RulesTest.Library
             p.LocalizedControlType = "controltype2";
             e.Parent = p;
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -72,7 +71,7 @@ namespace Axe.Windows.RulesTest.Library
             p.LocalizedControlType = "controltype";
             e.Parent = p;
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/ProgressBarRangeValue.cs
+++ b/src/RulesTest/Library/ProgressBarRangeValue.cs
@@ -5,7 +5,6 @@ using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -36,7 +35,7 @@ namespace Axe.Windows.RulesTest.Library
             AddPatternValue("Minimum", 0);
             AddPatternValue("Maximum", 1);
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(elementMock.Object));
+            Assert.IsTrue(Rule.PassesTest(elementMock.Object));
 
             patternMock.Verify();
             elementMock.Verify();
@@ -49,7 +48,7 @@ namespace Axe.Windows.RulesTest.Library
             AddPatternValue("Minimum", 1);
             AddPatternValue("Maximum", 1);
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(elementMock.Object));
+            Assert.IsFalse(Rule.PassesTest(elementMock.Object));
 
             patternMock.Verify();
             elementMock.Verify();
@@ -62,7 +61,7 @@ namespace Axe.Windows.RulesTest.Library
             AddPatternValue("Minimum", 1);
             AddPatternValue("Maximum", 0);
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(elementMock.Object));
+            Assert.IsFalse(Rule.PassesTest(elementMock.Object));
 
             patternMock.Verify();
             elementMock.Verify();
@@ -75,7 +74,7 @@ namespace Axe.Windows.RulesTest.Library
             AddPatternValue("Minimum", 0);
             AddPatternValue("Maximum", 1);
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(elementMock.Object));
+            Assert.IsFalse(Rule.PassesTest(elementMock.Object));
 
             patternMock.Verify();
             elementMock.Verify();
@@ -85,7 +84,7 @@ namespace Axe.Windows.RulesTest.Library
         [ExpectedException(typeof(ArgumentNullException))]
         public void ProgressBarRangeValue_NullElement_ThrowsException()
         {
-            Rule.Evaluate(null);
+            Rule.PassesTest(null);
         }
 
         [TestMethod]
@@ -94,7 +93,7 @@ namespace Axe.Windows.RulesTest.Library
             elementMock.Reset();
             elementMock.Setup(e => e.GetPattern(PatternType.UIA_RangeValuePatternId)).Returns<IA11yPattern>(null);
 
-            var ex = Assert.ThrowsException<ArgumentNullException>(() => Rule.Evaluate(elementMock.Object));
+            var ex = Assert.ThrowsException<ArgumentNullException>(() => Rule.PassesTest(elementMock.Object));
             Assert.AreEqual("pattern", ex.ParamName);
 
             elementMock.Verify();

--- a/src/RulesTest/Library/SelectionItemPatternSingleSelection.cs
+++ b/src/RulesTest/Library/SelectionItemPatternSingleSelection.cs
@@ -5,7 +5,6 @@ using Moq;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 using static Axe.Windows.RulesTest.ControlType;
 
 namespace Axe.Windows.RulesTest.Library
@@ -51,7 +50,7 @@ namespace Axe.Windows.RulesTest.Library
 
             parent.Setup(e => e.Children).Returns(children);
 
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(item3.Object));
+            Assert.IsTrue(Rule.PassesTest(item3.Object));
         }
 
         [TestMethod]
@@ -67,7 +66,7 @@ namespace Axe.Windows.RulesTest.Library
 
             parent.Setup(e => e.Children).Returns(children);
 
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(item3.Object));
+            Assert.IsTrue(Rule.PassesTest(item3.Object));
         }
 
         [TestMethod]
@@ -82,7 +81,7 @@ namespace Axe.Windows.RulesTest.Library
             IA11yElement[] children = { item1.Object, item2.Object, item3.Object };
             parent.Setup(e => e.Children).Returns(children);
 
-            Assert.AreEqual(EvaluationCode.Error, this.Rule.Evaluate(item3.Object));
+            Assert.IsFalse(Rule.PassesTest(item3.Object));
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/SiblingUniqueAndFocusableTest.cs
+++ b/src/RulesTest/Library/SiblingUniqueAndFocusableTest.cs
@@ -4,7 +4,6 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -43,7 +42,7 @@ namespace Axe.Windows.RulesTest.Library
             var child2 = parent.Children[1] as MockA11yElement;
             child2.LocalizedControlType = "MyType2";
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+            Assert.IsTrue(Rule.PassesTest(child2));
         }
 
         [TestMethod]
@@ -53,7 +52,7 @@ namespace Axe.Windows.RulesTest.Library
             var child2 = parent.Children[1] as MockA11yElement;
             child2.Name = "Bob";
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+            Assert.IsTrue(Rule.PassesTest(child2));
         }
 
         [TestMethod]
@@ -63,7 +62,7 @@ namespace Axe.Windows.RulesTest.Library
             var child2 = parent.Children[1] as MockA11yElement;
             child2.IsKeyboardFocusable = false;
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+            Assert.IsTrue(Rule.PassesTest(child2));
         }
 
         [TestMethod]
@@ -73,7 +72,7 @@ namespace Axe.Windows.RulesTest.Library
             var child2 = parent.Children[1] as MockA11yElement;
             child2.Patterns.Add(new A11yPattern(child2, PatternIDs.GridItem));
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+            Assert.IsTrue(Rule.PassesTest(child2));
         }
 
         [TestMethod]
@@ -82,7 +81,7 @@ namespace Axe.Windows.RulesTest.Library
             var parent = CreateParentWithMatchingChildren();
             var child2 = parent.Children[1] as MockA11yElement;
 
-            Assert.AreEqual(EvaluationCode.Error, Rule.Evaluate(child2));
+            Assert.IsFalse(Rule.PassesTest(child2));
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/SiblingUniqueAndNotFocusableTest.cs
+++ b/src/RulesTest/Library/SiblingUniqueAndNotFocusableTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -32,7 +31,7 @@ namespace Axe.Windows.RulesTest.Library
             parent.Children.Add(child1);
             parent.Children.Add(child2);
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+            Assert.IsTrue(Rule.PassesTest(child2));
         }
 
         [TestMethod]
@@ -56,7 +55,7 @@ namespace Axe.Windows.RulesTest.Library
             parent.Children.Add(child1);
             parent.Children.Add(child2);
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+            Assert.IsTrue(Rule.PassesTest(child2));
         }
 
         [TestMethod]
@@ -80,7 +79,7 @@ namespace Axe.Windows.RulesTest.Library
             parent.Children.Add(child1);
             parent.Children.Add(child2);
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+            Assert.IsTrue(Rule.PassesTest(child2));
         }
 
         [TestMethod]
@@ -104,7 +103,7 @@ namespace Axe.Windows.RulesTest.Library
             parent.Children.Add(child1);
             parent.Children.Add(child2);
 
-            Assert.AreEqual(EvaluationCode.Note, Rule.Evaluate(child2));
+            Assert.IsFalse(Rule.PassesTest(child2));
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/SplitButtonInvokeAndTogglePatterns.cs
+++ b/src/RulesTest/Library/SplitButtonInvokeAndTogglePatterns.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 using Axe.Windows.Core.Types;
 
 namespace Axe.Windows.RulesTest.Library
@@ -23,7 +22,7 @@ namespace Axe.Windows.RulesTest.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_InvokePatternId));
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_TogglePatternId));
 
-            Assert.AreEqual(EvaluationCode.Error, this.Rule.Evaluate(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         /// <summary>
@@ -37,7 +36,7 @@ namespace Axe.Windows.RulesTest.Library
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_SplitButtonControlTypeId;
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_InvokePatternId));
 
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         /// <summary>
@@ -51,7 +50,7 @@ namespace Axe.Windows.RulesTest.Library
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_SplitButtonControlTypeId;
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_TogglePatternId));
 
-            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(e));
+            Assert.IsTrue(Rule.PassesTest(e));
         }
 
         /// <summary>


### PR DESCRIPTION
#### Describe the change

    Adding the evaluation code to the rule's info will allow us to automatically generate documentation which provides the rule's expected error code.

This is a large change. When reviewing please try to make sure the expected error code for each rule is consistent with its former value. (Those changes were made by hand.)

All the changes in the test files were made by a search and replace.
