### PR TITLE
chore: Standardize on lower case "string" instead of Pascal case "String"

### DIFF
--- a/src/Rules/Conditions/StringDecoratorCondition.cs
+++ b/src/Rules/Conditions/StringDecoratorCondition.cs
@@ -15,7 +15,7 @@ namespace Axe.Windows.Rules
         private Condition Sub;
         private readonly string Decoration;
 
-        public StringDecoratorCondition(Condition c, String decoration)
+        public StringDecoratorCondition(Condition c, string decoration)
         {
             if (c == null) throw new ArgumentNullException(nameof(c));
             if (decoration == null) throw new ArgumentNullException(nameof(decoration));

--- a/src/Rules/Library/HelpTextExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/HelpTextExcludesPrivateUnicodeCharacters.cs
@@ -26,7 +26,7 @@ namespace Axe.Windows.Rules.Library
         public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
-            if (String.IsNullOrWhiteSpace(e.HelpText)) throw new ArgumentException(ErrorMessages.ElementHelpTextNullOrWhiteSpace, nameof(e));
+            if (string.IsNullOrWhiteSpace(e.HelpText)) throw new ArgumentException(ErrorMessages.ElementHelpTextNullOrWhiteSpace, nameof(e));
 
             return HelpText.ExcludesPrivateUnicodeCharacters.Matches(e);
         }

--- a/src/Rules/Library/ListItemSiblingsUnique.cs
+++ b/src/Rules/Library/ListItemSiblingsUnique.cs
@@ -34,7 +34,7 @@ namespace Axe.Windows.Rules.Library
                 & Name.Is(e.Name)
                 & LocalizedControlType.Is(e.LocalizedControlType));
             var count = siblings.GetValue(e);
-            if (count < 1) throw new Exception(String.Format(CultureInfo.InvariantCulture, ErrorMessages.NoElementFound, this.Info.ID));
+            if (count < 1) throw new Exception(string.Format(CultureInfo.InvariantCulture, ErrorMessages.NoElementFound, this.Info.ID));
 
             return count == 1;
         }

--- a/src/Rules/Library/LocalizedControlTypeExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/LocalizedControlTypeExcludesPrivateUnicodeCharacters.cs
@@ -26,7 +26,7 @@ namespace Axe.Windows.Rules.Library
         public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
-            if (String.IsNullOrWhiteSpace(e.LocalizedControlType)) throw new ArgumentException(ErrorMessages.ElementLocalizedControlTypeNullOrWhiteSpace, nameof(e));
+            if (string.IsNullOrWhiteSpace(e.LocalizedControlType)) throw new ArgumentException(ErrorMessages.ElementLocalizedControlTypeNullOrWhiteSpace, nameof(e));
 
             return LocalizedControlType.ExcludesPrivateUnicodeCharacters.Matches(e);
         }

--- a/src/Rules/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.Rules.Library
         public LocalizedControlTypeIsNotCustomWPFGridCell()
         {
             this.Info.Description = Descriptions.LocalizedControlTypeNotCustom;
-            this.Info.HowToFix = String.Format(CultureInfo.CurrentCulture, HowToFix.LocalizedControlTypeNotCustomWPFGridCell, HowToFix.LocalizedControlTypeNotCustom);
+            this.Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.LocalizedControlTypeNotCustomWPFGridCell, HowToFix.LocalizedControlTypeNotCustom);
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
             this.Info.ErrorCode = EvaluationCode.Error;

--- a/src/Rules/Library/LocalizedControlTypeIsReasonable.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsReasonable.cs
@@ -36,7 +36,7 @@ namespace Axe.Windows.Rules.Library
 
             if (names == null) throw new InvalidProgramException(ErrorMessages.NoLocalizedControlTypeStringFound);
 
