### PR TITLE
chore: Suppress warnings that VS 16.9.0 is suddenly generating

### DIFF
--- a/build/NetStandardRelease.targets
+++ b/build/NetStandardRelease.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <NoWarn>RS0100;RS0016</NoWarn>
+    <NoWarn>RS0100;RS0016;CA1002;CA1012;CA1014;CA1024;CA1508;CA1725;CA1813;CA2201;CS8073;IL3000</NoWarn>
     <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>


### PR DESCRIPTION
#### Details

VisualStudio 16.9.0 recently released, and builds with the new version are suddenly broken due to 10 new warnings that were not occurring before. We've reached out to the Visual Studio team to understand why VS suddenly decided to raise these warnings, but the quickest mitigation to get everyone unstuck is to suppress these warnings globally. 

##### Motivation

Allow the team to develop with VS 16.9.0

##### Context

This is a temporary mitigation to get unstuck. It comes with the understanding that we'll actually evaluate and maybe fix these issues going forward.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
