### PR TITLE
chore: Enable and address CA1002 warnings

### DIFF
--- a/build/NetStandardRelease.targets
+++ b/build/NetStandardRelease.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <NoWarn>RS0100;RS0016;CA1002;CA1024</NoWarn>
+    <NoWarn>RS0100;RS0016;CA1024</NoWarn>
     <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>

--- a/src/Automation/ScanResultsAssembler.cs
+++ b/src/Automation/ScanResultsAssembler.cs
@@ -80,7 +80,7 @@ namespace Axe.Windows.Automation
             return new ElementInfo
             {
                 Parent = parent,
-                Patterns = element.Patterns?.ConvertAll<string>(x => x.Name),
+                Patterns = element.Patterns?.ToList().ConvertAll<string>(x => x.Name),
                 Properties = element.Properties?.ToDictionary(p => p.Value.Name, p => p.Value.TextValue)
             };
         }

--- a/src/AutomationTests/ScanResultsAssemblerTests.cs
+++ b/src/AutomationTests/ScanResultsAssemblerTests.cs
@@ -26,7 +26,7 @@ namespace Axe.Windows.AutomationTests
 
             ElementInfo expectedParentInfo = new ElementInfo
             {
-                Patterns = element.Patterns.ConvertAll<string>(x => x.Name),
+                Patterns = element.Patterns.ToList().ConvertAll<string>(x => x.Name),
                 Properties = null,
             };
 

--- a/src/AutomationTests/ScanResultsAssemblerTests.cs
+++ b/src/AutomationTests/ScanResultsAssemblerTests.cs
@@ -131,6 +131,14 @@ namespace Axe.Windows.AutomationTests
             RuleId.BoundingRectangleCompletelyObscuresContainer,
         };
 
+        private void AddScanResults(IList<Core.Results.ScanResult> target, IList<Core.Results.ScanResult> itemsToAdd)
+        {
+            foreach (var item in itemsToAdd)
+            {
+                target.Add(item);
+            }
+        }
+
         private A11yElement GenerateA11yElementWithChild()
         {
             A11yElement element = new A11yElement()
@@ -141,7 +149,7 @@ namespace Axe.Windows.AutomationTests
 
             element.Properties = null;
             element.Patterns = GetFillerPatterns();
-            element.ScanResults.Items.AddRange(GetFillerScanResults());
+            AddScanResults(element.ScanResults.Items, GetFillerScanResults());
             element.Children.Add(GenerateA11yElementWithoutChild());
 
             return element;
@@ -152,7 +160,7 @@ namespace Axe.Windows.AutomationTests
 
             element.Properties = GetFillerProperties();
             element.Patterns = null;
-            element.ScanResults.Items.AddRange(GetFillerScanResults());
+            AddScanResults(element.ScanResults.Items, GetFillerScanResults());
 
             return element;
         }
@@ -161,7 +169,7 @@ namespace Axe.Windows.AutomationTests
         {
             A11yElement element = new A11yElement() { ScanResults = new Core.Results.ScanResults() };
 
-            element.ScanResults.Items.AddRange(GetBadScanResults());
+            AddScanResults(element.ScanResults.Items, GetBadScanResults());
 
             return element;
         }

--- a/src/Core/Bases/A11yElement.cs
+++ b/src/Core/Bases/A11yElement.cs
@@ -573,12 +573,12 @@ namespace Axe.Windows.Core.Bases
         /// a collection of patterns supported by the element
         /// </summary>
         public List<A11yPattern> Patterns { get; set; }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Child Elements
         /// </summary>
