### PR TITLE
Chore: Eliminate useless exception

### DIFF
--- a/src/Rules/PropertyConditions/StringProperty.cs
+++ b/src/Rules/PropertyConditions/StringProperty.cs
@@ -161,8 +161,11 @@ namespace Axe.Windows.Rules.PropertyConditions
         {
             return Condition.Create(e =>
             {
+                var propertyValue = GetStringPropertyValue(e);
+                if (propertyValue == null) return false;
+
                 Regex r = new Regex(s);
-                return r.IsMatch(GetStringPropertyValue(e));
+                return r.IsMatch(propertyValue);
             },
             string.Format(CultureInfo.InvariantCulture, ConditionDescriptions.MatchesRegEx, PropertyDescription, s));
         }
@@ -171,8 +174,11 @@ namespace Axe.Windows.Rules.PropertyConditions
         {
             return Condition.Create(e =>
             {
+                var propertyValue = GetStringPropertyValue(e);
+                if (propertyValue == null) return false;
+
                 Regex r = new Regex(s, options);
-                return r.IsMatch(GetStringPropertyValue(e));
+                return r.IsMatch(propertyValue);
                 },
                 string.Format(CultureInfo.InvariantCulture, ConditionDescriptions.MatchesRegExWithOptions, PropertyDescription, s, options.ToString()));
         }

--- a/src/RulesTest/PropertyConditions/StringPropertiesTest.cs
+++ b/src/RulesTest/PropertyConditions/StringPropertiesTest.cs
@@ -385,5 +385,25 @@ namespace Axe.Windows.RulesTest.PropertyConditions
                 Assert.IsTrue(condition.Matches(e));
             } // using
         }
+
+        [TestMethod]
+        public void MatchesRegEx_NullProperty_False()
+        {
+            using (var e = new MockA11yElement())
+            {
+                var condition = Name.MatchesRegEx(@"foo");
+                Assert.IsFalse(condition.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void MatchesRegEx_WithOptions_NullProperty_False()
+        {
+            using (var e = new MockA11yElement())
+            {
+                var condition = Name.MatchesRegEx(@"foo", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+                Assert.IsFalse(condition.Matches(e));
+            } // using
+        }
     } // class
 } // namespace


### PR DESCRIPTION
#### Details

Previously, in `StringProperty.MatchesRegEx` we did not check the return value of `GetStringPropertyValue`, which could occasionally be null. In such cases, this caused a null access exception.

##### Motivation

We have seen cases in our telemetry which show us that sometimes string properties being tested can be null. This isn't especially valuable to us as telemetry. But it is possibly worse for users who may see these execution errors represented as accessibility errors in the UI.

##### Context

The decision to return false outright rather than log an exception is based on the simple logic that if a string property is null, it cannot possibly match a regular expression. And any other logical part of a test should be uneffected.