### PR TITLE
Chore: Update rules to use the new PassesTest method instead of Evaluate

### DIFF
--- a/src/Rules/Library/Structure/ContentView/Button.cs
+++ b/src/Rules/Library/Structure/ContentView/Button.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.ButtonStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.ButtonStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.ButtonStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.ButtonStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/Calendar.cs
+++ b/src/Rules/Library/Structure/ContentView/Calendar.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.CalendarStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.CalendarStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.CalendarStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.CalendarStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/CheckBox.cs
+++ b/src/Rules/Library/Structure/ContentView/CheckBox.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.CheckBoxStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.CheckBoxStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.CheckBoxStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.CheckBoxStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/ComboBox.cs
+++ b/src/Rules/Library/Structure/ContentView/ComboBox.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.ComboBoxStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.ComboBoxStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.ComboBoxStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.ComboBoxStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/DataGrid.cs
+++ b/src/Rules/Library/Structure/ContentView/DataGrid.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.DataGridStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.DataGridStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.DataGridStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.DataGridStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/Edit.cs
+++ b/src/Rules/Library/Structure/ContentView/Edit.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.EditStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.EditStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.EditStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.EditStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/Hyperlink.cs
+++ b/src/Rules/Library/Structure/ContentView/Hyperlink.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.HyperlinkStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.HyperlinkStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.HyperlinkStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.HyperlinkStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/List.cs
+++ b/src/Rules/Library/Structure/ContentView/List.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.ListStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.ListStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.ListStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.ListStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/ListItem.cs
+++ b/src/Rules/Library/Structure/ContentView/ListItem.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.ListItemStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.ListItemStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.ListItemStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.ListItemStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/Menu.cs
+++ b/src/Rules/Library/Structure/ContentView/Menu.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.MenuStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.MenuStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.MenuStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.MenuStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/ProgressBar.cs
+++ b/src/Rules/Library/Structure/ContentView/ProgressBar.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.ProgressBarStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.ProgressBarStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.ProgressBarStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.ProgressBarStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/RadioButton.cs
+++ b/src/Rules/Library/Structure/ContentView/RadioButton.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.RadioButtonStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.RadioButtonStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.RadioButtonStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.RadioButtonStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/Slider.cs
+++ b/src/Rules/Library/Structure/ContentView/Slider.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.SliderStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.SliderStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.SliderStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.SliderStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/Spinner.cs
+++ b/src/Rules/Library/Structure/ContentView/Spinner.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.SpinnerStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.SpinnerStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.SpinnerStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.SpinnerStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/SplitButton.cs
+++ b/src/Rules/Library/Structure/ContentView/SplitButton.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.SplitButtonStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.SplitButtonStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.SplitButtonStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.SplitButtonStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/StatusBar.cs
+++ b/src/Rules/Library/Structure/ContentView/StatusBar.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.StatusBarStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.StatusBarStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.StatusBarStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.StatusBarStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/Tab.cs
+++ b/src/Rules/Library/Structure/ContentView/Tab.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.TabStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.TabStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.TabStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.TabStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/Tree.cs
+++ b/src/Rules/Library/Structure/ContentView/Tree.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.TreeStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.TreeStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.TreeStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.TreeStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ContentView/TreeItem.cs
+++ b/src/Rules/Library/Structure/ContentView/TreeItem.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.TreeItemStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.TreeItemStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ContentView.TreeItemStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ContentView.TreeItemStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/Button.cs
+++ b/src/Rules/Library/Structure/ControlView/Button.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ButtonStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ButtonStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.ButtonStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.ButtonStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/Calendar.cs
+++ b/src/Rules/Library/Structure/ControlView/Calendar.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.CalendarStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.CalendarStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.CalendarStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.CalendarStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/CheckBox.cs
+++ b/src/Rules/Library/Structure/ControlView/CheckBox.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.CheckBoxStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.CheckBoxStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.CheckBoxStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.CheckBoxStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/ComboBox.cs
+++ b/src/Rules/Library/Structure/ControlView/ComboBox.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ComboBoxStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ComboBoxStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.ComboBoxStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.ComboBoxStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/DataGrid.cs
+++ b/src/Rules/Library/Structure/ControlView/DataGrid.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.DataGridStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.DataGridStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.DataGridStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.DataGridStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/Edit.cs
+++ b/src/Rules/Library/Structure/ControlView/Edit.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.EditStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.EditStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.EditStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.EditStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/Header.cs
+++ b/src/Rules/Library/Structure/ControlView/Header.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.HeaderStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.HeaderStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.HeaderStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.HeaderStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/HeaderItem.cs
+++ b/src/Rules/Library/Structure/ControlView/HeaderItem.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.HeaderItemStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.HeaderItemStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.HeaderItemStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.HeaderItemStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/Hyperlink.cs
+++ b/src/Rules/Library/Structure/ControlView/Hyperlink.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.HyperlinkStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.HyperlinkStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.HyperlinkStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.HyperlinkStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/Image.cs
+++ b/src/Rules/Library/Structure/ControlView/Image.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ImageStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ImageStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.ImageStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.ImageStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/List.cs
+++ b/src/Rules/Library/Structure/ControlView/List.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ListStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ListStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.ListStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.ListStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/ListItem.cs
+++ b/src/Rules/Library/Structure/ControlView/ListItem.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ListItemStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ListItemStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.ListItemStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.ListItemStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/Menu.cs
+++ b/src/Rules/Library/Structure/ControlView/Menu.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.MenuStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.MenuStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.MenuStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.MenuStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/ProgressBar.cs
+++ b/src/Rules/Library/Structure/ControlView/ProgressBar.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ProgressBarStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ProgressBarStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.ProgressBarStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.ProgressBarStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/RadioButton.cs
+++ b/src/Rules/Library/Structure/ControlView/RadioButton.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.RadioButtonStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.RadioButtonStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.RadioButtonStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.RadioButtonStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/Scrollbar.cs
+++ b/src/Rules/Library/Structure/ControlView/Scrollbar.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ScrollbarStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ScrollbarStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.ScrollbarStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.ScrollbarStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/SemanticZoom.cs
+++ b/src/Rules/Library/Structure/ControlView/SemanticZoom.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.SemanticZoomStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.SemanticZoomStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.SemanticZoomStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.SemanticZoomStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/Separator.cs
+++ b/src/Rules/Library/Structure/ControlView/Separator.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.SeparatorStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.SeparatorStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.SeparatorStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.SeparatorStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/Slider.cs
+++ b/src/Rules/Library/Structure/ControlView/Slider.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.SliderStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.SliderStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.SliderStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.SliderStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/Spinner.cs
+++ b/src/Rules/Library/Structure/ControlView/Spinner.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.SpinnerStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.SpinnerStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.SpinnerStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.SpinnerStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/SplitButton.cs
+++ b/src/Rules/Library/Structure/ControlView/SplitButton.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.SplitButtonStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.SplitButtonStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.SplitButtonStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.SplitButtonStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/StatusBar.cs
+++ b/src/Rules/Library/Structure/ControlView/StatusBar.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.StatusBarStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.StatusBarStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.StatusBarStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.StatusBarStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/Tab.cs
+++ b/src/Rules/Library/Structure/ControlView/Tab.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.TabStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.TabStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.TabStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.TabStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/Thumb.cs
+++ b/src/Rules/Library/Structure/ControlView/Thumb.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ThumbStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ThumbStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.ThumbStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.ThumbStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/ToolTip.cs
+++ b/src/Rules/Library/Structure/ControlView/ToolTip.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ToolTipStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ToolTipStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.ToolTipStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.ToolTipStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/Tree.cs
+++ b/src/Rules/Library/Structure/ControlView/Tree.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.TreeStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.TreeStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.TreeStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.TreeStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/Structure/ControlView/TreeItem.cs
+++ b/src/Rules/Library/Structure/ControlView/TreeItem.cs
@@ -18,13 +18,14 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.TreeItemStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.TreeItemStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            this.Info.ErrorCode = EvaluationCode.Note;
         }
 
