### PR TITLE
chore: Enable + fix CA1813 warnings by sealing custom attributes

### DIFF
--- a/build/NetStandardRelease.targets
+++ b/build/NetStandardRelease.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <NoWarn>RS0100;RS0016;CA1002;CA1012;CA1014;CA1024;CA1508;CA1725;CA1813;CA2201;CS8073;IL3000</NoWarn>
+    <NoWarn>RS0100;RS0016;CA1002;CA1012;CA1014;CA1024;CA1508;CA1725;CA2201;CS8073;IL3000</NoWarn>
     <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>

--- a/src/Actions/Attributes/InteractionLevelAttribute.cs
+++ b/src/Actions/Attributes/InteractionLevelAttribute.cs
@@ -9,7 +9,7 @@ namespace Axe.Windows.Actions.Attributes
     /// Describes the amount of user interaction an Action offers
     /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
-    class InteractionLevelAttribute : Attribute
+    sealed class InteractionLevelAttribute : Attribute
     {
         private UxInteractionLevel _interactionLevel;
 

--- a/src/Core/Attributes/PatternEventAttribute.cs
+++ b/src/Core/Attributes/PatternEventAttribute.cs
@@ -9,7 +9,7 @@ namespace Axe.Windows.Core.Attributes
     /// indicate the expected events for the pattern
     /// </summary>
     [AttributeUsage(AttributeTargets.Class,AllowMultiple = true)]
-    public class PatternEventAttribute:Attribute
+    public sealed class PatternEventAttribute:Attribute
     {
         /// <summary>
         /// Event ID

--- a/src/Core/Attributes/PatternMethodAttribute.cs
+++ b/src/Core/Attributes/PatternMethodAttribute.cs
@@ -9,7 +9,7 @@ namespace Axe.Windows.Core.Attributes
     /// indicate the method is actionable via UI
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
-    public class PatternMethodAttribute:Attribute
+    public sealed class PatternMethodAttribute:Attribute
     {
         /// <summary>
         /// if it is true, the method is related with UI Action

--- a/src/Rules/RuleInfo.cs
+++ b/src/Rules/RuleInfo.cs
@@ -13,7 +13,7 @@ namespace Axe.Windows.Rules
     /// Provides metadata about a rule.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
-    public class RuleInfo : Attribute
+    public sealed class RuleInfo : Attribute
     {
 #pragma warning restore CA1710
 


### PR DESCRIPTION
#### Details
PR #529 disabled many warnings. This PR reenables the [CA1813 warning, which catches unsealed custom attributes](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1813). I sealed our custom attributes, which isn't a problem because they're not inherited from anywhere.

##### Motivation
Reenabling suppressed warnings.

##### Context
I considered suppressing these errors individually, but the changes made sense to me. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
