### PR TITLE
fix: Add unsupported framework rule

### DIFF
--- a/src/Core/Enums/RuleId.cs
+++ b/src/Core/Enums/RuleId.cs
@@ -260,5 +260,7 @@ namespace Axe.Windows.Core.Enums
 
         ClickablePointOnScreen,
         ClickablePointOffScreen,
+
+        FrameworkDoesNotSupportUIAutomation,
     }
 }

--- a/src/Core/Misc/ExtensionMethods.cs
+++ b/src/Core/Misc/ExtensionMethods.cs
@@ -647,9 +647,11 @@ namespace Axe.Windows.Core.Misc
         {
             if (e == null) return null;
 
-            return (string.IsNullOrEmpty(e.Framework))
+            string framework = e.Framework;
+
+            return (string.IsNullOrEmpty(framework))
                 ? GetUIFramework(e.Parent)
-                : e.Framework;
+                : framework;
         }
 
         /// <summary>

--- a/src/Core/Misc/ExtensionMethods.cs
+++ b/src/Core/Misc/ExtensionMethods.cs
@@ -647,6 +647,7 @@ namespace Axe.Windows.Core.Misc
         {
             if (e == null) return null;
 
+            // Only query Framework property once to simplify unit test setup 
             string framework = e.Framework;
 
             return (string.IsNullOrEmpty(framework))

--- a/src/Rules/Library/FrameworkDoesNotSupportUIAutomation.cs
+++ b/src/Rules/Library/FrameworkDoesNotSupportUIAutomation.cs
@@ -4,6 +4,7 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;
 using System.Text.RegularExpressions;
+using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Framework;
 
 namespace Axe.Windows.Rules.Library
@@ -11,7 +12,7 @@ namespace Axe.Windows.Rules.Library
     [RuleInfo(ID = RuleId.FrameworkDoesNotSupportUIAutomation)]
     class FrameworkDoesNotSupportUIAutomation : Rule
     {
-        private readonly static string[] KnownProblematiClasses =
+        private readonly static string[] KnownProblematicClasses =
         {
             @"^\s*SunAwt.*$",
         };
@@ -28,7 +29,7 @@ namespace Axe.Windows.Rules.Library
         {
             string className = e.ClassName;
 
-            foreach (var knownProblematicClass in KnownProblematiClasses)
+            foreach (var knownProblematicClass in KnownProblematicClasses)
             {
                 if (Regex.IsMatch(className, knownProblematicClass, RegexOptions.CultureInvariant))
                     return false;
@@ -39,7 +40,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return Win32Framework;
+            return Win32Framework & Window;
         }
     }
 }

--- a/src/Rules/Library/FrameworkDoesNotSupportUIAutomation.cs
+++ b/src/Rules/Library/FrameworkDoesNotSupportUIAutomation.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Rules.Resources;
+using System.Linq;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
+
+namespace Axe.Windows.Rules.Library
+{
+    [RuleInfo(ID = RuleId.FrameworkDoesNotSupportUIAutomation)]
+    class FrameworkDoesNotSupportUIAutomation : Rule
+    {
+        private readonly static string[] KnownBadClasses =
+        {
+            "SunAwtFrame",
+        };
+
+        public FrameworkDoesNotSupportUIAutomation ()
+        {
+            this.Info.Description = Descriptions.EditSupportsIncorrectRangeValuePattern;
+            this.Info.HowToFix = HowToFix.EditSupportsIncorrectRangeValuePattern;
+            this.Info.Standard = A11yCriteriaId.ObjectInformation;
+            this.Info.ErrorCode = EvaluationCode.Error;
+        }
+
+        public override bool PassesTest(IA11yElement element)
+        {
+            string className = element.ClassName;
+
+            return !KnownBadClasses.Contains(className);
+        }
+
+        protected override Condition CreateCondition()
+        {
+            return Win32Framework;
+        }
+    }
+}

--- a/src/Rules/Library/FrameworkDoesNotSupportUIAutomation.cs
+++ b/src/Rules/Library/FrameworkDoesNotSupportUIAutomation.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;
-using System.Linq;
+using System.Text.RegularExpressions;
 using static Axe.Windows.Rules.PropertyConditions.Framework;
 
 namespace Axe.Windows.Rules.Library
@@ -11,24 +11,30 @@ namespace Axe.Windows.Rules.Library
     [RuleInfo(ID = RuleId.FrameworkDoesNotSupportUIAutomation)]
     class FrameworkDoesNotSupportUIAutomation : Rule
     {
-        private readonly static string[] KnownBadClasses =
+        private readonly static string[] KnownProblematiClasses =
         {
-            "SunAwtFrame",
+            @"^\s*SunAwt.*$",
         };
 
         public FrameworkDoesNotSupportUIAutomation ()
         {
-            this.Info.Description = Descriptions.EditSupportsIncorrectRangeValuePattern;
-            this.Info.HowToFix = HowToFix.EditSupportsIncorrectRangeValuePattern;
+            this.Info.Description = Descriptions.FrameworkDoesNotSupportUIAutomation;
+            this.Info.HowToFix = HowToFix.FrameworkDoesNotSupportUIAutomation;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.ErrorCode = EvaluationCode.Error;
         }
 
-        public override bool PassesTest(IA11yElement element)
+        public override bool PassesTest(IA11yElement e)
         {
-            string className = element.ClassName;
+            string className = e.ClassName;
 
-            return !KnownBadClasses.Contains(className);
+            foreach (var knownProblematicClass in KnownProblematiClasses)
+            {
+                if (Regex.IsMatch(className, knownProblematicClass, RegexOptions.CultureInvariant))
+                    return false;
+            }
+
+            return true;
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Resources/Descriptions.Designer.cs
+++ b/src/Rules/Resources/Descriptions.Designer.cs
@@ -430,6 +430,15 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This framework in use does not support UI Automation..
+        /// </summary>
+        internal static string FrameworkDoesNotSupportUIAutomation {
+            get {
+                return ResourceManager.GetString("FrameworkDoesNotSupportUIAutomation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An element&apos;s HeadingLevel must be greater than or equal to that of its ancestors..
         /// </summary>
         internal static string HeadingLevelDescendsWhenNested {

--- a/src/Rules/Resources/Descriptions.Designer.cs
+++ b/src/Rules/Resources/Descriptions.Designer.cs
@@ -430,7 +430,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The framework in use does not support UI Automation..
+        ///   Looks up a localized string similar to The framework used to build this application does not support UI Automation..
         /// </summary>
         internal static string FrameworkDoesNotSupportUIAutomation {
             get {

--- a/src/Rules/Resources/Descriptions.Designer.cs
+++ b/src/Rules/Resources/Descriptions.Designer.cs
@@ -430,7 +430,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This framework in use does not support UI Automation..
+        ///   Looks up a localized string similar to The framework in use does not support UI Automation..
         /// </summary>
         internal static string FrameworkDoesNotSupportUIAutomation {
             get {

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -426,4 +426,7 @@
   <data name="ClickablePointOffScreen" xml:space="preserve">
     <value>An element's IsOffScreen property must be true when its clickable point is off screen.</value>
   </data>
+  <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
+    <value>This framework in use does not support UI Automation.</value>
+  </data>
 </root>

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -427,6 +427,6 @@
     <value>An element's IsOffScreen property must be true when its clickable point is off screen.</value>
   </data>
   <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
-    <value>This framework in use does not support UI Automation.</value>
+    <value>The framework in use does not support UI Automation.</value>
   </data>
 </root>

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -427,6 +427,6 @@
     <value>An element's IsOffScreen property must be true when its clickable point is off screen.</value>
   </data>
   <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
-    <value>The framework in use does not support UI Automation.</value>
+    <value>The framework used to build this application does not support UI Automation.</value>
   </data>
 </root>

--- a/src/Rules/Resources/HowToFix.Designer.cs
+++ b/src/Rules/Resources/HowToFix.Designer.cs
@@ -465,6 +465,15 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Switch your application to a framework that supports UI Automation..
+        /// </summary>
+        internal static string FrameworkDoesNotSupportUIAutomation {
+            get {
+                return ResourceManager.GetString("FrameworkDoesNotSupportUIAutomation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Modify the heading levels and/or nesting structure of the element and/or its ancestors.
         ///For example, if an element has a level-5 heading, its descendants can have only level-5 or level-6 headings..
         /// </summary>

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -542,4 +542,7 @@ If the element's ClickablePoint property is incorrect, please ensure it returns 
     <value>If the element's ClickablePoint property is correct, set the element's IsOffScreen property to true.
 If the element's ClickablePoint property is incorrect, please ensure it returns the correct value.</value>
   </data>
+  <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
+    <value>Switch your application to a framework that supports UI Automation.</value>
+  </data>
 </root>

--- a/src/RulesTest/Library/FrameworkDoesNotSupportUIAutomationTests.cs
+++ b/src/RulesTest/Library/FrameworkDoesNotSupportUIAutomationTests.cs
@@ -49,7 +49,7 @@ namespace Axe.Windows.RulesTest.Library
         }
 
         [TestMethod]
-        public void PassesTest_FrameworkIsWin32_ClassNameIsNotKnownBad_ReturnsFalse()
+        public void PassesTest_FrameworkIsWin32_ClassNameIsNotKnownProblematic_ReturnsFalse()
         {
             string[] testClasses = { "Edit", "SunAwT" };
 
@@ -64,7 +64,7 @@ namespace Axe.Windows.RulesTest.Library
         }
 
         [TestMethod]
-        public void PassesTest_FrameworkIsWin32_ClassNameIsKnownBad_ReturnsTrue()
+        public void PassesTest_FrameworkIsWin32_ClassNameIsKnownProblematic_ReturnsTrue()
         {
             string[] testClasses = { "SunAwt", "SunAwtXyz" };
 

--- a/src/RulesTest/Library/FrameworkDoesNotSupportUIAutomationTests.cs
+++ b/src/RulesTest/Library/FrameworkDoesNotSupportUIAutomationTests.cs
@@ -10,7 +10,7 @@ namespace Axe.Windows.RulesTest.Library
 {
     [TestClass]
 
-    public class FrameworkDoesNotSupportUIAutomationUnitTests
+    public class FrameworkDoesNotSupportUIAutomationTests
     {
         private readonly static Rules.IRule Rule = new Rules.Library.FrameworkDoesNotSupportUIAutomation();
         private Mock<IA11yElement> _elementMock;
@@ -51,9 +51,14 @@ namespace Axe.Windows.RulesTest.Library
         [TestMethod]
         public void PassesTest_FrameworkIsWin32_ClassNameIsNotKnownBad_ReturnsFalse()
         {
-            _elementMock.Setup(m => m.ClassName).Returns("Edit").Verifiable(); ;
+            string[] testClasses = { "Edit", "SunAwT" };
 
-            Assert.IsTrue(Rule.PassesTest(_elementMock.Object));
+            foreach (string testClass in testClasses)
+            {
+                _elementMock.Setup(m => m.ClassName).Returns(testClass).Verifiable(); ;
+
+                Assert.IsTrue(Rule.PassesTest(_elementMock.Object));
+            }
 
             _elementMock.VerifyAll();
         }
@@ -61,9 +66,14 @@ namespace Axe.Windows.RulesTest.Library
         [TestMethod]
         public void PassesTest_FrameworkIsWin32_ClassNameIsKnownBad_ReturnsTrue()
         {
-            _elementMock.Setup(m => m.ClassName).Returns("SunAwtFrame").Verifiable(); ;
+            string[] testClasses = { "SunAwt", "SunAwtXyz" };
 
-            Assert.IsFalse(Rule.PassesTest(_elementMock.Object));
+            foreach (string testClass in testClasses)
+            {
+                _elementMock.Setup(m => m.ClassName).Returns(testClass).Verifiable(); ;
+
+                Assert.IsFalse(Rule.PassesTest(_elementMock.Object));
+            }
 
             _elementMock.VerifyAll();
         }

--- a/src/RulesTest/Library/FrameworkDoesNotSupportUIAutomationTests.cs
+++ b/src/RulesTest/Library/FrameworkDoesNotSupportUIAutomationTests.cs
@@ -5,6 +5,7 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using System.Reflection;
 
 namespace Axe.Windows.RulesTests.Library
 {
@@ -29,7 +30,7 @@ namespace Axe.Windows.RulesTests.Library
             foreach (string nonWin32Value in nonWin32Values)
             {
                 _elementMock.Setup(m => m.Framework)
-                    .Returns(FrameworkId.DirectUI)
+                    .Returns(nonWin32Value)
                     .Verifiable();
 
                 Assert.IsFalse(Rule.Condition.Matches(_elementMock.Object));
@@ -39,17 +40,31 @@ namespace Axe.Windows.RulesTests.Library
         }
 
         [TestMethod]
-        public void Condition_FrameworkIsWin32_ReturnsTrue()
+        public void Condition_FrameworkIsWin32_ControlTypeIsNotWindow_ReturnsFalse()
         {
             _elementMock.Setup(m => m.Framework).Returns(FrameworkId.Win32).Verifiable();
+            _elementMock.Setup(m => m.ControlTypeId).Returns(Core.Types.ControlType.UIA_ButtonControlTypeId);
+
+            Assert.IsFalse(Rule.Condition.Matches(_elementMock.Object));
+
+            _elementMock.Verify(m => m.Framework, Times.Once());
+            _elementMock.Verify(m => m.ControlTypeId, Times.Once());
+        }
+
+        [TestMethod]
+        public void Condition_FrameworkIsWin32_ControlTypeIsWindow_ReturnsTrue()
+        {
+            _elementMock.Setup(m => m.Framework).Returns(FrameworkId.Win32).Verifiable();
+            _elementMock.Setup(m => m.ControlTypeId).Returns(Core.Types.ControlType.UIA_WindowControlTypeId);
 
             Assert.IsTrue(Rule.Condition.Matches(_elementMock.Object));
 
             _elementMock.Verify(m => m.Framework, Times.Once());
+            _elementMock.Verify(m => m.ControlTypeId, Times.Once());
         }
 
         [TestMethod]
-        public void PassesTest_FrameworkIsWin32_ClassNameIsNotKnownProblematic_ReturnsFalse()
+        public void PassesTest_ClassNameIsNotKnownProblematic_ReturnsFalse()
         {
             string[] testClasses = { "Edit", "SunAwT" };
 
@@ -64,7 +79,7 @@ namespace Axe.Windows.RulesTests.Library
         }
 
         [TestMethod]
-        public void PassesTest_FrameworkIsWin32_ClassNameIsKnownProblematic_ReturnsTrue()
+        public void PassesTest_ClassNameIsKnownProblematic_ReturnsTrue()
         {
             string[] testClasses = { "SunAwt", "SunAwtXyz" };
 

--- a/src/RulesTest/Library/FrameworkDoesNotSupportUIAutomationTests.cs
+++ b/src/RulesTest/Library/FrameworkDoesNotSupportUIAutomationTests.cs
@@ -6,7 +6,7 @@ using Axe.Windows.Core.Enums;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
 

--- a/src/RulesTest/Library/FrameworkDoesNotSupportUIAutomationUnitTests.cs
+++ b/src/RulesTest/Library/FrameworkDoesNotSupportUIAutomationUnitTests.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Axe.Windows.RulesTest.Library
+{
+    [TestClass]
+
+    public class FrameworkDoesNotSupportUIAutomationUnitTests
+    {
+        private readonly static Rules.IRule Rule = new Rules.Library.FrameworkDoesNotSupportUIAutomation();
+        private Mock<IA11yElement> _elementMock;
+
+        [TestInitialize]
+        public void BeforeEach()
+        {
+            _elementMock = new Mock<IA11yElement>(MockBehavior.Strict);
+        }
+
+        [TestMethod]
+        public void Condition_FrameworkIsNotWin32_ReturnsFalse()
+        {
+            string[] nonWin32Values = { FrameworkId.DirectUI, FrameworkId.Edge, FrameworkId.InternetExplorer, FrameworkId.WinForm, FrameworkId.WPF, FrameworkId.XAML, "NotWin32" };
+
+            foreach (string nonWin32Value in nonWin32Values)
+            {
+                _elementMock.Setup(m => m.Framework)
+                    .Returns(FrameworkId.DirectUI)
+                    .Verifiable();
+
+                Assert.IsFalse(Rule.Condition.Matches(_elementMock.Object));
+            }
+
+            _elementMock.Verify(m => m.Framework, Times.Exactly(nonWin32Values.Length));
+        }
+
+        [TestMethod]
+        public void Condition_FrameworkIsWin32_ReturnsTrue()
+        {
+            _elementMock.Setup(m => m.Framework).Returns(FrameworkId.Win32).Verifiable();
+
+            Assert.IsTrue(Rule.Condition.Matches(_elementMock.Object));
+
+            _elementMock.Verify(m => m.Framework, Times.Once());
+        }
+
+        [TestMethod]
+        public void PassesTest_FrameworkIsWin32_ClassNameIsNotKnownBad_ReturnsFalse()
+        {
+            _elementMock.Setup(m => m.ClassName).Returns("Edit").Verifiable(); ;
+
+            Assert.IsTrue(Rule.PassesTest(_elementMock.Object));
+
+            _elementMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void PassesTest_FrameworkIsWin32_ClassNameIsKnownBad_ReturnsTrue()
+        {
+            _elementMock.Setup(m => m.ClassName).Returns("SunAwtFrame").Verifiable(); ;
+
+            Assert.IsFalse(Rule.PassesTest(_elementMock.Object));
+
+            _elementMock.VerifyAll();
+        }
+    }
+}


### PR DESCRIPTION
#### Details

Issue #554 requests a way to warn users if they're using a framework that doesn't support UIA. We don't yet have a good way to do this in live mode, but a first step is to add an automated check that triggers an error based on the Windows class name. So far, the cases we've encountered are Win32 frameworks that return class names of `SunAwtFrame` or `SunAwtDialog`. Other classes could exist, so we've opted to raise the error for any Win32 object with a reported ClassName of `SunAwt*`. We use a case-sensitive regular expression here.

##### Motivation

Issue #554 

##### Context

The HowToFix text may be a little too blunt. It says "Switch your application to a framework that supports UI Automation.". I'm open to gentler ways to express this sentiment of "Sorry, you chose the wrong framework".

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