-        public override EvaluationCode Evaluate(IA11yElement e)
+        public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return ControlView.TreeItemStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+            return ControlView.TreeItemStructure.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/RulesTest/Library/Structure/ContentView/SpinnerTests.cs
+++ b/src/RulesTest/Library/Structure/ContentView/SpinnerTests.cs
@@ -17,7 +17,7 @@ namespace Axe.Windows.RulesTest.Library.Structure.ContentView
             var spinner = new MockA11yElement();
             spinner.ControlTypeId = ControlType.Spinner;
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(spinner));
+            Assert.IsTrue(Rule.PassesTest(spinner));
         }
 
         [TestMethod]
@@ -31,7 +31,7 @@ namespace Axe.Windows.RulesTest.Library.Structure.ContentView
 
             spinner.Children.Add(listItem);
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(spinner));
+            Assert.IsTrue(Rule.PassesTest(spinner));
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/Structure/ControlView/ScrollbarTest.cs
+++ b/src/RulesTest/Library/Structure/ControlView/ScrollbarTest.cs
@@ -5,7 +5,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System.Collections.Generic;
 using System.Linq;
-using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTest.Library
 {
@@ -21,7 +20,7 @@ namespace Axe.Windows.RulesTest.Library
             var m = new Mock<IA11yElement>();
             m.Setup(e => e.ControlTypeId).Returns(ControlType.ScrollBar);
             
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(m.Object));
+            Assert.IsTrue(Rule.PassesTest(m.Object));
         }
 
         [TestMethod]