-        public List<A11yElement> Children { get; set; }
-#pragma warning restore CA1002 // Do not expose generic lists
+        public IList<A11yElement> Children { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
 
         /*

--- a/src/Core/Bases/A11yElement.cs
+++ b/src/Core/Bases/A11yElement.cs
@@ -568,12 +568,10 @@ namespace Axe.Windows.Core.Bases
         /// </summary>
         public Dictionary<int, A11yProperty> PlatformProperties { get; set; }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// a collection of patterns supported by the element
         /// </summary>
-        public List<A11yPattern> Patterns { get; set; }
-#pragma warning restore CA1002 // Do not expose generic lists
+        public IList<A11yPattern> Patterns { get; set; }
 
         /// <summary>
         /// Child Elements

--- a/src/Core/Bases/A11yElement.cs
+++ b/src/Core/Bases/A11yElement.cs
@@ -568,6 +568,7 @@ namespace Axe.Windows.Core.Bases
         /// </summary>
         public Dictionary<int, A11yProperty> PlatformProperties { get; set; }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// a collection of patterns supported by the element
         /// </summary>
@@ -577,6 +578,7 @@ namespace Axe.Windows.Core.Bases
         /// Child Elements
         /// </summary>
         public List<A11yElement> Children { get; set; }
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2227 // Collection properties should be read only
 
         /*

--- a/src/Core/Bases/A11yElementData.cs
+++ b/src/Core/Bases/A11yElementData.cs
@@ -15,10 +15,12 @@ namespace Axe.Windows.Core.Bases
         /// </summary>
         public Dictionary<int, A11yProperty> Properties { get; set; }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Patterns
         /// </summary>
         public List<A11yPattern> Patterns { get; set; }
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/src/Core/Bases/A11yElementData.cs
+++ b/src/Core/Bases/A11yElementData.cs
@@ -15,12 +15,10 @@ namespace Axe.Windows.Core.Bases
         /// </summary>
         public Dictionary<int, A11yProperty> Properties { get; set; }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Patterns
         /// </summary>
-        public List<A11yPattern> Patterns { get; set; }
-#pragma warning restore CA1002 // Do not expose generic lists
+        public IList<A11yPattern> Patterns { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/src/Core/Bases/A11yPattern.cs
+++ b/src/Core/Bases/A11yPattern.cs
@@ -45,13 +45,11 @@ namespace Axe.Windows.Core.Bases
         [JsonIgnore]
         public A11yElement Element { get; private set; }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Pattern method list
         /// </summary>
         [JsonIgnore]
-        public List<MethodInfo> Methods { get; private set; }
-#pragma warning restore CA1002 // Do not expose generic lists
+        public IList<MethodInfo> Methods { get; private set; }
 
         /// <summary>
         /// Constructor

--- a/src/Core/Bases/A11yPattern.cs
+++ b/src/Core/Bases/A11yPattern.cs
@@ -155,7 +155,7 @@ namespace Axe.Windows.Core.Bases
             {
                 if (disposing)
                 {
-                    ListHelper.DisposeAndClear(this.Properties);
+                    ListHelper.DisposeAllItemsAndClearList(this.Properties);
                     this.Properties = null;
                     this.Name = null;
                     this.Element = null;

--- a/src/Core/Bases/A11yPattern.cs
+++ b/src/Core/Bases/A11yPattern.cs
@@ -30,9 +30,7 @@ namespace Axe.Windows.Core.Bases
         /// CA2227 exemption since Properties should be serialized in results file.
         /// </summary>
 #pragma warning disable CA2227 // Collection properties should be read only
-#pragma warning disable CA1002 // Do not expose generic lists
-        public List<A11yPatternProperty> Properties { get; set; }
-#pragma warning restore CA1002 // Do not expose generic lists
+        public IList<A11yPatternProperty> Properties { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
@@ -98,7 +96,7 @@ namespace Axe.Windows.Core.Bases
         {
             if (this.Properties == null) return default(T);
 
-            var item = this.Properties.Find(p => p.Name == propertyName);
+            var item = this.Properties.ToList().Find(p => p.Name == propertyName);
             if (item == null) return default(T);
 
             if (item.Value is T)
@@ -111,7 +109,7 @@ namespace Axe.Windows.Core.Bases
                 return default(T);
 
             // the return value will be an int of some kind, but it may require the cast not to throw and exception
-            return (T) item.Value;
+            return (T)item.Value;
         }
 
         private static bool IsNumber(dynamic d)
@@ -159,8 +157,7 @@ namespace Axe.Windows.Core.Bases
             {
                 if (disposing)
                 {
-                    this.Properties.ForEach(p => p.Dispose());
-                    this.Properties?.Clear();
+                    ListHelper.DisposeAndClear(this.Properties);
                     this.Properties = null;
                     this.Name = null;
                     this.Element = null;

--- a/src/Core/Bases/A11yPattern.cs
+++ b/src/Core/Bases/A11yPattern.cs
@@ -30,9 +30,11 @@ namespace Axe.Windows.Core.Bases
         /// CA2227 exemption since Properties should be serialized in results file.
         /// </summary>
 #pragma warning disable CA2227 // Collection properties should be read only
+#pragma warning disable CA1002 // Do not expose generic lists
         public List<A11yPatternProperty> Properties { get; set; }
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2227 // Collection properties should be read only
-        
+
         /// <summary>
         /// indicate whether it is actionable or not.
         /// </summary>
@@ -45,11 +47,13 @@ namespace Axe.Windows.Core.Bases
         [JsonIgnore]
         public A11yElement Element { get; private set; }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Pattern method list
         /// </summary>
         [JsonIgnore]
         public List<MethodInfo> Methods { get; private set; }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Constructor

--- a/src/Core/Bases/IA11yEventMessage.cs
+++ b/src/Core/Bases/IA11yEventMessage.cs
@@ -13,7 +13,9 @@ namespace Axe.Windows.Core.Bases
         /// </summary>
         string TimeStamp { get; set; }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         List<KeyValuePair<string, dynamic>> Properties { get; }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         A11yElement Element { get; set; }
     }

--- a/src/Core/Bases/IA11yEventMessage.cs
+++ b/src/Core/Bases/IA11yEventMessage.cs
@@ -13,9 +13,7 @@ namespace Axe.Windows.Core.Bases
         /// </summary>
         string TimeStamp { get; set; }
 
-#pragma warning disable CA1002 // Do not expose generic lists
-        List<KeyValuePair<string, dynamic>> Properties { get; }
-#pragma warning restore CA1002 // Do not expose generic lists
+        IList<KeyValuePair<string, dynamic>> Properties { get; }
 
         A11yElement Element { get; set; }
     }

--- a/src/Core/Misc/ExtensionMethods.cs
+++ b/src/Core/Misc/ExtensionMethods.cs
@@ -301,6 +301,7 @@ namespace Axe.Windows.Core.Misc
             return false;
         }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Returns a list of A11yElements along the path from the origin to this element
         /// </summary>
@@ -322,6 +323,7 @@ namespace Axe.Windows.Core.Misc
             }
             return res;
         }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Gets the Top level Ancestor from Ancestry.
@@ -517,6 +519,7 @@ namespace Axe.Windows.Core.Misc
                     select e).Count();
         }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Get all children with the specified control type Id
         /// </summary>
@@ -528,6 +531,7 @@ namespace Axe.Windows.Core.Misc
                     where e.ControlTypeId == id
                     select e).ToList();
         }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Count the number of element which are not matched in the given list

--- a/src/Core/Misc/ExtensionMethods.cs
+++ b/src/Core/Misc/ExtensionMethods.cs
@@ -301,14 +301,13 @@ namespace Axe.Windows.Core.Misc
             return false;
         }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
-        /// Returns a list of A11yElements along the path from the origin to this element
+        /// Returns an IList of A11yElements along the path from the origin to this element
         /// </summary>
         /// <param name="element">Element to find the path to</param>
         /// <param name="descending">Indicates whether the path goes from top to bottom</param>
         /// <returns></returns>
-        public static List<A11yElement> GetPathFromOriginAncestor(this A11yElement element, bool descending = true)
+        public static IList<A11yElement> GetPathFromOriginAncestor(this A11yElement element, bool descending = true)
         {
             List<A11yElement> res = new List<A11yElement>() { element };
             var e = element;
@@ -323,7 +322,6 @@ namespace Axe.Windows.Core.Misc
             }
             return res;
         }
-#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Gets the Top level Ancestor from Ancestry.
@@ -519,19 +517,17 @@ namespace Axe.Windows.Core.Misc
                     select e).Count();
         }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Get all children with the specified control type Id
         /// </summary>
         /// <param name="es"></param>
         /// <returns></returns>
-        public static List<A11yElement> ByControlType(this IList<A11yElement> es, int id)
+        public static IList<A11yElement> ByControlType(this IList<A11yElement> es, int id)
         {
             return (from e in es
                     where e.ControlTypeId == id
                     select e).ToList();
         }
-#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Count the number of element which are not matched in the given list

--- a/src/Core/Misc/ExtensionMethods.cs
+++ b/src/Core/Misc/ExtensionMethods.cs
@@ -437,7 +437,7 @@ namespace Axe.Windows.Core.Misc
         /// </summary>
         /// <param name="ps"></param>
         /// <returns></returns>
-        public static bool HasPatternBy(this List<A11yPattern> ps, int id)
+        public static bool HasPatternBy(this IList<A11yPattern> ps, int id)
         {
             if (ps == null || ps.Count == 0) return false;
 
@@ -451,7 +451,7 @@ namespace Axe.Windows.Core.Misc
         /// </summary>
         /// <param name="cs"></param>
         /// <returns></returns>
-        public static bool HasChildBy(this List<A11yElement> cs, int id)
+        public static bool HasChildBy(this IList<A11yElement> cs, int id)
         {
             return (from c in cs
                     let cid = c.Properties.ById(PropertyType.UIA_ControlTypePropertyId).Value
@@ -464,7 +464,7 @@ namespace Axe.Windows.Core.Misc
         /// </summary>
         /// <param name="ps"></param>
         /// <returns></returns>
-        public static A11yPattern ById(this List<A11yPattern> ps, int id)
+        public static A11yPattern ById(this IList<A11yPattern> ps, int id)
         {
             if (ps == null || ps.Count == 0) return null;
 
@@ -500,7 +500,7 @@ namespace Axe.Windows.Core.Misc
         /// </summary>
         /// <param name="ps"></param>
         /// <returns></returns>
-        public static A11yPatternProperty ByName(this List<A11yPatternProperty> ps, string name)
+        public static A11yPatternProperty ByName(this IList<A11yPatternProperty> ps, string name)
         {
             return (from p in ps
                     where p.Name == name
@@ -512,7 +512,7 @@ namespace Axe.Windows.Core.Misc
         /// </summary>
         /// <param name="es"></param>
         /// <returns></returns>
-        public static int CountMatchedByControlType(this List<A11yElement> es, int id)
+        public static int CountMatchedByControlType(this IList<A11yElement> es, int id)
         {
             return (from e in es
                     where e.ControlTypeId == id
@@ -525,7 +525,7 @@ namespace Axe.Windows.Core.Misc
         /// </summary>
         /// <param name="es"></param>
         /// <returns></returns>
-        public static List<A11yElement> ByControlType(this List<A11yElement> es, int id)
+        public static List<A11yElement> ByControlType(this IList<A11yElement> es, int id)
         {
             return (from e in es
                     where e.ControlTypeId == id
@@ -538,7 +538,7 @@ namespace Axe.Windows.Core.Misc
         /// </summary>
         /// <param name="es"></param>
         /// <returns></returns>
-        public static int CountUnMatchedByControlTypes(this List<A11yElement> es, int[] ids)
+        public static int CountUnMatchedByControlTypes(this IList<A11yElement> es, int[] ids)
         {
             return (from e in es
                     where ids.Contains(e.ControlTypeId) == false

--- a/src/Core/Misc/ListHelper.cs
+++ b/src/Core/Misc/ListHelper.cs
@@ -9,14 +9,18 @@ namespace Axe.Windows.Core.Misc
     {
         public static void DisposeAndClear<T>(IList<T> items) where T : IDisposable
         {
+            DisposeAllItems(items);
+            items?.Clear();
+        }
+
+        public static void DisposeAllItems<T>(IList<T> items) where T : IDisposable
+        {
             if (items != null)
             {
                 foreach (T item in items)
                 {
                     item.Dispose();
                 }
-
-                items.Clear();
             }
         }
     }

--- a/src/Core/Misc/ListHelper.cs
+++ b/src/Core/Misc/ListHelper.cs
@@ -7,7 +7,7 @@ namespace Axe.Windows.Core.Misc
 {
     public static class ListHelper
     {
-        public static void DisposeAndClear<T>(IList<T> items) where T : IDisposable
+        public static void DisposeAllItemsAndClearList<T>(IList<T> items) where T : IDisposable
         {
             DisposeAllItems(items);
             items?.Clear();

--- a/src/Core/Misc/ListHelper.cs
+++ b/src/Core/Misc/ListHelper.cs
@@ -3,11 +3,11 @@
 using System;
 using System.Collections.Generic;
 
-namespace Axe.Windows.Desktop.Utility
+namespace Axe.Windows.Core.Misc
 {
     public static class ListHelper
     {
-        public static void DisposeAndClear<T>(IList<T> items) where T:IDisposable
+        public static void DisposeAndClear<T>(IList<T> items) where T : IDisposable
         {
             if (items != null)
             {

--- a/src/Core/Results/RuleResult.cs
+++ b/src/Core/Results/RuleResult.cs
@@ -14,13 +14,11 @@ namespace Axe.Windows.Core.Results
     public class RuleResult
     {
 #pragma warning disable CA2227 // Collection properties should be read only
-#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Messages through Rule checking stages
         /// for JSON serialization, allow set()
         /// </summary>
-        public List<string> Messages { get; set; }
-#pragma warning restore CA1002 // Do not expose generic lists
+        public IList<string> Messages { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
         /// <summary>
         /// Status of Rule check

--- a/src/Core/Results/RuleResult.cs
+++ b/src/Core/Results/RuleResult.cs
@@ -14,11 +14,13 @@ namespace Axe.Windows.Core.Results
     public class RuleResult
     {
 #pragma warning disable CA2227 // Collection properties should be read only
+#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Messages through Rule checking stages
         /// for JSON serialization, allow set()
         /// </summary>
         public List<string> Messages { get; set; }
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2227 // Collection properties should be read only
         /// <summary>
         /// Status of Rule check

--- a/src/Core/Results/ScanResult.cs
+++ b/src/Core/Results/ScanResult.cs
@@ -58,12 +58,10 @@ namespace Axe.Windows.Core.Results
         public ScanMetaInfo MetaInfo { get; set; }
 
 #pragma warning disable CA2227 // Collection properties should be read only
-#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Rule Results
         /// </summary>
-        public List<RuleResult> Items { get; set; }
-#pragma warning restore CA1002 // Do not expose generic lists
+        public IList<RuleResult> Items { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>

--- a/src/Core/Results/ScanResult.cs
+++ b/src/Core/Results/ScanResult.cs
@@ -58,10 +58,12 @@ namespace Axe.Windows.Core.Results
         public ScanMetaInfo MetaInfo { get; set; }
 
 #pragma warning disable CA2227 // Collection properties should be read only
+#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Rule Results
         /// </summary>
         public List<RuleResult> Items { get; set; }
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>

--- a/src/Core/Results/ScanResults.cs
+++ b/src/Core/Results/ScanResults.cs
@@ -15,10 +15,12 @@ namespace Axe.Windows.Core.Results
     {
         private readonly object _itemsLock = new object();
 
+#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Items with ScanResult
         /// </summary>
         public List<ScanResult> Items { get; private set; }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Aggregated status

--- a/src/Core/Results/ScanResults.cs
+++ b/src/Core/Results/ScanResults.cs
@@ -15,12 +15,10 @@ namespace Axe.Windows.Core.Results
     {
         private readonly object _itemsLock = new object();
 
-#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Items with ScanResult
         /// </summary>
-        public List<ScanResult> Items { get; private set; }
-#pragma warning restore CA1002 // Do not expose generic lists
+        public IList<ScanResult> Items { get; private set; }
 
         /// <summary>
         /// Aggregated status

--- a/src/Core/Types/TypeBase.cs
+++ b/src/Core/Types/TypeBase.cs
@@ -75,6 +75,7 @@ namespace Axe.Windows.Core.Types
             return true;
         }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Get the full list of known types in List of KeyValuePairs
         /// </summary>
@@ -92,6 +93,7 @@ namespace Axe.Windows.Core.Types
 
             return list;
         }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Get Name of Type by Id

--- a/src/Core/Types/TypeBase.cs
+++ b/src/Core/Types/TypeBase.cs
@@ -75,11 +75,10 @@ namespace Axe.Windows.Core.Types
             return true;
         }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Get the full list of known types in List of KeyValuePairs
         /// </summary>
-        public List<KeyValuePair<int, string>> GetKeyValuePairList()
+        public IList<KeyValuePair<int, string>> GetKeyValuePairList()
         {
             var list = new List<KeyValuePair<int, string>>();
 
@@ -93,7 +92,6 @@ namespace Axe.Windows.Core.Types
 
             return list;
         }
-#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Get Name of Type by Id

--- a/src/CoreTests/Misc/MiscTests.cs
+++ b/src/CoreTests/Misc/MiscTests.cs
@@ -24,12 +24,13 @@ namespace Axe.Windows.CoreTests.Misc
         public void GetStatusCounts()
         {
             A11yElement ke = UnitTestSharedLibrary.Utility.LoadA11yElementsFromJSON("Snapshots/Taskbar.snapshot");
-            ke.ScanResults.Items.ForEach(item => {
+            foreach (var item in ke.ScanResults.Items)
+            {
                 item.Items = new System.Collections.Generic.List<RuleResult>();
                 RuleResult r = new RuleResult();
                 r.Status = ScanStatus.Pass;
                 item.Items.Add(r);
-            });
+            };
             foreach (var c in ke.Children)
             {
                 Utility.PopulateChildrenTests(c);

--- a/src/CoreTests/Misc/MiscTests.cs
+++ b/src/CoreTests/Misc/MiscTests.cs
@@ -30,9 +30,10 @@ namespace Axe.Windows.CoreTests.Misc
                 r.Status = ScanStatus.Pass;
                 item.Items.Add(r);
             });
-            ke.Children.ForEach(c => {
+            foreach (var c in ke.Children)
+            {
                 Utility.PopulateChildrenTests(c);
-            });
+            };
             var statuses = (from child in ke.Children
                            select child.TestStatus);
             int[] statusCounts = statuses.GetStatusCounts();

--- a/src/Desktop/Settings/SnapshotMetaInfo.cs
+++ b/src/Desktop/Settings/SnapshotMetaInfo.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.Desktop.Settings
 
 #pragma warning disable CA2227 // Collection properties should be read only
 #pragma warning disable CA1002 // Do not expose generic lists
-        // these properties are serialized/deserialized via json. so can't make it readonly. 
+        // these properties are serialized/deserialized via json. so can't make it readonly or an IList
 
         /// <summary>
         /// Selected elements' unique IDs

--- a/src/Desktop/Settings/SnapshotMetaInfo.cs
+++ b/src/Desktop/Settings/SnapshotMetaInfo.cs
@@ -18,12 +18,14 @@ namespace Axe.Windows.Desktop.Settings
         public A11yFileMode Mode { get; set; }
 
 #pragma warning disable CA2227 // Collection properties should be read only
+#pragma warning disable CA1002 // Do not expose generic lists
         // these properties are serialized/deserialized via json. so can't make it readonly. 
 
         /// <summary>
         /// Selected elements' unique IDs
         /// </summary>
         public List<int> SelectedItems { get; set; }
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2227 // Collection properties should be read only
 
         public int ScreenshotElementId { get; set; }

--- a/src/Desktop/Types/TextAttributeTemplate.cs
+++ b/src/Desktop/Types/TextAttributeTemplate.cs
@@ -14,13 +14,12 @@ namespace Axe.Windows.Desktop.Types
 
     public static class TextAttributeTemplate
     {
-#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Get template of each attribute type
         /// it is used in TextRangeFindDialog.
         /// </summary>
         /// <returns></returns>
-        public static List<TemplateData> GetTemplate()
+        public static IList<TemplateData> GetTemplate()
         {
             var boolList = new List<KeyValuePair<bool, string>>() { new KeyValuePair<bool, string>(false, "False"), new KeyValuePair<bool, string>(true, "True") };
 
@@ -72,7 +71,6 @@ namespace Axe.Windows.Desktop.Types
                 CreateTemplateData<int>(UIA_SayAsInterpretAsAttributeId, SayAsInterpretAs.GetInstance()),
             };
         }
-#pragma warning restore CA1002 // Do not expose generic lists
 
         private static TemplateData CreateTemplateData<T>(int id, dynamic value = null)
         {

--- a/src/Desktop/Types/TextAttributeTemplate.cs
+++ b/src/Desktop/Types/TextAttributeTemplate.cs
@@ -14,6 +14,7 @@ namespace Axe.Windows.Desktop.Types
 
     public static class TextAttributeTemplate
     {
+#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Get template of each attribute type
         /// it is used in TextRangeFindDialog.
@@ -71,6 +72,7 @@ namespace Axe.Windows.Desktop.Types
                 CreateTemplateData<int>(UIA_SayAsInterpretAsAttributeId, SayAsInterpretAs.GetInstance()),
             };
         }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         private static TemplateData CreateTemplateData<T>(int id, dynamic value = null)
         {

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -197,7 +197,7 @@ namespace Axe.Windows.Desktop.UIAutomation
 
                 tree.Items.Remove(app);
 
-                tree.Items.ForEach(el => el.Dispose());
+                ListHelper.DisposeAllItems(tree.Items);
 
                 // make sure that Unique ID is set to 0 since this element will be POI.
                 app.UniqueId = 0;

--- a/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
+++ b/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
@@ -13,6 +13,7 @@ using UIAutomationClient;
 using System.Runtime.InteropServices;
 using Axe.Windows.Win32;
 using System.Text.RegularExpressions;
+using Axe.Windows.Desktop.Utility;
 
 namespace Axe.Windows.Desktop.UIAutomation
 {
@@ -169,12 +170,8 @@ namespace Axe.Windows.Desktop.UIAutomation
                 element.Properties = null;
             }
 
-            if (element.Patterns != null)
-            {
-                element.Patterns.ForEach(ptn => ptn.Dispose());
-                element.Patterns?.Clear();
-                element.Patterns = null;
-            }
+            ListHelper.DisposeAndClear(element.Patterns);
+            element.Patterns = null;
 
             element.PlatformProperties?.Clear();
             element.PlatformProperties = null;

--- a/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
+++ b/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
@@ -170,7 +170,7 @@ namespace Axe.Windows.Desktop.UIAutomation
                 element.Properties = null;
             }
 
-            ListHelper.DisposeAndClear(element.Patterns);
+            ListHelper.DisposeAllItemsAndClearList(element.Patterns);
             element.Patterns = null;
 
             element.PlatformProperties?.Clear();

--- a/src/Desktop/UIAutomation/DesktopElementHelper.cs
+++ b/src/Desktop/UIAutomation/DesktopElementHelper.cs
@@ -53,13 +53,12 @@ namespace Axe.Windows.Desktop.UIAutomation
             return sCoreProperties;
         }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Build a cacherequest for properties and patterns
         /// </summary>
         /// <param name="pps">Property ids</param>
         /// <param name="pts">Pattern ids</param>
-        public static IUIAutomationCacheRequest BuildCacheRequest(List<int> pps, List<int> pts)
+        public static IUIAutomationCacheRequest BuildCacheRequest(IEnumerable<int> pps, IEnumerable<int> pts)
         {
             return GetPropertiesCache(A11yAutomation.GetUIAutomationObject(), pps, pts);
         }
@@ -71,7 +70,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// <param name="pps">Property ids</param>
         /// <param name="pts">Pattern ids</param>
         /// <returns></returns>
-        public static IUIAutomationCacheRequest GetPropertiesCache(IUIAutomation uia, List<int> pps, List<int> pts)
+        public static IUIAutomationCacheRequest GetPropertiesCache(IUIAutomation uia, IEnumerable<int> pps, IEnumerable<int> pts)
         {
             if (uia == null) throw new ArgumentNullException(nameof(uia));
 
@@ -99,6 +98,7 @@ namespace Axe.Windows.Desktop.UIAutomation
             return cr;
         }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Get the default list of selected properties
         /// </summary>

--- a/src/Desktop/UIAutomation/DesktopElementHelper.cs
+++ b/src/Desktop/UIAutomation/DesktopElementHelper.cs
@@ -53,6 +53,7 @@ namespace Axe.Windows.Desktop.UIAutomation
             return sCoreProperties;
         }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Build a cacherequest for properties and patterns
         /// </summary>
@@ -106,5 +107,6 @@ namespace Axe.Windows.Desktop.UIAutomation
         {
             return sDefaultCoreProperties;
         }
+#pragma warning restore CA1002 // Do not expose generic lists
     }
 }

--- a/src/Desktop/UIAutomation/EventHandlers/EventMessage.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventMessage.cs
@@ -22,9 +22,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         public string TimeStamp { get; set; }
 
 #pragma warning disable CA2227 // Collection properties should be read only
-#pragma warning disable CA1002 // Do not expose generic lists
-        public List<KeyValuePair<string,dynamic>> Properties { get; set; }
-#pragma warning restore CA1002 // Do not expose generic lists
+        public IList<KeyValuePair<string,dynamic>> Properties { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
 
         public A11yElement Element { get; set; }

--- a/src/Desktop/UIAutomation/EventHandlers/EventMessage.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventMessage.cs
@@ -22,7 +22,9 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         public string TimeStamp { get; set; }
 
 #pragma warning disable CA2227 // Collection properties should be read only
+#pragma warning disable CA1002 // Do not expose generic lists
         public List<KeyValuePair<string,dynamic>> Properties { get; set; }
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2227 // Collection properties should be read only
 
         public A11yElement Element { get; set; }

--- a/src/Desktop/UIAutomation/Patterns/AnnotationPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/AnnotationPattern.cs
@@ -26,10 +26,12 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "AnnotationTypeId", Value = this.Pattern.CurrentAnnotationTypeId });
             this.Properties.Add(new A11yPatternProperty() { Name = "AnnotationTypeName", Value = this.Pattern.CurrentAnnotationTypeName });
             this.Properties.Add(new A11yPatternProperty() { Name = "Author", Value = this.Pattern.CurrentAuthor });
             this.Properties.Add(new A11yPatternProperty() { Name = "DateTime", Value = this.Pattern.CurrentDateTime });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod]

--- a/src/Desktop/UIAutomation/Patterns/DockPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/DockPattern.cs
@@ -24,7 +24,9 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "DockPosition", Value = this.Pattern.CurrentDockPosition });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod(IsUIAction = true)]

--- a/src/Desktop/UIAutomation/Patterns/DragPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/DragPattern.cs
@@ -61,11 +61,13 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             return sb.ToString();
         }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
         public List<DesktopElement> GetGrabbedItems()
         {
             return this.Pattern.GetCurrentGrabbedItems()?.ToListOfDesktopElements();      
         }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         protected override void Dispose(bool disposing)
         {

--- a/src/Desktop/UIAutomation/Patterns/DragPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/DragPattern.cs
@@ -38,9 +38,11 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "DropEffect", Value = this.Pattern.CurrentDropEffect });
             this.Properties.Add(new A11yPatternProperty() { Name = "DropEffects", Value = GetDropEffectsString(this.Pattern.CurrentDropEffects) });
             this.Properties.Add(new A11yPatternProperty() { Name = "IsGrabbed", Value = Convert.ToBoolean(this.Pattern.CurrentIsGrabbed) });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         private static dynamic GetDropEffectsString(Array effects)

--- a/src/Desktop/UIAutomation/Patterns/DragPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/DragPattern.cs
@@ -63,13 +63,11 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             return sb.ToString();
         }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
-        public List<DesktopElement> GetGrabbedItems()
+        public IList<DesktopElement> GetGrabbedItems()
         {
             return this.Pattern.GetCurrentGrabbedItems()?.ToListOfDesktopElements();      
         }
-#pragma warning restore CA1002 // Do not expose generic lists
 
         protected override void Dispose(bool disposing)
         {

--- a/src/Desktop/UIAutomation/Patterns/DropTargetPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/DropTargetPattern.cs
@@ -31,6 +31,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "DropTargetEffect", Value = this.Pattern.CurrentDropTargetEffect });
             var array = this.Pattern.CurrentDropTargetEffects;
             if (array.Length != 0)
@@ -40,6 +41,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
                     this.Properties.Add(new A11yPatternProperty() { Name = Invariant($"DropTargetEffects[{i}]"), Value = array.GetValue(i)?.ToString()});
                 }
             }
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         protected override void Dispose(bool disposing)

--- a/src/Desktop/UIAutomation/Patterns/ExpandCollapsePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ExpandCollapsePattern.cs
@@ -33,7 +33,9 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "ExpandCollapseState", Value = this.Pattern.CurrentExpandCollapseState });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod(IsUIAction = true)]

--- a/src/Desktop/UIAutomation/Patterns/GridItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/GridItemPattern.cs
@@ -26,10 +26,12 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "Column", Value = this.Pattern.CurrentColumn });
             this.Properties.Add(new A11yPatternProperty() { Name = "ColumnSpan", Value = this.Pattern.CurrentColumnSpan });
             this.Properties.Add(new A11yPatternProperty() { Name = "Row", Value = this.Pattern.CurrentRow });
             this.Properties.Add(new A11yPatternProperty() { Name = "RowSpan", Value = this.Pattern.CurrentRowSpan });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod]

--- a/src/Desktop/UIAutomation/Patterns/GridPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/GridPattern.cs
@@ -24,8 +24,10 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "ColumnCount", Value = this.Pattern.CurrentColumnCount });
             this.Properties.Add(new A11yPatternProperty() { Name = "RowCount", Value = this.Pattern.CurrentRowCount });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod]

--- a/src/Desktop/UIAutomation/Patterns/LegacyIAccessiblePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/LegacyIAccessiblePattern.cs
@@ -49,13 +49,11 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 #pragma warning restore CA1031 // Do not catch general exception types
         }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
-        public List<DesktopElement> GetSelection()
+        public IList<DesktopElement> GetSelection()
         {
             return this.Pattern.GetCurrentSelection().ToListOfDesktopElements();
         }
-#pragma warning restore CA1002 // Do not expose generic lists
 
         [PatternMethod]
         public void DoDefaultAction()

--- a/src/Desktop/UIAutomation/Patterns/LegacyIAccessiblePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/LegacyIAccessiblePattern.cs
@@ -29,6 +29,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         {
             try
             {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
                 this.Properties.Add(new A11yPatternProperty() { Name = "ChildId", Value = this.Pattern.CurrentChildId });
                 this.Properties.Add(new A11yPatternProperty() { Name = "DefaultAction", Value = this.Pattern.CurrentDefaultAction });
                 this.Properties.Add(new A11yPatternProperty() { Name = "Description", Value = this.Pattern.CurrentDescription });
@@ -38,6 +39,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
                 this.Properties.Add(new A11yPatternProperty() { Name = "Role", Value = this.Pattern.CurrentRole });
                 this.Properties.Add(new A11yPatternProperty() { Name = "State", Value = this.Pattern.CurrentState });
                 this.Properties.Add(new A11yPatternProperty() { Name = "Value", Value = this.Pattern.CurrentValue });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception e)

--- a/src/Desktop/UIAutomation/Patterns/LegacyIAccessiblePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/LegacyIAccessiblePattern.cs
@@ -47,11 +47,13 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 #pragma warning restore CA1031 // Do not catch general exception types
         }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
         public List<DesktopElement> GetSelection()
         {
             return this.Pattern.GetCurrentSelection().ToListOfDesktopElements();
         }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         [PatternMethod]
         public void DoDefaultAction()

--- a/src/Desktop/UIAutomation/Patterns/MultipleViewPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/MultipleViewPattern.cs
@@ -26,6 +26,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "CurrentView", Value = this.Pattern.CurrentCurrentView });
             var array = this.Pattern.GetCurrentSupportedViews();
             if (array.Length > 0)
@@ -36,6 +37,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
                     Properties.Add(new A11yPatternProperty() { Name = Invariant($"SupportedViews[{i}]"), Value = Invariant($"{view}: {Pattern.GetViewName(view)}")});
                 }
             }
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod]

--- a/src/Desktop/UIAutomation/Patterns/RangeValuePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/RangeValuePattern.cs
@@ -25,12 +25,14 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "IsReadOnly", Value = Convert.ToBoolean(this.Pattern.CurrentIsReadOnly) });
             this.Properties.Add(new A11yPatternProperty() { Name = "LargeChange", Value = this.Pattern.CurrentLargeChange });
             this.Properties.Add(new A11yPatternProperty() { Name = "Maximum", Value = this.Pattern.CurrentMaximum });
             this.Properties.Add(new A11yPatternProperty() { Name = "Minimum", Value = this.Pattern.CurrentMinimum });
             this.Properties.Add(new A11yPatternProperty() { Name = "SmallChange", Value = this.Pattern.CurrentSmallChange });
             this.Properties.Add(new A11yPatternProperty() { Name = "Value", Value = this.Pattern.CurrentValue });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod(IsUIAction = true)]

--- a/src/Desktop/UIAutomation/Patterns/ScrollPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ScrollPattern.cs
@@ -25,12 +25,14 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "HorizontallyScrollable", Value = Convert.ToBoolean(this.Pattern.CurrentHorizontallyScrollable) });
             this.Properties.Add(new A11yPatternProperty() { Name = "HorizontalScrollPercent", Value = this.Pattern.CurrentHorizontalScrollPercent });
             this.Properties.Add(new A11yPatternProperty() { Name = "HorizontalViewSize", Value = this.Pattern.CurrentHorizontalViewSize });
             this.Properties.Add(new A11yPatternProperty() { Name = "VerticallyScrollable", Value = Convert.ToBoolean(this.Pattern.CurrentVerticallyScrollable) });
             this.Properties.Add(new A11yPatternProperty() { Name = "VerticalScrollPercent", Value = this.Pattern.CurrentVerticalScrollPercent });
             this.Properties.Add(new A11yPatternProperty() { Name = "VerticalViewSize", Value = this.Pattern.CurrentVerticalViewSize });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         //Scroll() means that it has scroll functionality. but doesn't mean that item should be focused since scroll actuall happens by scrollitem

--- a/src/Desktop/UIAutomation/Patterns/SelectionItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SelectionItemPattern.cs
@@ -29,7 +29,9 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "IsSelected", Value = Convert.ToBoolean(this.Pattern.CurrentIsSelected) });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod(IsUIAction = true)]

--- a/src/Desktop/UIAutomation/Patterns/SelectionPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SelectionPattern.cs
@@ -35,13 +35,11 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
-        public List<DesktopElement> GetSelection()
+        public IList<DesktopElement> GetSelection()
         {
             return this.Pattern.GetCurrentSelection().ToListOfDesktopElements();
         }
-#pragma warning restore CA1002 // Do not expose generic lists
 
         protected override void Dispose(bool disposing)
         {

--- a/src/Desktop/UIAutomation/Patterns/SelectionPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SelectionPattern.cs
@@ -33,11 +33,13 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             this.Properties.Add(new A11yPatternProperty() { Name = "IsSelectionRequired", Value = Convert.ToBoolean(this.Pattern.CurrentIsSelectionRequired) });
         }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
         public List<DesktopElement> GetSelection()
         {
             return this.Pattern.GetCurrentSelection().ToListOfDesktopElements();
         }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         protected override void Dispose(bool disposing)
         {

--- a/src/Desktop/UIAutomation/Patterns/SelectionPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SelectionPattern.cs
@@ -29,8 +29,10 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "CanSelectMultiple", Value = Convert.ToBoolean(this.Pattern.CurrentCanSelectMultiple) });
             this.Properties.Add(new A11yPatternProperty() { Name = "IsSelectionRequired", Value = Convert.ToBoolean(this.Pattern.CurrentIsSelectionRequired) });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
 #pragma warning disable CA1002 // Do not expose generic lists

--- a/src/Desktop/UIAutomation/Patterns/SelectionPattern2.cs
+++ b/src/Desktop/UIAutomation/Patterns/SelectionPattern2.cs
@@ -36,13 +36,11 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
-        public List<DesktopElement> GetSelection()
+        public IList<DesktopElement> GetSelection()
         {
             return this.Pattern.GetCurrentSelection().ToListOfDesktopElements();
         }
-#pragma warning restore CA1002 // Do not expose generic lists
 
         [PatternMethod]
         public DesktopElement LastSelectedItem()

--- a/src/Desktop/UIAutomation/Patterns/SelectionPattern2.cs
+++ b/src/Desktop/UIAutomation/Patterns/SelectionPattern2.cs
@@ -34,11 +34,13 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             this.Properties.Add(new A11yPatternProperty() { Name = "CurrentItemCount", Value = this.Pattern.CurrentItemCount });
         }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
         public List<DesktopElement> GetSelection()
         {
             return this.Pattern.GetCurrentSelection().ToListOfDesktopElements();
         }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         [PatternMethod]
         public DesktopElement LastSelectedItem()

--- a/src/Desktop/UIAutomation/Patterns/SelectionPattern2.cs
+++ b/src/Desktop/UIAutomation/Patterns/SelectionPattern2.cs
@@ -29,9 +29,11 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "CanSelectMultiple", Value = Convert.ToBoolean(this.Pattern.CurrentCanSelectMultiple) });
             this.Properties.Add(new A11yPatternProperty() { Name = "IsSelectionRequired", Value = Convert.ToBoolean(this.Pattern.CurrentIsSelectionRequired) });
             this.Properties.Add(new A11yPatternProperty() { Name = "CurrentItemCount", Value = this.Pattern.CurrentItemCount });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
 #pragma warning disable CA1002 // Do not expose generic lists

--- a/src/Desktop/UIAutomation/Patterns/SpreadsheetItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SpreadsheetItemPattern.cs
@@ -32,15 +32,14 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
-        public List<DesktopElement> GetAnnotationObjects()
+        public IList<DesktopElement> GetAnnotationObjects()
         {
             return this.Pattern.GetCurrentAnnotationObjects()?.ToListOfDesktopElements();
         }
 
         [PatternMethod]
-        public List<string> GetAnnotationTypes()
+        public IList<string> GetAnnotationTypes()
         {
             var array = this.Pattern.GetCurrentAnnotationTypes();
             List<string> list = new List<string>();
@@ -55,7 +54,6 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
             return list;
         }
-#pragma warning restore CA1002 // Do not expose generic lists
 
         protected override void Dispose(bool disposing)
         {

--- a/src/Desktop/UIAutomation/Patterns/SpreadsheetItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SpreadsheetItemPattern.cs
@@ -27,7 +27,9 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "Formula", Value = this.Pattern.CurrentFormula });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
 #pragma warning disable CA1002 // Do not expose generic lists

--- a/src/Desktop/UIAutomation/Patterns/SpreadsheetItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SpreadsheetItemPattern.cs
@@ -30,6 +30,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             this.Properties.Add(new A11yPatternProperty() { Name = "Formula", Value = this.Pattern.CurrentFormula });
         }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
         public List<DesktopElement> GetAnnotationObjects()
         {
@@ -52,6 +53,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
             return list;
         }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         protected override void Dispose(bool disposing)
         {

--- a/src/Desktop/UIAutomation/Patterns/StylesPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/StylesPattern.cs
@@ -23,6 +23,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "ExtendedProperties", Value = this.Pattern.CurrentExtendedProperties });
             this.Properties.Add(new A11yPatternProperty() { Name = "FillColor ", Value = this.Pattern.CurrentFillColor });
             this.Properties.Add(new A11yPatternProperty() { Name = "FillPatternColor ", Value = this.Pattern.CurrentFillPatternColor });
@@ -30,6 +31,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             this.Properties.Add(new A11yPatternProperty() { Name = "Shape ", Value = this.Pattern.CurrentShape });
             this.Properties.Add(new A11yPatternProperty() { Name = "StyleId ", Value = this.Pattern.CurrentStyleId });
             this.Properties.Add(new A11yPatternProperty() { Name = "StyleName ", Value = this.Pattern.CurrentStyleName });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         protected override void Dispose(bool disposing)

--- a/src/Desktop/UIAutomation/Patterns/TableItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TableItemPattern.cs
@@ -22,19 +22,17 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             Pattern = p;
         }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
-        public List<DesktopElement> GetColumnHeaderItems()
+        public IList<DesktopElement> GetColumnHeaderItems()
         {
             return this.Pattern.GetCurrentColumnHeaderItems()?.ToListOfDesktopElements();
         }
 
         [PatternMethod]
-        public List<DesktopElement> GetRowHeaderItems()
+        public IList<DesktopElement> GetRowHeaderItems()
         {
             return this.Pattern.GetCurrentRowHeaderItems()?.ToListOfDesktopElements();
         }
-#pragma warning restore CA1002 // Do not expose generic lists
 
         protected override void Dispose(bool disposing)
         {

--- a/src/Desktop/UIAutomation/Patterns/TableItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TableItemPattern.cs
@@ -22,6 +22,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             Pattern = p;
         }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
         public List<DesktopElement> GetColumnHeaderItems()
         {
@@ -33,6 +34,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         {
             return this.Pattern.GetCurrentRowHeaderItems()?.ToListOfDesktopElements();
         }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         protected override void Dispose(bool disposing)
         {

--- a/src/Desktop/UIAutomation/Patterns/TablePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TablePattern.cs
@@ -26,7 +26,9 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "RowOrColumnMajor", Value = this.Pattern.CurrentRowOrColumnMajor });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
 #pragma warning disable CA1002 // Do not expose generic lists

--- a/src/Desktop/UIAutomation/Patterns/TablePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TablePattern.cs
@@ -31,19 +31,17 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
-        public List<DesktopElement> GetColumnHeaders()
+        public IList<DesktopElement> GetColumnHeaders()
         {
             return this.Pattern.GetCurrentColumnHeaders()?.ToListOfDesktopElements();
         }
 
         [PatternMethod]
-        public List<DesktopElement> GetRowHeaders()
+        public IList<DesktopElement> GetRowHeaders()
         {
             return this.Pattern.GetCurrentRowHeaders()?.ToListOfDesktopElements();
         }
-#pragma warning restore CA1002 // Do not expose generic lists
 
         protected override void Dispose(bool disposing)
         {

--- a/src/Desktop/UIAutomation/Patterns/TablePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TablePattern.cs
@@ -29,6 +29,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             this.Properties.Add(new A11yPatternProperty() { Name = "RowOrColumnMajor", Value = this.Pattern.CurrentRowOrColumnMajor });
         }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
         public List<DesktopElement> GetColumnHeaders()
         {
@@ -40,6 +41,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         {
             return this.Pattern.GetCurrentRowHeaders()?.ToListOfDesktopElements();
         }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         protected override void Dispose(bool disposing)
         {

--- a/src/Desktop/UIAutomation/Patterns/TextPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextPattern.cs
@@ -49,19 +49,17 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             return new TextRange(this.Pattern.DocumentRange, this);
         }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
-        public List<TextRange> GetSelection()
+        public IList<TextRange> GetSelection()
         {
             return ToListOfTextRanges(this.Pattern.GetSelection());
         }
 
         [PatternMethod]
-        public List<TextRange> GetVisibleRanges()
+        public IList<TextRange> GetVisibleRanges()
         {
             return ToListOfTextRanges(this.Pattern.GetVisibleRanges());
         }
-#pragma warning restore CA1002 // Do not expose generic lists
 
         [PatternMethod]
         public TextRange RangeFromChild(DesktopElement child)

--- a/src/Desktop/UIAutomation/Patterns/TextPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextPattern.cs
@@ -47,6 +47,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             return new TextRange(this.Pattern.DocumentRange, this);
         }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
         public List<TextRange> GetSelection()
         {
@@ -58,6 +59,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         {
             return ToListOfTextRanges(this.Pattern.GetVisibleRanges());
         }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         [PatternMethod]
         public TextRange RangeFromChild(DesktopElement child)

--- a/src/Desktop/UIAutomation/Patterns/TextPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextPattern.cs
@@ -38,7 +38,9 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "SupportedTextSelection", Value = this.Pattern.SupportedTextSelection });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod]

--- a/src/Desktop/UIAutomation/Patterns/TextRange.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextRange.cs
@@ -57,13 +57,11 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             this.UIATextRange.ScrollIntoView(alignToTop ? 1 : 0);
         }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
-        public List<DesktopElement> GetChildren()
+        public IList<DesktopElement> GetChildren()
         {
             return this.UIATextRange.GetChildren()?.ToListOfDesktopElements();
         }
-#pragma warning restore CA1002 // Do not expose generic lists
 
         [PatternMethod]
         public DesktopElement GetEnclosingElement()
@@ -156,9 +154,8 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             return null;
         }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
-        public List<Rectangle> GetBoundingRectangles()
+        public IList<Rectangle> GetBoundingRectangles()
         {
             List<Rectangle> list = new List<Rectangle>();
 
@@ -170,7 +167,6 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
             return list;
         }
-#pragma warning restore CA1002 // Do not expose generic lists
 
         [PatternMethod]
         public string GetText(int max)

--- a/src/Desktop/UIAutomation/Patterns/TextRange.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextRange.cs
@@ -57,11 +57,13 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             this.UIATextRange.ScrollIntoView(alignToTop ? 1 : 0);
         }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
         public List<DesktopElement> GetChildren()
         {
             return this.UIATextRange.GetChildren()?.ToListOfDesktopElements();
         }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         [PatternMethod]
         public DesktopElement GetEnclosingElement()
@@ -154,6 +156,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             return null;
         }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         [PatternMethod]
         public List<Rectangle> GetBoundingRectangles()
         {
@@ -167,6 +170,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
             return list;
         }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         [PatternMethod]
         public string GetText(int max)

--- a/src/Desktop/UIAutomation/Patterns/TogglePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TogglePattern.cs
@@ -23,7 +23,9 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "ToggleState", Value = this.Pattern.CurrentToggleState });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod(IsUIAction = true)]

--- a/src/Desktop/UIAutomation/Patterns/TransformPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TransformPattern.cs
@@ -29,9 +29,11 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "CanMove", Value = Convert.ToBoolean(this.Pattern.CurrentCanMove) });
             this.Properties.Add(new A11yPatternProperty() { Name = "CanResize", Value = Convert.ToBoolean(this.Pattern.CurrentCanResize) });
             this.Properties.Add(new A11yPatternProperty() { Name = "CanRotate", Value = Convert.ToBoolean(this.Pattern.CurrentCanRotate) });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod]

--- a/src/Desktop/UIAutomation/Patterns/TransformPattern2.cs
+++ b/src/Desktop/UIAutomation/Patterns/TransformPattern2.cs
@@ -25,6 +25,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "CanMove", Value = Convert.ToBoolean(this.Pattern.CurrentCanMove) });
             this.Properties.Add(new A11yPatternProperty() { Name = "CanResize", Value = Convert.ToBoolean(this.Pattern.CurrentCanResize) });
             this.Properties.Add(new A11yPatternProperty() { Name = "CanRotate", Value = Convert.ToBoolean(this.Pattern.CurrentCanRotate) });
@@ -32,6 +33,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             this.Properties.Add(new A11yPatternProperty() { Name = "CanZoomLevel", Value = Convert.ToBoolean(this.Pattern.CurrentZoomLevel) });
             this.Properties.Add(new A11yPatternProperty() { Name = "CanZoomMaximum", Value = Convert.ToBoolean(this.Pattern.CurrentZoomMaximum) });
             this.Properties.Add(new A11yPatternProperty() { Name = "CanZoomMinimum", Value = Convert.ToBoolean(this.Pattern.CurrentZoomMinimum) });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod(IsUIAction = true)]

--- a/src/Desktop/UIAutomation/Patterns/ValuePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ValuePattern.cs
@@ -25,6 +25,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "IsReadOnly", Value = Convert.ToBoolean(this.Pattern.CurrentIsReadOnly) });
             try
             {
@@ -36,6 +37,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
                 // there is a known case that CurrentValue is not ready. 
                 // to avoid catastrophic failure downstream, handle it here. 
             }
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod]

--- a/src/Desktop/UIAutomation/Patterns/WindowPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/WindowPattern.cs
@@ -27,12 +27,14 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         private void PopulateProperties()
         {
+#pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
             this.Properties.Add(new A11yPatternProperty() { Name = "CanMaximize", Value = Convert.ToBoolean(this.Pattern.CurrentCanMaximize) });
             this.Properties.Add(new A11yPatternProperty() { Name = "CanMinimize", Value = Convert.ToBoolean(this.Pattern.CurrentCanMinimize) });
             this.Properties.Add(new A11yPatternProperty() { Name = "IsModal", Value = Convert.ToBoolean(this.Pattern.CurrentIsModal) });
             this.Properties.Add(new A11yPatternProperty() { Name = "IsTopmost", Value = Convert.ToBoolean(this.Pattern.CurrentIsTopmost) });
             this.Properties.Add(new A11yPatternProperty() { Name = "WindowInteractionState", Value = this.Pattern.CurrentWindowInteractionState });
             this.Properties.Add(new A11yPatternProperty() { Name = "WindowVisualState", Value = this.Pattern.CurrentWindowVisualState });
+#pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod]

--- a/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
@@ -153,7 +153,9 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 
                 while (child != null)
                 {
+#pragma warning disable CA2000 // Use recommended dispose patterns
                     var childNode = new DesktopElement(child, true, false);
+#pragma warning restore CA2000 // Use recommended dispose patterns
                     childNode.PopulateMinimumPropertiesForSelection();
 
                     if (childNode.IsSameUIElement(poiNode) == false)

--- a/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
@@ -28,7 +28,9 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// </summary>
         public A11yElement Last { get; private set; }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         public List<A11yElement> Items { get; private set; }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         private readonly IUIAutomationTreeWalker TreeWalker;
 

--- a/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
@@ -28,9 +28,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// </summary>
         public A11yElement Last { get; private set; }
 
-#pragma warning disable CA1002 // Do not expose generic lists
-        public List<A11yElement> Items { get; private set; }
-#pragma warning restore CA1002 // Do not expose generic lists
+        public IList<A11yElement> Items { get; private set; }
 
         private readonly IUIAutomationTreeWalker TreeWalker;
 

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
@@ -14,9 +14,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 {
     public interface ITreeWalkerForLive
     {
-#pragma warning disable CA1002 // Do not expose generic lists
-        List<A11yElement> Elements { get; }
-#pragma warning restore CA1002 // Do not expose generic lists
+        IList<A11yElement> Elements { get; }
         A11yElement RootElement { get; }
         void GetTreeHierarchy(A11yElement e, TreeViewMode mode);
     }
@@ -27,12 +25,10 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
     /// </summary>
     public class TreeWalkerForLive : ITreeWalkerForLive
     {
-#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// List to keep all elements in tree walking(Ancestors, self and children)
         /// </summary>
-        public List<A11yElement> Elements { get; private set; }
-#pragma warning restore CA1002 // Do not expose generic lists
+        public IList<A11yElement> Elements { get; private set; }
 
         /// <summary>
         /// Top root node in whole hierarchy
@@ -95,7 +91,10 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             });
 
             // Add ancestry into Elements list.
-            this.Elements.AddRange(ancestry.Items);
+            foreach (var item in ancestry.Items)
+            {
+                this.Elements.Add(item);
+            }
 
             this.LastWalkTime = DateTime.Now - begin;
         }
@@ -128,11 +127,13 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 
                 while (child != null)
                 {
+#pragma warning disable CA2000 // childNode will be disposed by the parent node
                     // Create child without populating basic property. it will be set all at once in parallel.
                     var childNode = new DesktopElement(child, true, false)
                     {
                         UniqueId = childId++
                     };
+#pragma warning restore CA2000 // childNode will be disposed by the parent node
 
                     rootNode.Children.Add(childNode);
 

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
@@ -78,7 +78,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             this.RootElement = ancestry.First;
 
             // clear children
-            ListHelper.DisposeAndClear(e.Children);
+            ListHelper.DisposeAllItemsAndClearList(e.Children);
 
             // populate selected element relationship and add it to list. 
             e.Parent = ancestry.Last;

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
@@ -13,7 +13,9 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 {
     public interface ITreeWalkerForLive
     {
+#pragma warning disable CA1002 // Do not expose generic lists
         List<A11yElement> Elements { get; }
+#pragma warning restore CA1002 // Do not expose generic lists
         A11yElement RootElement { get; }
         void GetTreeHierarchy(A11yElement e, TreeViewMode mode);
     }
@@ -24,10 +26,12 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
     /// </summary>
     public class TreeWalkerForLive : ITreeWalkerForLive
     {
+#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// List to keep all elements in tree walking(Ancestors, self and children)
         /// </summary>
         public List<A11yElement> Elements { get; private set; }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Top root node in whole hierarchy

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
@@ -8,7 +8,7 @@ using UIAutomationClient;
 using System.Linq;
 using Axe.Windows.Core.Enums;
 using System.Runtime.InteropServices;
-using Axe.Windows.Desktop.Utility;
+using Axe.Windows.Core.Misc;
 
 namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 {

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
@@ -8,6 +8,7 @@ using UIAutomationClient;
 using System.Linq;
 using Axe.Windows.Core.Enums;
 using System.Runtime.InteropServices;
+using Axe.Windows.Desktop.Utility;
 
 namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 {
@@ -77,8 +78,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             this.RootElement = ancestry.First;
 
             // clear children
-            e.Children?.ForEach(c => c.Dispose());
-            e.Children?.Clear();
+            ListHelper.DisposeAndClear(e.Children);
 
             // populate selected element relationship and add it to list. 
             e.Parent = ancestry.Last;

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -79,7 +79,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             this.TopMostElement = ancestry.First;
 
             // clear children
-            ListHelper.DisposeAndClear(this.SelectedElement.Children);
+            ListHelper.DisposeAllItemsAndClearList(this.SelectedElement.Children);
             this.SelectedElement.UniqueId = 0;
 
             PopulateChildrenTreeNode(this.SelectedElement, ancestry.Last, ancestry.NextId);

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -15,7 +15,9 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 {
     public interface ITreeWalkerForTest
     {
+#pragma warning disable CA1002 // Do not expose generic lists
         List<A11yElement> Elements { get; }
+#pragma warning restore CA1002 // Do not expose generic lists
         A11yElement TopMostElement { get; }
         void RefreshTreeData(TreeViewMode mode);
     }
@@ -28,10 +30,12 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
     {
         private readonly BoundedCounter _elementCounter;
 
+#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// List of all Elements including SelectedElement and descendents
         /// </summary>
         public List<A11yElement> Elements { get; }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         public TimeSpan LastWalkTime { get; private set; }
         

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using Axe.Windows.Core.Enums;
 using System.Runtime.InteropServices;
 using Axe.Windows.Core.Misc;
-using Axe.Windows.Desktop.Utility;
 
 namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 {

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -16,9 +16,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 {
     public interface ITreeWalkerForTest
     {
-#pragma warning disable CA1002 // Do not expose generic lists
-        List<A11yElement> Elements { get; }
-#pragma warning restore CA1002 // Do not expose generic lists
+        IList<A11yElement> Elements { get; }
         A11yElement TopMostElement { get; }
         void RefreshTreeData(TreeViewMode mode);
     }
@@ -31,12 +29,10 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
     {
         private readonly BoundedCounter _elementCounter;
 
-#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// List of all Elements including SelectedElement and descendents
         /// </summary>
-        public List<A11yElement> Elements { get; }
-#pragma warning restore CA1002 // Do not expose generic lists
+        public IList<A11yElement> Elements { get; }
 
         public TimeSpan LastWalkTime { get; private set; }
         
@@ -86,7 +82,10 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 
             // do population of ancesters all togather with children
             var list = new List<A11yElement>(this.Elements);
-            this.Elements.AddRange(ancestry.Items);
+            foreach (var item in ancestry.Items)
+            {
+                this.Elements.Add(item);
+            }
 
             // populate Elements first
             this.Elements.AsParallel().ForAll(e => e.PopulateAllPropertiesWithLiveData());
@@ -140,8 +139,10 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 
                 while (child != null && _elementCounter.TryIncrement())
                 {
+#pragma warning disable CA2000 // childNode will be disposed by the parent node
                     // Create child without populating basic property. it will be set all at once in parallel.
                     var childNode = new DesktopElement(child, true, false);
+#pragma warning restore CA2000 // childNode will be disposed by the parent node
 
                     rootNode.Children.Add(childNode);
                     childNode.Parent = rootNode;

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using Axe.Windows.Core.Enums;
 using System.Runtime.InteropServices;
 using Axe.Windows.Core.Misc;
+using Axe.Windows.Desktop.Utility;
 
 namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 {
@@ -78,8 +79,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             this.TopMostElement = ancestry.First;
 
             // clear children
-            this.SelectedElement.Children?.ForEach(c => c.Dispose());
-            this.SelectedElement.Children?.Clear();
+            ListHelper.DisposeAndClear(this.SelectedElement.Children);
             this.SelectedElement.UniqueId = 0;
 
             PopulateChildrenTreeNode(this.SelectedElement, ancestry.Last, ancestry.NextId);

--- a/src/Desktop/Utility/ExtensionMethods.cs
+++ b/src/Desktop/Utility/ExtensionMethods.cs
@@ -64,13 +64,12 @@ namespace Axe.Windows.Desktop.Utility
 #pragma warning restore CA1031 // Do not catch general exception types
         }
 
-#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
-        /// Change IUIAutomationElementArray To a list of DesktopElement
+        /// Change IUIAutomationElementArray To an IList of DesktopElement
         /// </summary>
         /// <param name="array"></param>
         /// <returns></returns>
-        public static List<DesktopElement> ToListOfDesktopElements(this IUIAutomationElementArray array)
+        public static IList<DesktopElement> ToListOfDesktopElements(this IUIAutomationElementArray array)
         {
             if (array == null) throw new ArgumentNullException(nameof(array));
 
@@ -83,7 +82,6 @@ namespace Axe.Windows.Desktop.Utility
 
             return list;
         }
-#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Capture the bitmap of the given element

--- a/src/Desktop/Utility/ExtensionMethods.cs
+++ b/src/Desktop/Utility/ExtensionMethods.cs
@@ -64,6 +64,7 @@ namespace Axe.Windows.Desktop.Utility
 #pragma warning restore CA1031 // Do not catch general exception types
         }
 
+#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Change IUIAutomationElementArray To a list of DesktopElement
         /// </summary>
@@ -82,6 +83,7 @@ namespace Axe.Windows.Desktop.Utility
 
             return list;
         }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Capture the bitmap of the given element

--- a/src/Desktop/Utility/ListHelper.cs
+++ b/src/Desktop/Utility/ListHelper.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+
+namespace Axe.Windows.Desktop.Utility
+{
+    public static class ListHelper
+    {
+        public static void DisposeAndClear<T>(IList<T> items) where T:IDisposable
+        {
+            if (items != null)
+            {
+                foreach (T item in items)
+                {
+                    item.Dispose();
+                }
+
+                items.Clear();
+            }
+        }
+    }
+}

--- a/src/Desktop/Utility/SupportedEvents.cs
+++ b/src/Desktop/Utility/SupportedEvents.cs
@@ -190,6 +190,7 @@ namespace Axe.Windows.Desktop.Utility
             (ControlType.UIA_WindowControlTypeId, EventType.UIA_Window_WindowOpenedEventId, null)
         };
 
+#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Use mapping list to get specific list for a control
         /// </summary>
@@ -202,5 +203,6 @@ namespace Axe.Windows.Desktop.Utility
                     where map.ControlId == controlId && (map.PatternId == null || patterns.Select(p=>p.Id).Contains(map.PatternId.Value))
                     select map.EventId).ToList();
         }
+#pragma warning restore CA1002 // Do not expose generic lists
     }
 }

--- a/src/Desktop/Utility/SupportedEvents.cs
+++ b/src/Desktop/Utility/SupportedEvents.cs
@@ -190,19 +190,17 @@ namespace Axe.Windows.Desktop.Utility
             (ControlType.UIA_WindowControlTypeId, EventType.UIA_Window_WindowOpenedEventId, null)
         };
 
-#pragma warning disable CA1002 // Do not expose generic lists
         /// <summary>
         /// Use mapping list to get specific list for a control
         /// </summary>
         /// <param name="controlId"></param>
         /// <param name="patterns"></param>
         /// <returns></returns>
-        public static IEnumerable<int> GetEventsForControl(int controlId, List<A11yPattern> patterns)
+        public static IEnumerable<int> GetEventsForControl(int controlId, IEnumerable<A11yPattern> patterns)
         {
             return (from map in EventTypeMappings
                     where map.ControlId == controlId && (map.PatternId == null || patterns.Select(p=>p.Id).Contains(map.PatternId.Value))
                     select map.EventId).ToList();
         }
-#pragma warning restore CA1002 // Do not expose generic lists
     }
 }

--- a/src/UnitTestSharedLibrary/Utility.cs
+++ b/src/UnitTestSharedLibrary/Utility.cs
@@ -62,12 +62,13 @@ namespace Axe.Windows.UnitTestSharedLibrary
         {
             if (ke == null) throw new ArgumentNullException(nameof(ke));
 
-            ke.ScanResults.Items.ForEach(item => {
+            foreach (var item in ke.ScanResults.Items)
+            {
                 item.Items = new List<RuleResult>();
                 RuleResult r = new RuleResult();
                 r.Status = ke.ControlTypeId == Axe.Windows.Core.Types.ControlType.UIA_ButtonControlTypeId ? ScanStatus.Pass : ScanStatus.Fail;
                 item.Items.Add(r);
-            });
+            };
             foreach (var c in ke.Children)
             {
                 PopulateChildrenTests(c);

--- a/src/UnitTestSharedLibrary/Utility.cs
+++ b/src/UnitTestSharedLibrary/Utility.cs
@@ -39,10 +39,11 @@ namespace Axe.Windows.UnitTestSharedLibrary
                     var next = elements.Dequeue();
                     if (next.Children != null)
                     {
-                        next.Children.ForEach(c => {
+                        foreach (var c in next.Children)
+                        {
                             c.Parent = next;
                             elements.Enqueue(c);
-                        });
+                        };
                     }
                 }
             }
@@ -67,9 +68,10 @@ namespace Axe.Windows.UnitTestSharedLibrary
                 r.Status = ke.ControlTypeId == Axe.Windows.Core.Types.ControlType.UIA_ButtonControlTypeId ? ScanStatus.Pass : ScanStatus.Fail;
                 item.Items.Add(r);
             });
-            ke.Children.ForEach(c => {
+            foreach (var c in ke.Children)
+            {
                 PopulateChildrenTests(c);
-            });
+            };
         }
     }
 }


### PR DESCRIPTION
#### Details
PR #529 disabled many warnings. This PR reenables the [CA1002 warning](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1002), which nudges us away from using the `List` class as a property, parameter type, or return type. We should be able to replace almost all of these with the `IList` interface. In some of these cases, the CA2000 analyzer raises a warning with `IList` (but not with `List`, so some CA2000 suppressions needed to be added..

This change was done in very small commits, but it can probably be reviewed as a whole.

I'm sure that there are places where we could use `IReadOnlyList`, `IReadOnlyCollection`, or `IEnumerable` instead of `IList`, but this PR feels large enough in its current form.

##### Motivation
Reenabling suppressed warnings.

##### Context

Unit tests are all happy. A file generated with the CLI opens correctly in AIWin, suggesting that our file formats are OK.

This change may require some changes in AIWin, especially with the pattern changes. Before merging, I'll publish the package locally and evaluate its impact on AIWIn. There are already some changes required by #552, but this could possibly add some more. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
