### PR TITLE
chore: Enable and address IL3000 warnings

### DIFF
--- a/build/NetStandardRelease.targets
+++ b/build/NetStandardRelease.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <NoWarn>RS0100;RS0016;CA1002;CA1012;CA1024;CA1508;CA1725;CA2201;CS8073;IL3000</NoWarn>
+    <NoWarn>RS0100;RS0016;CA1002;CA1012;CA1024;CA1508;CA1725;CA2201;CS8073</NoWarn>
     <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>

--- a/src/CLI/OutputGenerator.cs
+++ b/src/CLI/OutputGenerator.cs
@@ -52,8 +52,10 @@ namespace AxeWindowsCLI
 
         private void WriteAppBanner()
         {
+#pragma warning disable IL3000 // We don't use a single file installer
             string version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
             _writer.WriteLine("Axe.Windows Accessibility Scanner CLI (version {0})", version);
+#pragma warning restore IL3000 // We don't use a single file installer
         }
 
         private void WriteBanner(IOptions options, VerbosityLevel minimumVerbosity)

--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -103,8 +103,7 @@ namespace AxeWindowsCLI
 
         private void HandleThirdPartyNoticesAndExit()
         {
-            string currentFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            string pathToFile = Path.Combine(currentFolder, "thirdpartynotices.html");
+            string pathToFile = Path.Combine(AppContext.BaseDirectory, "thirdpartynotices.html");
             _outputGenerator.WriteThirdPartyNoticeOutput(pathToFile);
 
             _browserAbstraction.Open(pathToFile);


### PR DESCRIPTION
#### Details
PR #529 disabled many warnings. This PR reenables the [IL3000 warning](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/il3000), which calls out a possible error if shipping as a single file executable. We don't ship this way, so we don't _need_ to change any code. However, the suggested change made sense in one place, since we were doing extra work to get a directory that is available in a less expensive way.

##### Motivation
Reenabling suppressed warnings.

##### Context

Tested by running locally and ensuring that the third party notices file displays as expected.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
