### PR TITLE
chore: Sort using blocks (done by a tool)

### DIFF
--- a/src/Actions/Misc/ExtensionMethods.cs
+++ b/src/Actions/Misc/ExtensionMethods.cs
@@ -7,8 +7,8 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Telemetry;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Globalization;
+using System.Linq;
 
 namespace Axe.Windows.Actions.Misc
 {

--- a/src/ActionsTests/Misc/ExtensionMethodsTests.cs
+++ b/src/ActionsTests/Misc/ExtensionMethodsTests.cs
@@ -5,8 +5,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Globalization;
+using System.Linq;
 
 namespace Axe.Windows.Actions.Misc.Tests
 {

--- a/src/Automation/Data/ScanResult.cs
+++ b/src/Automation/Data/ScanResult.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Rules;
+using System;
 
 namespace Axe.Windows.Automation
 {

--- a/src/AutomationTests/ExecutionWrapperUnitTests.cs
+++ b/src/AutomationTests/ExecutionWrapperUnitTests.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Automation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace Axe.Windows.AutomationTests
 {

--- a/src/CI/Program.cs
+++ b/src/CI/Program.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Automation;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using Axe.Windows.Automation;
 
 namespace Axe.Windows.CI
 {

--- a/src/Core/Bases/A11yProperty.cs
+++ b/src/Core/Bases/A11yProperty.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using System;
 using Axe.Windows.Core.Misc;
-using Newtonsoft.Json;
+using Axe.Windows.Core.Types;
 using Axe.Windows.Win32;
+using Newtonsoft.Json;
+using System;
 
 namespace Axe.Windows.Core.Bases
 {

--- a/src/Core/Bases/IA11yElement.cs
+++ b/src/Core/Bases/IA11yElement.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Enums;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using Axe.Windows.Core.Enums;
 
 namespace Axe.Windows.Core.Bases
 {

--- a/src/CoreTests/Misc/MiscTests.cs
+++ b/src/CoreTests/Misc/MiscTests.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
-using Axe.Windows.Core.Results;
 using Axe.Windows.Core.Misc;
+using Axe.Windows.Core.Results;
 using Axe.Windows.UnitTestSharedLibrary;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;

--- a/src/CoreTests/Misc/UtilityTests.cs
+++ b/src/CoreTests/Misc/UtilityTests.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Misc;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Diagnostics;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Axe.Windows.Core.Misc;
 
 namespace Axe.Windows.CoreTests.Misc
 {

--- a/src/CoreTests/Results/ScanMetaInfoTests.cs
+++ b/src/CoreTests/Results/ScanMetaInfoTests.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 
 namespace Axe.Windows.Core.Results.Tests
 {

--- a/src/Desktop/UIAutomation/DesktopElement.cs
+++ b/src/Desktop/UIAutomation/DesktopElement.cs
@@ -3,11 +3,11 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Telemetry;
+using Axe.Windows.Win32;
 using System;
 using System.Collections.Generic;
-using UIAutomationClient;
 using System.Runtime.InteropServices;
-using Axe.Windows.Win32;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation
 {

--- a/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
+++ b/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
@@ -3,17 +3,17 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;
+using Axe.Windows.Desktop.Utility;
 using Axe.Windows.Telemetry;
+using Axe.Windows.Win32;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Text;
-using UIAutomationClient;
 using System.Runtime.InteropServices;
-using Axe.Windows.Win32;
+using System.Text;
 using System.Text.RegularExpressions;
-using Axe.Windows.Desktop.Utility;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation
 {

--- a/src/Desktop/UIAutomation/Patterns/CustomNavigationPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/CustomNavigationPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
 using System.Runtime.InteropServices;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/DockPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/DockPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
 using System.Runtime.InteropServices;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/DragPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/DragPattern.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
+using Axe.Windows.Desktop.Types;
+using Axe.Windows.Desktop.Utility;
 using System;
 using System.Collections.Generic;
-using System.Text;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
-using Axe.Windows.Core.Attributes;
-using Axe.Windows.Desktop.Utility;
-using Axe.Windows.Desktop.Types;
 using System.Runtime.InteropServices;
+using System.Text;
+using UIAutomationClient;
 
 using static System.FormattableString;
 

--- a/src/Desktop/UIAutomation/Patterns/DropTargetPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/DropTargetPattern.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.Types;
 using System.Runtime.InteropServices;
+using UIAutomationClient;
 
 using static System.FormattableString;
 

--- a/src/Desktop/UIAutomation/Patterns/GridPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/GridPattern.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/InvokePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/InvokePattern.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/ItemContainerPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ItemContainerPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
 using System;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/LegacyIAccessiblePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/LegacyIAccessiblePattern.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
+using Axe.Windows.Desktop.Utility;
 using Axe.Windows.Telemetry;
 using System;
 using System.Collections.Generic;
-using Axe.Windows.Core.Bases;
 using UIAutomationClient;
-using Axe.Windows.Core.Attributes;
-using Axe.Windows.Desktop.Utility;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/MultipleViewPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/MultipleViewPattern.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using UIAutomationClient;
 
 using static System.FormattableString;
 

--- a/src/Desktop/UIAutomation/Patterns/ObjectModelPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ObjectModelPattern.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/RangeValuePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/RangeValuePattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using System;
-using Axe.Windows.Core.Bases;
 using UIAutomationClient;
-using Axe.Windows.Core.Attributes;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/ScrollItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ScrollItemPattern.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/ScrollPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ScrollPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using System;
-using Axe.Windows.Core.Bases;
 using UIAutomationClient;
-using Axe.Windows.Core.Attributes;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/SelectionItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SelectionItemPattern.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using System;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.Types;
+using System;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/SelectionPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SelectionPattern.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
+using Axe.Windows.Desktop.Types;
+using Axe.Windows.Desktop.Utility;
 using System;
 using System.Collections.Generic;
-using Axe.Windows.Core.Bases;
 using UIAutomationClient;
-using Axe.Windows.Core.Attributes;
-using Axe.Windows.Desktop.Utility;
-using Axe.Windows.Desktop.Types;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/SelectionPattern2.cs
+++ b/src/Desktop/UIAutomation/Patterns/SelectionPattern2.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
+using Axe.Windows.Desktop.Types;
+using Axe.Windows.Desktop.Utility;
 using System;
 using System.Collections.Generic;
-using Axe.Windows.Core.Bases;
 using UIAutomationClient;
-using Axe.Windows.Core.Attributes;
-using Axe.Windows.Desktop.Utility;
-using Axe.Windows.Desktop.Types;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/SpreadsheetItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SpreadsheetItemPattern.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using System.Collections.Generic;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
-using Axe.Windows.Desktop.Utility;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.Types;
+using Axe.Windows.Desktop.Utility;
+using System.Collections.Generic;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/SpreadsheetPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SpreadsheetPattern.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/StylesPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/StylesPattern.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
 using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
 using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns

--- a/src/Desktop/UIAutomation/Patterns/SynchronizedInputPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SynchronizedInputPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.Types;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/TableItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TableItemPattern.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using System.Collections.Generic;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.Utility;
+using System.Collections.Generic;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/TablePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TablePattern.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using System.Collections.Generic;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
-using Axe.Windows.Desktop.Utility;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using Axe.Windows.Desktop.Utility;
+using System.Collections.Generic;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/TextChildPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextChildPattern.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/TextEditPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextEditPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.Types;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/TextPattern2.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextPattern2.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
 using System;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/TextRange.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextRange.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Collections.Generic;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Desktop.Utility;
 using Axe.Windows.Telemetry;
+using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/TogglePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TogglePattern.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/TransformPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TransformPattern.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using System;
 using System.Linq;
-using Axe.Windows.Core.Bases;
 using UIAutomationClient;
-using Axe.Windows.Core.Attributes;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/TransformPattern2.cs
+++ b/src/Desktop/UIAutomation/Patterns/TransformPattern2.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using System;
-using Axe.Windows.Core.Bases;
 using UIAutomationClient;
-using Axe.Windows.Core.Attributes;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/UnKnownPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/UnKnownPattern.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
 using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/VirtualizedItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/VirtualizedItemPattern.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/Patterns/WindowPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/WindowPattern.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
-using System;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
 using Axe.Windows.Core.Attributes;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.Types;
+using System;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Core.Misc;
+using Axe.Windows.Telemetry;
 using System;
 using System.Collections.Generic;
-using Axe.Windows.Core.Bases;
-using Axe.Windows.Telemetry;
-using UIAutomationClient;
 using System.Linq;
-using Axe.Windows.Core.Enums;
 using System.Runtime.InteropServices;
-using Axe.Windows.Core.Misc;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 {

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Collections.Generic;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Core.Misc;
 using Axe.Windows.RuleSelection;
 using Axe.Windows.Telemetry;
-using Axe.Windows.Core.Bases;
-using UIAutomationClient;
+using System;
+using System.Collections.Generic;
 using System.Linq;
-using Axe.Windows.Core.Enums;
 using System.Runtime.InteropServices;
-using Axe.Windows.Core.Misc;
+using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 {

--- a/src/Desktop/Utility/ExtensionMethods.cs
+++ b/src/Desktop/Utility/ExtensionMethods.cs
@@ -5,11 +5,11 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.UIAutomation;
 using Axe.Windows.Telemetry;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
-using System;
 using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.Utility

--- a/src/DesktopTests/ColorContrastAnalyzer/ColorTests.cs
+++ b/src/DesktopTests/ColorContrastAnalyzer/ColorTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Desktop.ColorContrastAnalyzer;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using Axe.Windows.Desktop.ColorContrastAnalyzer;
 
 namespace Axe.Windows.DesktopTests.ColorContrastAnalyzer
 {

--- a/src/DesktopTests/ColorContrastAnalyzer/ImageTests.cs
+++ b/src/DesktopTests/ColorContrastAnalyzer/ImageTests.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Desktop.ColorContrastAnalyzer;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.IO;
 using System.Drawing;
+using System.IO;
+using System.Linq;
 using static Axe.Windows.Desktop.ColorContrastAnalyzer.ColorContrastResult;
 using CCColor = Axe.Windows.Desktop.ColorContrastAnalyzer.Color;
-using System;
+using System.Reflection;
 
 namespace Axe.Windows.DesktopTests.ColorContrastAnalyzer
 {

--- a/src/DesktopTests/Utility/SupportedEventsTests.cs
+++ b/src/DesktopTests/Utility/SupportedEventsTests.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 
 namespace Axe.Windows.Desktop.Utility.Tests

--- a/src/RuleSelection/DefaultReferenceLinks.cs
+++ b/src/RuleSelection/DefaultReferenceLinks.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
 using Axe.Windows.Extensions.Interfaces.ReferenceLinks;
 using Axe.Windows.RuleSelection.Resources;
 using Axe.Windows.Telemetry;
+using System;
+using System.Globalization;
 
 namespace Axe.Windows.RuleSelection
 {

--- a/src/RuleSelection/ReferenceLink.cs
+++ b/src/RuleSelection/ReferenceLink.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Axe.Windows.Extensions.Interfaces.ReferenceLinks;
+using System;
 
 namespace Axe.Windows.RuleSelection
 {

--- a/src/RuleSelectionTests/DefaultReferenceLinksTests.cs
+++ b/src/RuleSelectionTests/DefaultReferenceLinksTests.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Rules;
 using Axe.Windows.RuleSelection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace Axe.Windows.RuleSelectionTests
 {

--- a/src/RuleSelectionTests/ReferenceLinksTests.cs
+++ b/src/RuleSelectionTests/ReferenceLinksTests.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Rules;
 using Axe.Windows.RuleSelection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace RuleSelectionTests
 {

--- a/src/Rules/Conditions/AndCondition.cs
+++ b/src/Rules/Conditions/AndCondition.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/Conditions/Condition.cs
+++ b/src/Rules/Conditions/Condition.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Threading;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules.Resources;
+using System.Threading;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/Conditions/ConditionContext.cs
+++ b/src/Rules/Conditions/ConditionContext.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Collections.Generic;
 using Axe.Windows.Core.Bases;
+using System.Collections.Generic;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/Conditions/ContextCondition.cs
+++ b/src/Rules/Conditions/ContextCondition.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
+using System;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/Conditions/ControlTypeCondition.cs
+++ b/src/Rules/Conditions/ControlTypeCondition.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules.Resources;
+using System;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/Conditions/DelegateCondition.cs
+++ b/src/Rules/Conditions/DelegateCondition.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
+using System;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/Conditions/NotCondition.cs
+++ b/src/Rules/Conditions/NotCondition.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/Conditions/OrCondition.cs
+++ b/src/Rules/Conditions/OrCondition.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/Conditions/PatternCondition.cs
+++ b/src/Rules/Conditions/PatternCondition.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
+using System;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/Conditions/RecursiveCondition.cs
+++ b/src/Rules/Conditions/RecursiveCondition.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
+using System;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/Conditions/StringDecoratorCondition.cs
+++ b/src/Rules/Conditions/StringDecoratorCondition.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
 using System;
 using System.Globalization;
-using Axe.Windows.Core.Bases;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/Conditions/TreeDescentCondition.cs
+++ b/src/Rules/Conditions/TreeDescentCondition.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
+using System;
 
 using static System.FormattableString;
 

--- a/src/Rules/Conditions/ValueCondition.cs
+++ b/src/Rules/Conditions/ValueCondition.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
+using System;
 
 using static System.FormattableString;
 

--- a/src/Rules/Extensions/ExtensionMethods.cs
+++ b/src/Rules/Extensions/ExtensionMethods.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Diagnostics;
-using System.Drawing;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
+using System;
+using System.Diagnostics;
+using System.Drawing;
 using UIAutomationClient;
 using static System.FormattableString;
 

--- a/src/Rules/Library/BoundingRectangleCompletelyObscuresContainer.cs
+++ b/src/Rules/Library/BoundingRectangleCompletelyObscuresContainer.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;

--- a/src/Rules/Library/BoundingRectangleContainedInParent.cs
+++ b/src/Rules/Library/BoundingRectangleContainedInParent.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Text.RegularExpressions;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.Extensions;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Text.RegularExpressions;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;

--- a/src/Rules/Library/BoundingRectangleNotValidButOffScreen.cs
+++ b/src/Rules/Library/BoundingRectangleNotValidButOffScreen.cs
@@ -3,8 +3,8 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
-using Axe.Windows.Rules.Resources;
 using Axe.Windows.Rules.PropertyConditions;
+using Axe.Windows.Rules.Resources;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/BoundingRectangleOnUWPMenuBar.cs
+++ b/src/Rules/Library/BoundingRectangleOnUWPMenuBar.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
-using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Core.Types;
+using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 

--- a/src/Rules/Library/ButtonShouldHavePatterns.cs
+++ b/src/Rules/Library/ButtonShouldHavePatterns.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/ChildrenNotAllowedInContentView.cs
+++ b/src/Rules/Library/ChildrenNotAllowedInContentView.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;

--- a/src/Rules/Library/ComboBoxShouldNotSupportScrollPattern.cs
+++ b/src/Rules/Library/ComboBoxShouldNotSupportScrollPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/ControlShouldNotSupportScrollPattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportScrollPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/ControlShouldNotSupportTablePattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportTablePattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 

--- a/src/Rules/Library/ControlShouldNotSupportTogglePattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportTogglePattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/ControlShouldNotSupportValuePattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportValuePattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/ControlShouldNotSupportWindowPattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportWindowPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/ControlShouldSupportExpandCollapsePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportExpandCollapsePattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 

--- a/src/Rules/Library/ControlShouldSupportGridItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportGridItemPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 

--- a/src/Rules/Library/ControlShouldSupportGridPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportGridPattern.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/ControlShouldSupportInvokePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportInvokePattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/ControlShouldSupportScrollItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportScrollItemPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 

--- a/src/Rules/Library/ControlShouldSupportSelectionItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportSelectionItemPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/ControlShouldSupportSelectionPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportSelectionPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/ControlShouldSupportSpreadsheetItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportSpreadsheetItemPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 

--- a/src/Rules/Library/ControlShouldSupportTableItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTableItemPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 

--- a/src/Rules/Library/ControlShouldSupportTablePatternInEdge.cs
+++ b/src/Rules/Library/ControlShouldSupportTablePatternInEdge.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Framework;
 

--- a/src/Rules/Library/ControlShouldSupportTextPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTextPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Framework;

--- a/src/Rules/Library/ControlShouldSupportTogglePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTogglePattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/ControlShouldSupportTransformPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTransformPattern.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 

--- a/src/Rules/Library/EditSupportsIncorrectRangeValuePattern.cs
+++ b/src/Rules/Library/EditSupportsIncorrectRangeValuePattern.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/HeadingLevelDescendsWhenNested.cs
+++ b/src/Rules/Library/HeadingLevelDescendsWhenNested.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.IntProperties;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 

--- a/src/Rules/Library/HelpTextNotEqualToName.cs
+++ b/src/Rules/Library/HelpTextNotEqualToName.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/IsContentElementPropertyExists.cs
+++ b/src/Rules/Library/IsContentElementPropertyExists.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 

--- a/src/Rules/Library/IsControlElementPropertyExists.cs
+++ b/src/Rules/Library/IsControlElementPropertyExists.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/IsControlElementTrueRequired.cs
+++ b/src/Rules/Library/IsControlElementTrueRequired.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/IsKeyboardFocusableForCustomShouldBeTrue.cs
+++ b/src/Rules/Library/IsKeyboardFocusableForCustomShouldBeTrue.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 

--- a/src/Rules/Library/IsKeyboardFocusableForListItemShouldBeTrue.cs
+++ b/src/Rules/Library/IsKeyboardFocusableForListItemShouldBeTrue.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;

--- a/src/Rules/Library/IsKeyboardFocusableShouldBeTrue.cs
+++ b/src/Rules/Library/IsKeyboardFocusableShouldBeTrue.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;

--- a/src/Rules/Library/LandmarkBannerIsTopLevel.cs
+++ b/src/Rules/Library/LandmarkBannerIsTopLevel.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.EdgeConditions;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 

--- a/src/Rules/Library/LandmarkComplementaryIsTopLevel.cs
+++ b/src/Rules/Library/LandmarkComplementaryIsTopLevel.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.EdgeConditions;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 

--- a/src/Rules/Library/LandmarkContentInfoIsTopLevel.cs
+++ b/src/Rules/Library/LandmarkContentInfoIsTopLevel.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.EdgeConditions;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 

--- a/src/Rules/Library/LandmarkMainIsTopLevel.cs
+++ b/src/Rules/Library/LandmarkMainIsTopLevel.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.EdgeConditions;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 

--- a/src/Rules/Library/LocalizedControlTypeIsNotEmpty.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotEmpty.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 

--- a/src/Rules/Library/LocalizedControlTypeIsNotNull.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotNull.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/LocalizedControlTypeIsNotWhiteSpace.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotWhiteSpace.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/LocalizedControlTypeIsReasonable.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsReasonable.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Linq;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Linq;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 

--- a/src/Rules/Library/LocalizedLandmarkTypeIsReasonableLength.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeIsReasonableLength.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/LocalizedLandmarkTypeNotCustom.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeNotCustom.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/LocalizedLandmarkTypeNotEmpty.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeNotEmpty.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/LocalizedLandmarkTypeNotNull.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeNotNull.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/LocalizedLandmarkTypeNotWhiteSpace.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeNotWhiteSpace.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/NameExcludesLocalizedControlType.cs
+++ b/src/Rules/Library/NameExcludesLocalizedControlType.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Text.RegularExpressions;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Text.RegularExpressions;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/NameIsReasonableLength.cs
+++ b/src/Rules/Library/NameIsReasonableLength.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 

--- a/src/Rules/Library/OrientationPropertyExists.cs
+++ b/src/Rules/Library/OrientationPropertyExists.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.IntProperties;
 

--- a/src/Rules/Library/ProgressBarRangeValue.cs
+++ b/src/Rules/Library/ProgressBarRangeValue.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
-using Axe.Windows.Rules.Resources;
 using Axe.Windows.Rules.PropertyConditions;
+using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/SelectionItemPatternSingleSelection.cs
+++ b/src/Rules/Library/SelectionItemPatternSingleSelection.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 

--- a/src/Rules/Library/SelectionPatternSingleSelection.cs
+++ b/src/Rules/Library/SelectionPatternSingleSelection.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/SplitButtonInvokeAndTogglePatterns.cs
+++ b/src/Rules/Library/SplitButtonInvokeAndTogglePatterns.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Button.cs
+++ b/src/Rules/Library/Structure/ContentView/Button.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Calendar.cs
+++ b/src/Rules/Library/Structure/ContentView/Calendar.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/CheckBox.cs
+++ b/src/Rules/Library/Structure/ContentView/CheckBox.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/ComboBox.cs
+++ b/src/Rules/Library/Structure/ContentView/ComboBox.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/DataGrid.cs
+++ b/src/Rules/Library/Structure/ContentView/DataGrid.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Edit.cs
+++ b/src/Rules/Library/Structure/ContentView/Edit.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Hyperlink.cs
+++ b/src/Rules/Library/Structure/ContentView/Hyperlink.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/List.cs
+++ b/src/Rules/Library/Structure/ContentView/List.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/ListItem.cs
+++ b/src/Rules/Library/Structure/ContentView/ListItem.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Menu.cs
+++ b/src/Rules/Library/Structure/ContentView/Menu.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/ProgressBar.cs
+++ b/src/Rules/Library/Structure/ContentView/ProgressBar.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/RadioButton.cs
+++ b/src/Rules/Library/Structure/ContentView/RadioButton.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Slider.cs
+++ b/src/Rules/Library/Structure/ContentView/Slider.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Spinner.cs
+++ b/src/Rules/Library/Structure/ContentView/Spinner.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/SplitButton.cs
+++ b/src/Rules/Library/Structure/ContentView/SplitButton.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/StatusBar.cs
+++ b/src/Rules/Library/Structure/ContentView/StatusBar.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Tab.cs
+++ b/src/Rules/Library/Structure/ContentView/Tab.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Tree.cs
+++ b/src/Rules/Library/Structure/ContentView/Tree.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/TreeItem.cs
+++ b/src/Rules/Library/Structure/ContentView/TreeItem.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Button.cs
+++ b/src/Rules/Library/Structure/ControlView/Button.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Calendar.cs
+++ b/src/Rules/Library/Structure/ControlView/Calendar.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/CheckBox.cs
+++ b/src/Rules/Library/Structure/ControlView/CheckBox.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/ComboBox.cs
+++ b/src/Rules/Library/Structure/ControlView/ComboBox.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/DataGrid.cs
+++ b/src/Rules/Library/Structure/ControlView/DataGrid.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Edit.cs
+++ b/src/Rules/Library/Structure/ControlView/Edit.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Header.cs
+++ b/src/Rules/Library/Structure/ControlView/Header.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/HeaderItem.cs
+++ b/src/Rules/Library/Structure/ControlView/HeaderItem.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Hyperlink.cs
+++ b/src/Rules/Library/Structure/ControlView/Hyperlink.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Image.cs
+++ b/src/Rules/Library/Structure/ControlView/Image.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/List.cs
+++ b/src/Rules/Library/Structure/ControlView/List.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/ListItem.cs
+++ b/src/Rules/Library/Structure/ControlView/ListItem.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Menu.cs
+++ b/src/Rules/Library/Structure/ControlView/Menu.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/ProgressBar.cs
+++ b/src/Rules/Library/Structure/ControlView/ProgressBar.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/RadioButton.cs
+++ b/src/Rules/Library/Structure/ControlView/RadioButton.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/SemanticZoom.cs
+++ b/src/Rules/Library/Structure/ControlView/SemanticZoom.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Separator.cs
+++ b/src/Rules/Library/Structure/ControlView/Separator.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Slider.cs
+++ b/src/Rules/Library/Structure/ControlView/Slider.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Spinner.cs
+++ b/src/Rules/Library/Structure/ControlView/Spinner.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/SplitButton.cs
+++ b/src/Rules/Library/Structure/ControlView/SplitButton.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/StatusBar.cs
+++ b/src/Rules/Library/Structure/ControlView/StatusBar.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Tab.cs
+++ b/src/Rules/Library/Structure/ControlView/Tab.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Thumb.cs
+++ b/src/Rules/Library/Structure/ControlView/Thumb.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/ToolTip.cs
+++ b/src/Rules/Library/Structure/ControlView/ToolTip.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Tree.cs
+++ b/src/Rules/Library/Structure/ControlView/Tree.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/TreeItem.cs
+++ b/src/Rules/Library/Structure/ControlView/TreeItem.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/PropertyConditions/BoundingRectangle.cs
+++ b/src/Rules/PropertyConditions/BoundingRectangle.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.Extensions;
 using Axe.Windows.Rules.Resources;
+using System;
 
 namespace Axe.Windows.Rules.PropertyConditions
 {

--- a/src/Rules/PropertyConditions/EnumProperty.cs
+++ b/src/Rules/PropertyConditions/EnumProperty.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules.Resources;
+using System;
 using static Axe.Windows.Rules.PropertyConditions.General;
 
 namespace Axe.Windows.Rules.PropertyConditions

--- a/src/Rules/PropertyConditions/Patterns.cs
+++ b/src/Rules/PropertyConditions/Patterns.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
+using System;
 
 namespace Axe.Windows.Rules.PropertyConditions
 {

--- a/src/Rules/PropertyConditions/PlatformProperties.cs
+++ b/src/Rules/PropertyConditions/PlatformProperties.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
+using System;
 
 namespace Axe.Windows.Rules.PropertyConditions
 {

--- a/src/Rules/PropertyConditions/Relationships.cs
+++ b/src/Rules/PropertyConditions/Relationships.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Globalization;
-using System.Linq;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Exceptions;
 using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
+using System.Linq;
 
 namespace Axe.Windows.Rules.PropertyConditions
 {

--- a/src/Rules/PropertyConditions/ScrollPattern.cs
+++ b/src/Rules/PropertyConditions/ScrollPattern.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
+using System;
 
 namespace Axe.Windows.Rules.PropertyConditions
 {

--- a/src/Rules/PropertyConditions/SelectionItemPattern .cs
+++ b/src/Rules/PropertyConditions/SelectionItemPattern .cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
+using System;
 
 namespace Axe.Windows.Rules.PropertyConditions
 {

--- a/src/Rules/PropertyConditions/SelectionPattern.cs
+++ b/src/Rules/PropertyConditions/SelectionPattern.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
+using System;
 
 namespace Axe.Windows.Rules.PropertyConditions
 {

--- a/src/Rules/PropertyConditions/StringProperty.cs
+++ b/src/Rules/PropertyConditions/StringProperty.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Rules.Resources;
 using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
-using Axe.Windows.Core.Bases;
-using Axe.Windows.Rules.Resources;
 
 namespace Axe.Windows.Rules.PropertyConditions
 {

--- a/src/Rules/RuleFactory.cs
+++ b/src/Rules/RuleFactory.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Enums;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Axe.Windows.Core.Enums;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/RuleInfo.cs
+++ b/src/Rules/RuleInfo.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Core.Enums;
+using System;
 
 using static System.FormattableString;
 

--- a/src/Rules/RuleProvider.cs
+++ b/src/Rules/RuleProvider.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Enums;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using Axe.Windows.Core.Enums;
 
 namespace Axe.Windows.Rules
 {

--- a/src/RulesMD/Properties/AssemblyInfo.cs
+++ b/src/RulesMD/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Resources;
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/RulesTest/Conditions/AndConditionTest.cs
+++ b/src/RulesTest/Conditions/AndConditionTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Rules;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Conditions
 {

--- a/src/RulesTest/Conditions/ConditionTest.cs
+++ b/src/RulesTest/Conditions/ConditionTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Rules;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Conditions
 {

--- a/src/RulesTest/Conditions/ControlTypeConditionTest.cs
+++ b/src/RulesTest/Conditions/ControlTypeConditionTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Rules;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Conditions
 {

--- a/src/RulesTest/Conditions/NotConditionTest.cs
+++ b/src/RulesTest/Conditions/NotConditionTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Rules;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Conditions
 {

--- a/src/RulesTest/Conditions/OrConditionTest.cs
+++ b/src/RulesTest/Conditions/OrConditionTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Rules;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Conditions
 {

--- a/src/RulesTest/Conditions/PatternConditionTest.cs
+++ b/src/RulesTest/Conditions/PatternConditionTest.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace Axe.Windows.RulesTest.Conditions
 {

--- a/src/RulesTest/Library/BoundingRectangleContainedInParentTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleContainedInParentTest.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
 using static Axe.Windows.RulesTest.ControlType;
 
 

--- a/src/RulesTest/Library/BoundingRectangleDataFormatCorrectTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleDataFormatCorrectTest.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/BoundingRectangleNotAllZerosTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotAllZerosTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/BoundingRectangleNotNullTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotNullTest.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Enums;
-using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/BoundingRectangleOnUWPMenuBarTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleOnUWPMenuBarTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/BoundingRectangleOnUWPMenuItemTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleOnUWPMenuItemTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/BoundingRectangleOnWPFTextParentTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleOnWPFTextParentTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/BoundingRectangleSizeReasonableTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleSizeReasonableTest.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Drawing;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/ButtonInvokeAndExpandCollapsePatterns.cs
+++ b/src/RulesTest/Library/ButtonInvokeAndExpandCollapsePatterns.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/ButtonInvokeAndTogglePatterns.cs
+++ b/src/RulesTest/Library/ButtonInvokeAndTogglePatterns.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/ButtonPatterns.cs
+++ b/src/RulesTest/Library/ButtonPatterns.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/ButtonToggleAndExpandCollapsePatterns.cs
+++ b/src/RulesTest/Library/ButtonToggleAndExpandCollapsePatterns.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/ComboBoxShouldNotSupportScrollPatternTests.cs
+++ b/src/RulesTest/Library/ComboBoxShouldNotSupportScrollPatternTests.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/ControlShouldNotSupportScrollPatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldNotSupportScrollPatternTests.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/ControlShouldSupportExpandCollapsePattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportExpandCollapsePattern.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/ControlShouldSupportGridPattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportGridPattern.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Diagnostics;
 using UIAutomationClient;
 

--- a/src/RulesTest/Library/ControlShouldSupportTextPatternUnitTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTextPatternUnitTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/HeadingLevelDescendsWhenNestedTest.cs
+++ b/src/RulesTest/Library/HeadingLevelDescendsWhenNestedTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/HelpTextExcludesPrivateUnicodeCharactersUnitTests.cs
+++ b/src/RulesTest/Library/HelpTextExcludesPrivateUnicodeCharactersUnitTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using static Axe.Windows.RulesTest.ControlType;
 
 namespace Axe.Windows.RulesTest.Library

--- a/src/RulesTest/Library/HyperlinkNameShouldBeUniqueTest.cs
+++ b/src/RulesTest/Library/HyperlinkNameShouldBeUniqueTest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/IsKeyboardFocusableShouldBeTrue.cs
+++ b/src/RulesTest/Library/IsKeyboardFocusableShouldBeTrue.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/LandmarkIsTopLevel.cs
+++ b/src/RulesTest/Library/LandmarkIsTopLevel.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/ListItemSiblingUniqueTests.cs
+++ b/src/RulesTest/Library/ListItemSiblingUniqueTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/LocalizedControlTypeExcludesPrivateUnicodeCharactersUnitTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeExcludesPrivateUnicodeCharactersUnitTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using static Axe.Windows.RulesTest.ControlType;
 
 namespace Axe.Windows.RulesTest.Library

--- a/src/RulesTest/Library/LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters.cs
+++ b/src/RulesTest/Library/LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/LocalizedLandmarkTypeNotCustomTests.cs
+++ b/src/RulesTest/Library/LocalizedLandmarkTypeNotCustomTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/NameExcludesControlType.cs
+++ b/src/RulesTest/Library/NameExcludesControlType.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using static Axe.Windows.RulesTest.ControlType;
 
 namespace Axe.Windows.RulesTest.Library

--- a/src/RulesTest/Library/NameExcludesPrivateUnicodeCharactersUnitTests.cs
+++ b/src/RulesTest/Library/NameExcludesPrivateUnicodeCharactersUnitTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/NameIsReasonableLength.cs
+++ b/src/RulesTest/Library/NameIsReasonableLength.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Text;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Text;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/SelectionItemPatternSingleSelection.cs
+++ b/src/RulesTest/Library/SelectionItemPatternSingleSelection.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using static Axe.Windows.RulesTest.ControlType;
 
 namespace Axe.Windows.RulesTest.Library

--- a/src/RulesTest/Library/SelectionPatternSelectionRequired.cs
+++ b/src/RulesTest/Library/SelectionPatternSelectionRequired.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/SiblingUniqueAndFocusableTest.cs
+++ b/src/RulesTest/Library/SiblingUniqueAndFocusableTest.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
-using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/SiblingUniqueAndNotFocusableTest.cs
+++ b/src/RulesTest/Library/SiblingUniqueAndNotFocusableTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/SplitButtonInvokeAndTogglePatterns.cs
+++ b/src/RulesTest/Library/SplitButtonInvokeAndTogglePatterns.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/Library/Structure/ContentView/SpinnerTests.cs
+++ b/src/RulesTest/Library/Structure/ContentView/SpinnerTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Rules;
-using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace Axe.Windows.RulesTest.Library.Structure.ContentView
 {

--- a/src/RulesTest/Library/Structure/ControlView/SpinnerTests.cs
+++ b/src/RulesTest/Library/Structure/ControlView/SpinnerTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Rules;
-using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace Axe.Windows.RulesTest.Library.Structure.ControlView
 {

--- a/src/RulesTest/Library/UWPTest.cs
+++ b/src/RulesTest/Library/UWPTest.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.Library
 {

--- a/src/RulesTest/MockA11yElement.cs
+++ b/src/RulesTest/MockA11yElement.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Collections.Generic;
-using System.Drawing;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
+using System.Collections.Generic;
+using System.Drawing;
 
 namespace Axe.Windows.RulesTest
 {

--- a/src/RulesTest/MonsterTest.cs
+++ b/src/RulesTest/MonsterTest.cs
@@ -3,9 +3,9 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.UnitTestSharedLibrary;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 

--- a/src/RulesTest/PropertyConditions/BoolPropertiesTest.cs
+++ b/src/RulesTest/PropertyConditions/BoolPropertiesTest.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 
 namespace Axe.Windows.RulesTest.PropertyConditions

--- a/src/RulesTest/PropertyConditions/BoundingRectangleTest.cs
+++ b/src/RulesTest/PropertyConditions/BoundingRectangleTest.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Drawing;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Axe.Windows.Core.Types;
-using BoundingRectangle = Axe.Windows.Rules.PropertyConditions.BoundingRectangle;
 using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using BoundingRectangle = Axe.Windows.Rules.PropertyConditions.BoundingRectangle;
+using System.Drawing;
 
 namespace Axe.Windows.RulesTest.PropertyConditions
 {

--- a/src/RulesTest/PropertyConditions/ContentViewTest.cs
+++ b/src/RulesTest/PropertyConditions/ContentViewTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.RulesTest.ControlType;
 
 namespace Axe.Windows.RulesTest.PropertyConditions

--- a/src/RulesTest/PropertyConditions/ControlViewTest.cs
+++ b/src/RulesTest/PropertyConditions/ControlViewTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.RulesTest.ControlType;
 
 namespace Axe.Windows.RulesTest.PropertyConditions

--- a/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
+++ b/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Axe.Windows.Rules.PropertyConditions;
 using static Axe.Windows.RulesTest.ControlType;
 
 namespace Axe.Windows.RulesTest.PropertyConditions

--- a/src/RulesTest/PropertyConditions/IntPropertyTest.cs
+++ b/src/RulesTest/PropertyConditions/IntPropertyTest.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.PropertyConditions
 {

--- a/src/RulesTest/PropertyConditions/LandmarksTest.cs
+++ b/src/RulesTest/PropertyConditions/LandmarksTest.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.PropertyConditions
 {

--- a/src/RulesTest/PropertyConditions/NameTest.cs
+++ b/src/RulesTest/PropertyConditions/NameTest.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using static Axe.Windows.RulesTest.ControlType;
 using Misc = Axe.Windows.Rules.PropertyConditions.ElementGroups;
 

--- a/src/RulesTest/PropertyConditions/PatternsTest.cs
+++ b/src/RulesTest/PropertyConditions/PatternsTest.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.PropertyConditions
 {

--- a/src/RulesTest/PropertyConditions/PlatformPropertiesTests.cs
+++ b/src/RulesTest/PropertyConditions/PlatformPropertiesTests.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.PropertyConditions
 {

--- a/src/RulesTest/PropertyConditions/RelationshipsTest.cs
+++ b/src/RulesTest/PropertyConditions/RelationshipsTest.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Rules;
 using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 using static Axe.Windows.RulesTest.ControlType;
 

--- a/src/RulesTest/PropertyConditions/ScrollPatternTest.cs
+++ b/src/RulesTest/PropertyConditions/ScrollPatternTest.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTest.PropertyConditions
 {

--- a/src/RulesTest/PropertyConditions/SelectionItemPattern.cs
+++ b/src/RulesTest/PropertyConditions/SelectionItemPattern.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
 
 namespace Axe.Windows.RulesTest.PropertyConditions
 {

--- a/src/RulesTest/PropertyConditions/SelectionPattern.cs
+++ b/src/RulesTest/PropertyConditions/SelectionPattern.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
 
 namespace Axe.Windows.RulesTest.PropertyConditions
 {

--- a/src/RulesTest/PropertyConditions/StringPropertiesTest.cs
+++ b/src/RulesTest/PropertyConditions/StringPropertiesTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.RulesTest.PropertyConditions

--- a/src/RulesTest/PropertyConditions/ValueConditionUnitTests.cs
+++ b/src/RulesTest/PropertyConditions/ValueConditionUnitTests.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace Axe.Windows.RulesTest.PropertyConditions
 {

--- a/src/SystemAbstractionsTests/SystemUnitTests.cs
+++ b/src/SystemAbstractionsTests/SystemUnitTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.SystemAbstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Axe.Windows.SystemAbstractions;
 
 namespace SystemAbstractionsTests
 {

--- a/src/TelemetryTests/ExcludingExceptionWrapperUnitTests.cs
+++ b/src/TelemetryTests/ExcludingExceptionWrapperUnitTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using Axe.Windows.Telemetry;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace Axe.Windows.TelemetryTests
 {


### PR DESCRIPTION
#### Details

Our using blocks have been left in a disarray after multiple renames that have occurred over the last year or two. This PR sorts the using blocks. It was done via a tool. A couple of test files that didn't previously end with a newline now have the newline--I left them that way since those files were outliers and normalizing them would make future tool-driven changes simpler.

##### Motivation

Code hygiene

##### Context

@RobGallo is on board with this change (we discussed it earlier today). 

This PR does not remove unneeded using blocks. VS is smart enough to handle this, but the tool that I created isn't.

Also, this makes no attempt to sort `using static` blocks or using blocks that are used as aliases.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
