### PR TITLE
chore: Tidy things up in DesktopElementHelper

### DIFF
--- a/src/Desktop/UIAutomation/DesktopElementHelper.cs
+++ b/src/Desktop/UIAutomation/DesktopElementHelper.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
 using System;
 using System.Collections.Generic;
 using UIAutomationClient;
@@ -8,57 +7,16 @@ using UIAutomationClient;
 namespace Axe.Windows.Desktop.UIAutomation
 {
     /// <summary>
-    /// Class DesktopElementHelper
-    /// it is a helper class for DesktopElement to handle property/pattern related caching and more
-    /// it is a singleton object via static members
+    /// A helper class to manage the cached properties that we always request from UIA
     /// </summary>
     public static class DesktopElementHelper
     {
-
-        /// <summary>
-        /// List of basic properties 
-        /// these will be cached at instantiation of Element
-        /// </summary>
-        static List<int> sDefaultCoreProperties = new List<int>()
-        {
-            PropertyType.UIA_NamePropertyId,
-            PropertyType.UIA_ControlTypePropertyId,
-            PropertyType.UIA_LocalizedControlTypePropertyId,
-            PropertyType.UIA_IsKeyboardFocusablePropertyId,
-            PropertyType.UIA_BoundingRectanglePropertyId,
-            PropertyType.UIA_AccessKeyPropertyId,
-            PropertyType.UIA_AcceleratorKeyPropertyId,
-            PropertyType.UIA_HelpTextPropertyId,
-            PropertyType.UIA_AriaPropertiesPropertyId,
-            PropertyType.UIA_AriaRolePropertyId,
-        };
-
-        static IEnumerable<int> sCoreProperties;
-
-        /// <summary>
-        /// Set the selected properties list
-        /// </summary>
-        /// <param name="pps"></param>
-        public static void SetCorePropertiesList(IEnumerable<int> pps)
-        {
-            sCoreProperties = pps;
-        }
-
-        /// <summary>
-        /// Get the selected properties list
-        /// </summary>
-        /// <returns></returns>
-        public static IEnumerable<int> GetCorePropertiesList()
-        {
-            return sCoreProperties;
-        }
-
         /// <summary>
         /// Build a cacherequest for properties and patterns
         /// </summary>
         /// <param name="pps">Property ids</param>
         /// <param name="pts">Pattern ids</param>
-        public static IUIAutomationCacheRequest BuildCacheRequest(List<int> pps, List<int> pts)
+        public static IUIAutomationCacheRequest BuildCacheRequest(IEnumerable<int> pps, IEnumerable<int> pts)
         {
             return GetPropertiesCache(A11yAutomation.GetUIAutomationObject(), pps, pts);
         }
@@ -70,7 +28,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// <param name="pps">Property ids</param>
         /// <param name="pts">Pattern ids</param>
         /// <returns></returns>
-        public static IUIAutomationCacheRequest GetPropertiesCache(IUIAutomation uia, List<int> pps, List<int> pts)
+        public static IUIAutomationCacheRequest GetPropertiesCache(IUIAutomation uia, IEnumerable<int> pps, IEnumerable<int> pts)
         {
             if (uia == null) throw new ArgumentNullException(nameof(uia));
 
@@ -96,15 +54,6 @@ namespace Axe.Windows.Desktop.UIAutomation
             }
 
             return cr;
-        }
-
-        /// <summary>
-        /// Get the default list of selected properties
-        /// </summary>
-        /// <returns></returns>
-        public static List<int> GetDefaultCoreProperties()
-        {
-            return sDefaultCoreProperties;
         }
     }
 }


### PR DESCRIPTION
#### Details

While addressing some analyzer issues in Axe.Windows, I realized that the following methods (and their backing code) in https://github.com/microsoft/axe-windows/blob/main/src/Desktop/UIAutomation/DesktopElementHelper.cs are not used anywhere in Axe.Windows, and should be migrated into AIWin:

`SetCorePropertiesList`
`GetCorePropertiesList`
`GetDefaultCoreProperties`

After talking with @jalkire, we've chosen the following plan of action:
1. Give AIWin its own implementation of this functionality (https://github.com/microsoft/accessibility-insights-windows/pull/1081)
2. Remove the code from Axe.Windows (this PR). 

I opportunistically changed the input parameters to the remaining functions from List`<int>` to `IEnumerable<int>`. Existing code will just work and we'll have a slightly cleaner interface.

##### Motivation

Improve code cohesion (and will help to address CA1024 warnings in Axe.Windows)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
