### PR TITLE
chore: Include missing control type in Exception message

### DIFF
--- a/src/Rules/Library/NameExcludesControlType.cs
+++ b/src/Rules/Library/NameExcludesControlType.cs
@@ -28,7 +28,7 @@ namespace Axe.Windows.Rules.Library
         public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
-            if (string.IsNullOrWhiteSpace(e.Name)) throw new ArgumentException(ErrorMessages.ElementNameNullOrWhiteSpace, nameof(e));
+            if (String.IsNullOrWhiteSpace(e.Name)) throw new ArgumentException(ErrorMessages.ElementNameNullOrWhiteSpace, nameof(e));
 
             if (!ControlTypeStrings.Dictionary.TryGetValue(e.ControlTypeId, out string controlTypeString))
             {

--- a/src/Rules/Library/NameExcludesControlType.cs
+++ b/src/Rules/Library/NameExcludesControlType.cs
@@ -7,6 +7,7 @@ using Axe.Windows.Rules.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
@@ -27,9 +28,13 @@ namespace Axe.Windows.Rules.Library
         public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
-            if (String.IsNullOrWhiteSpace(e.Name)) throw new ArgumentException(ErrorMessages.ElementNameNullOrWhiteSpace, nameof(e));
+            if (string.IsNullOrWhiteSpace(e.Name)) throw new ArgumentException(ErrorMessages.ElementNameNullOrWhiteSpace, nameof(e));
 
-            if (!ControlTypeStrings.Dictionary.TryGetValue(e.ControlTypeId, out string controlTypeString)) throw new InvalidOperationException(ErrorMessages.NoControlTypeEntryFound);
+            if (!ControlTypeStrings.Dictionary.TryGetValue(e.ControlTypeId, out string controlTypeString))
+            {
+                string exceptionMessage = string.Format(CultureInfo.InvariantCulture, ErrorMessages.NoControlTypeEntryFound, e.ControlTypeId);
+                throw new InvalidOperationException(exceptionMessage);
+            }
 
             var r = new Regex($@"\b{controlTypeString}\b", RegexOptions.IgnoreCase);
 

--- a/src/Rules/Resources/ErrorMessages.Designer.cs
+++ b/src/Rules/Resources/ErrorMessages.Designer.cs
@@ -151,7 +151,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No control type entry was found in dictionary.
+        ///   Looks up a localized string similar to No control type entry was found in dictionary. Key value = {0}.
         /// </summary>
         internal static string NoControlTypeEntryFound {
             get {

--- a/src/Rules/Resources/ErrorMessages.resx
+++ b/src/Rules/Resources/ErrorMessages.resx
@@ -148,7 +148,8 @@
     <value>Int parameter must not be less than zero</value>
   </data>
   <data name="NoControlTypeEntryFound" xml:space="preserve">
-    <value>No control type entry was found in dictionary</value>
+    <value>No control type entry was found in dictionary. Key value = {0}</value>
+    <comment>{0} is the numeric key</comment>
   </data>
   <data name="NoElementFound" xml:space="preserve">
     <value>Based on the Rule.Condition match, there should have been at least one element found in the PassesTest method of {0}</value>


### PR DESCRIPTION
#### Details

We have an Exception message that tells us that a control has an invalid ControlTypeId, but since the message doesn't tell us what the ID is, the message is not overly useful.

##### Motivation

Make the message more useful

##### Context

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
