### PR TITLE
chore: Disable CG in unsigned builds

### DIFF
--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -58,11 +58,6 @@ jobs:
       command: test
       projects: |
         **\*test*.csproj
-        
-  # Command line
-  # Run a command line script using Bash on Linux and macOS and cmd.exe on Windows
-  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-    displayName: 'Component Detection'
 
 - job: Debug
   pool:


### PR DESCRIPTION
#### Details

Disable CG in unsigned builds. 

##### Motivation

Unsigned CG builds have recently failed, and when working, they don't block merging with bad components. CG works correctly in the signed pipeline, so there's no risk of accidentally releasing a bad component should it get introduced in a PR.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