-            return Array.Exists(names, s => String.Compare(e.LocalizedControlType, s, StringComparison.OrdinalIgnoreCase) == 0);
+            return Array.Exists(names, s => string.Compare(e.LocalizedControlType, s, StringComparison.OrdinalIgnoreCase) == 0);
         }
 
         private static string[] GetExpectedLocalizedControlTypeNames(int controlTypeId)

--- a/src/Rules/Library/NameExcludesControlType.cs
+++ b/src/Rules/Library/NameExcludesControlType.cs
@@ -27,7 +27,7 @@ namespace Axe.Windows.Rules.Library
         public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
-            if (String.IsNullOrWhiteSpace(e.Name)) throw new ArgumentException(ErrorMessages.ElementNameNullOrWhiteSpace, nameof(e));
+            if (string.IsNullOrWhiteSpace(e.Name)) throw new ArgumentException(ErrorMessages.ElementNameNullOrWhiteSpace, nameof(e));
 
             if (!ControlTypeStrings.Dictionary.TryGetValue(e.ControlTypeId, out string controlTypeString)) throw new InvalidOperationException(ErrorMessages.NoControlTypeEntryFound);
 

--- a/src/Rules/Library/NameExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/NameExcludesPrivateUnicodeCharacters.cs
@@ -25,7 +25,7 @@ namespace Axe.Windows.Rules.Library
         public override bool PassesTest(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
-            if (String.IsNullOrWhiteSpace(e.Name)) throw new ArgumentException(ErrorMessages.ElementNameNullOrWhiteSpace, nameof(e));
+            if (string.IsNullOrWhiteSpace(e.Name)) throw new ArgumentException(ErrorMessages.ElementNameNullOrWhiteSpace, nameof(e));
 
             return Name.ExcludesPrivateUnicodeCharacters.Matches(e);
         }

--- a/src/Rules/PropertyConditions/Relationships.cs
+++ b/src/Rules/PropertyConditions/Relationships.cs
@@ -324,7 +324,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         public static Condition ExactlyOne(params Condition[] conditions)
         {
             var paramsString = ParameterizeConditionStrings(conditions);
-            var description = String.Format(CultureInfo.InvariantCulture, ConditionDescriptions.ExactlyOne, paramsString);
+            var description = string.Format(CultureInfo.InvariantCulture, ConditionDescriptions.ExactlyOne, paramsString);
 
             return Condition.Create(e => MatchExactlyOne(e, conditions), description);
         }
@@ -348,7 +348,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         public static Condition Any(params Condition[] conditions)
         {
             var paramsString = ParameterizeConditionStrings(conditions);
-            var description = String.Format(CultureInfo.InvariantCulture, ConditionDescriptions.Any, paramsString);
+            var description = string.Format(CultureInfo.InvariantCulture, ConditionDescriptions.Any, paramsString);
 
             return Condition.Create(e => MatchAny(e, conditions), description);
         }
@@ -366,7 +366,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         public static Condition All(params Condition[] conditions)
         {
             var paramsString = ParameterizeConditionStrings(conditions);
-            var description = String.Format(CultureInfo.InvariantCulture, ConditionDescriptions.All, paramsString);
+            var description = string.Format(CultureInfo.InvariantCulture, ConditionDescriptions.All, paramsString);
 
             return Condition.Create(e => MatchAll(e, conditions), description);
         }
@@ -386,7 +386,7 @@ namespace Axe.Windows.Rules.PropertyConditions
             string text = "";
             foreach (var c in conditions)
             {
-                if (!String.IsNullOrEmpty(text))
+                if (!string.IsNullOrEmpty(text))
                     text += ", ";
 
                 text += c.ToString();


### PR DESCRIPTION
#### Details

StyleCop used to insist that we use lower-case `string` instead of Pascal-case `String`. As a result, the vast majority of the code uses the lower-case version. There are a dozen outliers--one caught my attention so I decided to change them purely for consistency. This has no impact on the functionality of the code.

##### Motivation

Code consistency

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
