### PR TITLE
Chore: Add error code to auto generated documentation

### DIFF
--- a/src/RulesMD/EvaluationCodeDescriptions.md
+++ b/src/RulesMD/EvaluationCodeDescriptions.md
@@ -1,0 +1,17 @@
+﻿## Severity descriptions
+
+### Error
+
+The given element did not meet the success criteria of the rule evaluation. The problem likely can be addressed by the developer and the impact to users is significant.
+
+### Warning
+
+The given element did not meet the success criteria of the rule evaluation, but the cause is known to be difficult for developers to fix (as in issues caused by the platform itself) or impact to users has been determined to be low.
+
+### Open
+
+There may be a problem, but the rule is unable to make a definitive determination. The element should be investigated.
+
+### Note
+
+The rule's description is informational and does not indicate success or failure.

--- a/src/RulesMD/MarkdownCreator.tt
+++ b/src/RulesMD/MarkdownCreator.tt
@@ -7,10 +7,12 @@
 
 ## Rules in Axe.Windows
 
-Name | Description | Standard referenced
---- | --- | ---
+Name | Severity | Description | Standard referenced
+--- | --- | --- | ---
 <# foreach (var rule in Rules.All.Values)
 {
 #>
-<#= rule.ID.ToString()#> | <#= rule.Description#> | <#= RulesMD.Helpers.GetStandardName(rule.Standard)#> <#= rule.Standard#>
+<#= rule.ID.ToString()#> | <#= rule.ErrorCode.ToString()#> | <#= rule.Description#> | <#= RulesMD.Helpers.GetStandardName(rule.Standard)#> <#= rule.Standard#>
 <#}#>
+
+<#@ include file="EvaluationCodeDescriptions.md" #>

--- a/src/RulesMD/RulesMD.csproj
+++ b/src/RulesMD/RulesMD.csproj
@@ -61,6 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="EvaluationCodeDescriptions.md" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
#### Details

Adding a column for error code to the autogenerated table of details for the axe-windows rules.

##### Motivation

Provides the error code/severity for each ule in axe-windows. This allows users to get a comprehensive overview of which rules throw which type of error code:  error/warning/open/note.