@@ -34,7 +33,7 @@ namespace Axe.Windows.RulesTest.Library
                 { Core.Types.ControlType.UIA_ButtonControlTypeId, 1 },
             }));
 
-            Assert.AreEqual(EvaluationCode.Note, Rule.Evaluate(m.Object));
+            Assert.IsFalse(Rule.PassesTest(m.Object));
         }
 
         [TestMethod]
@@ -47,7 +46,7 @@ namespace Axe.Windows.RulesTest.Library
                 { Core.Types.ControlType.UIA_ButtonControlTypeId, 2 },
             }));
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(m.Object));
+            Assert.IsTrue(Rule.PassesTest(m.Object));
         }
 
         [TestMethod]
@@ -60,7 +59,7 @@ namespace Axe.Windows.RulesTest.Library
                 { Core.Types.ControlType.UIA_ButtonControlTypeId, 4 },
             }));
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(m.Object));
+            Assert.IsTrue(Rule.PassesTest(m.Object));
         }
 
         [TestMethod]
@@ -74,7 +73,7 @@ namespace Axe.Windows.RulesTest.Library
                 { Core.Types.ControlType.UIA_ThumbControlTypeId, 1 },
             }));
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(m.Object));
+            Assert.IsTrue(Rule.PassesTest(m.Object));
         }
 
         [TestMethod]
@@ -88,7 +87,7 @@ namespace Axe.Windows.RulesTest.Library
                 { Core.Types.ControlType.UIA_ThumbControlTypeId, 2 },
             }));
 
-            Assert.AreEqual(EvaluationCode.Note, Rule.Evaluate(m.Object));
+            Assert.IsFalse(Rule.PassesTest(m.Object));
         }
 
         /// <summary>

--- a/src/RulesTest/Library/Structure/ControlView/SpinnerTests.cs
+++ b/src/RulesTest/Library/Structure/ControlView/SpinnerTests.cs
@@ -26,7 +26,7 @@ namespace Axe.Windows.RulesTest.Library.Structure.ControlView
             spinner.Children.Add(button1);
             spinner.Children.Add(button2);
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(spinner));
+            Assert.IsTrue(Rule.PassesTest(spinner));
         }
 
         [TestMethod]
@@ -48,7 +48,7 @@ namespace Axe.Windows.RulesTest.Library.Structure.ControlView
             spinner.Children.Add(button2);
             spinner.Children.Add(listItem);
 
-            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(spinner));
+            Assert.IsTrue(Rule.PassesTest(spinner));
         }
     } // class
 } // namespace


### PR DESCRIPTION
#### Describe the change

        Adding the evaluation code to the rule's info will allow us to automatically generate documentation which provides the rule's expected error code.

This change covers the remaining set of rules to convert to the new PassesTest method. There are still changes yet to be made which will remove the old `Evaluate` method and to add unit tests ensuring all rules have ErrorCode` specified.
