### PR TITLE
chore: Normalize namespace for RulesTests project

### DIFF
--- a/src/RulesTest/AllRules.test.cs
+++ b/src/RulesTest/AllRules.test.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace RulesTests
+namespace Axe.Windows.RulesTests
 {
     [TestClass]
     public class AllRules
@@ -11,7 +11,7 @@ namespace RulesTests
         [TestMethod]
         public void AllRulesHaveErrorCode()
         {
-            foreach (var rule in Rules.All.Values)
+            foreach (var rule in Rules.Rules.All.Values)
                 Assert.AreNotEqual(EvaluationCode.NotSet, rule.ErrorCode);
         }
     } // class

--- a/src/RulesTest/Conditions/AndConditionTest.cs
+++ b/src/RulesTest/Conditions/AndConditionTest.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Conditions
+namespace Axe.Windows.RulesTests.Conditions
 {
     [TestClass]
     public class AndConditionTest

--- a/src/RulesTest/Conditions/ConditionTest.cs
+++ b/src/RulesTest/Conditions/ConditionTest.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Conditions
+namespace Axe.Windows.RulesTests.Conditions
 {
     [TestClass]
     public class ConditionTest

--- a/src/RulesTest/Conditions/ControlTypeConditionTest.cs
+++ b/src/RulesTest/Conditions/ControlTypeConditionTest.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Conditions
+namespace Axe.Windows.RulesTests.Conditions
 {
     [TestClass]
     public class ControlTypeConditionTest

--- a/src/RulesTest/Conditions/NotConditionTest.cs
+++ b/src/RulesTest/Conditions/NotConditionTest.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Conditions
+namespace Axe.Windows.RulesTests.Conditions
 {
     [TestClass]
     public class NotConditionTest

--- a/src/RulesTest/Conditions/OrConditionTest.cs
+++ b/src/RulesTest/Conditions/OrConditionTest.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Conditions
+namespace Axe.Windows.RulesTests.Conditions
 {
     [TestClass]
     public class OrConditionTest

--- a/src/RulesTest/Conditions/PatternConditionTest.cs
+++ b/src/RulesTest/Conditions/PatternConditionTest.cs
@@ -5,7 +5,7 @@ using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-namespace Axe.Windows.RulesTest.Conditions
+namespace Axe.Windows.RulesTests.Conditions
 {
     [TestClass]
     public class PatternConditionTest

--- a/src/RulesTest/Conditions/TreeDescentConditionTest.cs
+++ b/src/RulesTest/Conditions/TreeDescentConditionTest.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using Condition = Axe.Windows.Rules.Condition;
 
-namespace Axe.Windows.RulesTest.Conditions
+namespace Axe.Windows.RulesTests.Conditions
 {
     [TestClass]
     public class TreeDescentConditionTest

--- a/src/RulesTest/ControlType.cs
+++ b/src/RulesTest/ControlType.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace Axe.Windows.RulesTest
+namespace Axe.Windows.RulesTests
 {
     static class ControlType
     {

--- a/src/RulesTest/Extensions.cs
+++ b/src/RulesTest/Extensions.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Axe.Windows.RulesTest
+namespace Axe.Windows.RulesTests
 {
     static class Extensions
     {

--- a/src/RulesTest/Library/BoundingRectangleCompletelyObscuresContainerTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleCompletelyObscuresContainerTest.cs
@@ -6,7 +6,7 @@ using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class BoundingRectangleCompletelyObscuresContainerTest

--- a/src/RulesTest/Library/BoundingRectangleContainedInParentTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleContainedInParentTest.cs
@@ -7,10 +7,10 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using static Axe.Windows.RulesTest.ControlType;
+using static Axe.Windows.RulesTests.ControlType;
 
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class BoundingRectangleContainedInParentTest

--- a/src/RulesTest/Library/BoundingRectangleDataFormatCorrectTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleDataFormatCorrectTest.cs
@@ -4,7 +4,7 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class BoundingRectangleDataFormatCorrectTest

--- a/src/RulesTest/Library/BoundingRectangleNotAllZerosTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotAllZerosTest.cs
@@ -3,7 +3,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class BoundingRectangleNotAllZerosTest

--- a/src/RulesTest/Library/BoundingRectangleNotNullTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotNullTest.cs
@@ -4,7 +4,7 @@ using Axe.Windows.Core.Enums;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class BoundingRectangleNotNullTest

--- a/src/RulesTest/Library/BoundingRectangleNotValidButOffScreenTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotValidButOffScreenTest.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class BoundingRectangleNotValidButOffScreenTest

--- a/src/RulesTest/Library/BoundingRectangleOnUWPMenuBarTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleOnUWPMenuBarTest.cs
@@ -3,7 +3,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class BoundingRectangleOnUWPMenuBarTest

--- a/src/RulesTest/Library/BoundingRectangleOnUWPMenuItemTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleOnUWPMenuItemTest.cs
@@ -3,7 +3,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class BoundingRectangleOnUWPMenuItemTest

--- a/src/RulesTest/Library/BoundingRectangleOnWPFTextParentTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleOnWPFTextParentTest.cs
@@ -3,7 +3,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class BoundingRectangleOnWPFTextParentTest

--- a/src/RulesTest/Library/BoundingRectangleSizeReasonableTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleSizeReasonableTest.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class BoundingRectangleSizeReasonableTest

--- a/src/RulesTest/Library/ButtonInvokeAndExpandCollapsePatterns.cs
+++ b/src/RulesTest/Library/ButtonInvokeAndExpandCollapsePatterns.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class ButtonInvokeAndExpandCollapsePatterns

--- a/src/RulesTest/Library/ButtonInvokeAndTogglePatterns.cs
+++ b/src/RulesTest/Library/ButtonInvokeAndTogglePatterns.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class ButtonInvokeAndTogglePatterns

--- a/src/RulesTest/Library/ButtonPatterns.cs
+++ b/src/RulesTest/Library/ButtonPatterns.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class ButtonPatterns

--- a/src/RulesTest/Library/ButtonToggleAndExpandCollapsePatterns.cs
+++ b/src/RulesTest/Library/ButtonToggleAndExpandCollapsePatterns.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class ButtonToggleAndExpandCollapsePatterns

--- a/src/RulesTest/Library/ClickablePointOffScreen.cs
+++ b/src/RulesTest/Library/ClickablePointOffScreen.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class ClickablePointOffScreenTests

--- a/src/RulesTest/Library/ClickablePointOnScreen.cs
+++ b/src/RulesTest/Library/ClickablePointOnScreen.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class ClickablePointOnScreenTests

--- a/src/RulesTest/Library/ComboBoxShouldNotSupportScrollPatternTests.cs
+++ b/src/RulesTest/Library/ComboBoxShouldNotSupportScrollPatternTests.cs
@@ -5,7 +5,7 @@ using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     [TestCategory("Axe.Windows.Rules")]

--- a/src/RulesTest/Library/ControlShouldNotSupportInvokePattern.cs
+++ b/src/RulesTest/Library/ControlShouldNotSupportInvokePattern.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Core.Enums;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     [TestCategory("Axe.Windows.Rules")]

--- a/src/RulesTest/Library/ControlShouldNotSupportScrollPatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldNotSupportScrollPatternTests.cs
@@ -5,7 +5,7 @@ using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     [TestCategory("Axe.Windows.Rules")]

--- a/src/RulesTest/Library/ControlShouldNotSupportTablePattern.cs
+++ b/src/RulesTest/Library/ControlShouldNotSupportTablePattern.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class ControlShouldNotSupportTablePattern

--- a/src/RulesTest/Library/ControlShouldSupportExpandCollapsePattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportExpandCollapsePattern.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class ControlShouldSupportExpandCollapsePattern

--- a/src/RulesTest/Library/ControlShouldSupportGridPattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportGridPattern.cs
@@ -7,7 +7,7 @@ using System;
 using System.Diagnostics;
 using UIAutomationClient;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class ControlShouldSupportGridPattern

--- a/src/RulesTest/Library/ControlShouldSupportSetInfoWPFTest.cs
+++ b/src/RulesTest/Library/ControlShouldSupportSetInfoWPFTest.cs
@@ -5,7 +5,7 @@ using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     [TestCategory("Axe.Windows.Rules")]

--- a/src/RulesTest/Library/ControlShouldSupportSetInfoXAMLTest.cs
+++ b/src/RulesTest/Library/ControlShouldSupportSetInfoXAMLTest.cs
@@ -5,7 +5,7 @@ using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     [TestCategory("Axe.Windows.Rules")]

--- a/src/RulesTest/Library/ControlShouldSupportTablePattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTablePattern.cs
@@ -3,11 +3,11 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
-using Axe.Windows.RulesTest;
+using Axe.Windows.RulesTests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class ControlShouldSupportTablePattern

--- a/src/RulesTest/Library/ControlShouldSupportTablePatternInEdge.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTablePatternInEdge.cs
@@ -3,11 +3,11 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
-using Axe.Windows.RulesTest;
+using Axe.Windows.RulesTests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class ControlShouldSupportTablePatternInEdge

--- a/src/RulesTest/Library/ControlShouldSupportTextPatternUnitTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTextPatternUnitTests.cs
@@ -6,7 +6,7 @@ using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class ControlShouldSupportTextPatternUnitTests

--- a/src/RulesTest/Library/HeadingLevelDescendsWhenNestedTest.cs
+++ b/src/RulesTest/Library/HeadingLevelDescendsWhenNestedTest.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class HeadingLevelDescendsWhenNestedTest

--- a/src/RulesTest/Library/HelpTextExcludesPrivateUnicodeCharactersUnitTests.cs
+++ b/src/RulesTest/Library/HelpTextExcludesPrivateUnicodeCharactersUnitTests.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using static Axe.Windows.RulesTest.ControlType;
+using static Axe.Windows.RulesTests.ControlType;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class HelpTextExcludesPrivateUnicodeCharactersUnitTests

--- a/src/RulesTest/Library/HyperlinkNameShouldBeUniqueTest.cs
+++ b/src/RulesTest/Library/HyperlinkNameShouldBeUniqueTest.cs
@@ -3,7 +3,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class HyperlinkNameShouldBeUniqueTest

--- a/src/RulesTest/Library/IsKeyboardFocusableOnEmptyContainer.cs
+++ b/src/RulesTest/Library/IsKeyboardFocusableOnEmptyContainer.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class IsKeyboardFocusableOnEmptyContainer

--- a/src/RulesTest/Library/IsKeyboardFocusableShouldBeTrue.cs
+++ b/src/RulesTest/Library/IsKeyboardFocusableShouldBeTrue.cs
@@ -3,7 +3,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class IsKeyboardFocusableShouldBeTrue

--- a/src/RulesTest/Library/IsKeyboardFocusableTopLevelTextPattern.cs
+++ b/src/RulesTest/Library/IsKeyboardFocusableTopLevelTextPattern.cs
@@ -4,7 +4,7 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class IsKeyboardFocusableTopLevelTextPattern

--- a/src/RulesTest/Library/LandmarkIsTopLevel.cs
+++ b/src/RulesTest/Library/LandmarkIsTopLevel.cs
@@ -5,7 +5,7 @@ using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     public class LandmarkIsTopLevel
     {

--- a/src/RulesTest/Library/ListItemSiblingUniqueTests.cs
+++ b/src/RulesTest/Library/ListItemSiblingUniqueTests.cs
@@ -3,7 +3,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class ListItemSiblingUniqueTests

--- a/src/RulesTest/Library/LocalizedControlTypeExcludesPrivateUnicodeCharactersUnitTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeExcludesPrivateUnicodeCharactersUnitTests.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using static Axe.Windows.RulesTest.ControlType;
+using static Axe.Windows.RulesTests.ControlType;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class LocalizedControlTypeExcludesPrivateUnicodeCharactersUnitTests

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotCustom.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotCustom.cs
@@ -3,7 +3,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class LocalizedControlTypeIsNotCustom

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
@@ -3,7 +3,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class LocalizedControlTypeIsNotCustomWPFGridCell

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotEmpty.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotEmpty.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     [TestCategory("Axe.Windows.Rules")]

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotNull.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotNull.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     [TestCategory("Axe.Windows.Rules")]

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotWhiteSpace.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotWhiteSpace.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class LocalizedControlTypeIsNotWhiteSpace

--- a/src/RulesTest/Library/LocalizedControlTypeIsReasonable.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsReasonable.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using static Axe.Windows.RulesTest.ControlType;
+using static Axe.Windows.RulesTests.ControlType;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class LocalizedControlTypeIsReasonable

--- a/src/RulesTest/Library/LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters.cs
+++ b/src/RulesTest/Library/LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters.cs
@@ -3,7 +3,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters

--- a/src/RulesTest/Library/LocalizedLandmarkTypeNotCustomTests.cs
+++ b/src/RulesTest/Library/LocalizedLandmarkTypeNotCustomTests.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class LocalizedLandmarkTypeNotCustomTests

--- a/src/RulesTest/Library/NameExcludesControlType.cs
+++ b/src/RulesTest/Library/NameExcludesControlType.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using static Axe.Windows.RulesTest.ControlType;
+using static Axe.Windows.RulesTests.ControlType;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class NameExcludesControlType

--- a/src/RulesTest/Library/NameExcludesLocalizedControlType.cs
+++ b/src/RulesTest/Library/NameExcludesLocalizedControlType.cs
@@ -3,9 +3,9 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
-using static Axe.Windows.RulesTest.ControlType;
+using static Axe.Windows.RulesTests.ControlType;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class NameExcludesLocalizedControlType

--- a/src/RulesTest/Library/NameExcludesPrivateUnicodeCharactersUnitTests.cs
+++ b/src/RulesTest/Library/NameExcludesPrivateUnicodeCharactersUnitTests.cs
@@ -3,7 +3,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class NameExcludesPrivateUnicodeCharactersUnitTests

--- a/src/RulesTest/Library/NameIsEmptyButElementIsNotKeyboardFocusableTest.cs
+++ b/src/RulesTest/Library/NameIsEmptyButElementIsNotKeyboardFocusableTest.cs
@@ -3,9 +3,9 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Drawing;
-using static Axe.Windows.RulesTest.ControlType;
+using static Axe.Windows.RulesTests.ControlType;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class NameIsEmptyButElementIsNotKeyboardFocusableTest

--- a/src/RulesTest/Library/NameIsInformative.cs
+++ b/src/RulesTest/Library/NameIsInformative.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class NameIsInformative

--- a/src/RulesTest/Library/NameIsNotEmpty.cs
+++ b/src/RulesTest/Library/NameIsNotEmpty.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using static Axe.Windows.RulesTest.ControlType;
+using static Axe.Windows.RulesTests.ControlType;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     [TestCategory("Axe.Windows.Rules")]

--- a/src/RulesTest/Library/NameIsNotNull.cs
+++ b/src/RulesTest/Library/NameIsNotNull.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
-using static Axe.Windows.RulesTest.ControlType;
+using static Axe.Windows.RulesTests.ControlType;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     [TestCategory("Axe.Windows.Rules")]

--- a/src/RulesTest/Library/NameIsNotWhiteSpace.cs
+++ b/src/RulesTest/Library/NameIsNotWhiteSpace.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class NameIsNotWhiteSpace

--- a/src/RulesTest/Library/NameIsNullButElementIsNotKeyboardFocusableTest.cs
+++ b/src/RulesTest/Library/NameIsNullButElementIsNotKeyboardFocusableTest.cs
@@ -3,9 +3,9 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Drawing;
-using static Axe.Windows.RulesTest.ControlType;
+using static Axe.Windows.RulesTests.ControlType;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class NameIsNullButElementIsNotKeyboardFocusableTest

--- a/src/RulesTest/Library/NameIsReasonableLength.cs
+++ b/src/RulesTest/Library/NameIsReasonableLength.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Text;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class NameIsReasonableLength

--- a/src/RulesTest/Library/ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs
+++ b/src/RulesTest/Library/ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     [TestCategory("Axe.Windows.Rules")]

--- a/src/RulesTest/Library/ProgressBarRangeValue.cs
+++ b/src/RulesTest/Library/ProgressBarRangeValue.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class ProgressBarRangeValueTests

--- a/src/RulesTest/Library/SelectionItemPatternSingleSelection.cs
+++ b/src/RulesTest/Library/SelectionItemPatternSingleSelection.cs
@@ -5,9 +5,9 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using static Axe.Windows.RulesTest.ControlType;
+using static Axe.Windows.RulesTests.ControlType;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class SelectionItemPatternSingleSelectionTests

--- a/src/RulesTest/Library/SelectionPatternSelectionRequired.cs
+++ b/src/RulesTest/Library/SelectionPatternSelectionRequired.cs
@@ -5,7 +5,7 @@ using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     [TestCategory("Axe.Windows.Rules")]

--- a/src/RulesTest/Library/SiblingUniqueAndFocusableTest.cs
+++ b/src/RulesTest/Library/SiblingUniqueAndFocusableTest.cs
@@ -5,7 +5,7 @@ using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class SiblingUniqueAndFocusableTest

--- a/src/RulesTest/Library/SiblingUniqueAndNotFocusableTest.cs
+++ b/src/RulesTest/Library/SiblingUniqueAndNotFocusableTest.cs
@@ -3,7 +3,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class SiblingUniqueAndNotFocusableTest

--- a/src/RulesTest/Library/SplitButtonInvokeAndTogglePatterns.cs
+++ b/src/RulesTest/Library/SplitButtonInvokeAndTogglePatterns.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class SplitButtonInvokeAndTogglePatterns

--- a/src/RulesTest/Library/Structure/ContentView/SpinnerTests.cs
+++ b/src/RulesTest/Library/Structure/ContentView/SpinnerTests.cs
@@ -4,7 +4,7 @@ using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-namespace Axe.Windows.RulesTest.Library.Structure.ContentView
+namespace Axe.Windows.RulesTests.Library.Structure.ContentView
 {
     [TestClass]
     public class SpinnerTests

--- a/src/RulesTest/Library/Structure/ControlView/ScrollbarTest.cs
+++ b/src/RulesTest/Library/Structure/ControlView/ScrollbarTest.cs
@@ -6,7 +6,7 @@ using Moq;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class ControlViewScrollbarStructureTest

--- a/src/RulesTest/Library/Structure/ControlView/SpinnerTests.cs
+++ b/src/RulesTest/Library/Structure/ControlView/SpinnerTests.cs
@@ -4,7 +4,7 @@ using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-namespace Axe.Windows.RulesTest.Library.Structure.ControlView
+namespace Axe.Windows.RulesTests.Library.Structure.ControlView
 {
     [TestClass]
     public class SpinnerTests

--- a/src/RulesTest/Library/UWPTest.cs
+++ b/src/RulesTest/Library/UWPTest.cs
@@ -4,7 +4,7 @@ using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class UWPTest

--- a/src/RulesTest/MockA11yElement.cs
+++ b/src/RulesTest/MockA11yElement.cs
@@ -6,7 +6,7 @@ using Axe.Windows.Core.Types;
 using System.Collections.Generic;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest
+namespace Axe.Windows.RulesTests
 {
     class MockA11yElement : A11yElement
     {

--- a/src/RulesTest/MonsterTest.cs
+++ b/src/RulesTest/MonsterTest.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
-namespace Axe.Windows.RulesTest
+namespace Axe.Windows.RulesTests
 {
     [TestClass]
     public class MonsterTest

--- a/src/RulesTest/PatternIDs.cs
+++ b/src/RulesTest/PatternIDs.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-namespace Axe.Windows.RulesTest
+namespace Axe.Windows.RulesTests
 {
     static class PatternIDs
     {

--- a/src/RulesTest/PropertyConditions/BoolPropertiesTest.cs
+++ b/src/RulesTest/PropertyConditions/BoolPropertiesTest.cs
@@ -5,7 +5,7 @@ using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class BoolPropertiesTest

--- a/src/RulesTest/PropertyConditions/BoundingRectangleTest.cs
+++ b/src/RulesTest/PropertyConditions/BoundingRectangleTest.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using BoundingRectangle = Axe.Windows.Rules.PropertyConditions.BoundingRectangle;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class BoundingRectangleTest

--- a/src/RulesTest/PropertyConditions/ClickablePointTests.cs
+++ b/src/RulesTest/PropertyConditions/ClickablePointTests.cs
@@ -8,7 +8,7 @@ using Moq;
 using System;
 using System.Drawing;
 
-namespace Axe.Windows.RulesTest.Library
+namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
     public class ClickablePointTests

--- a/src/RulesTest/PropertyConditions/ContentViewTest.cs
+++ b/src/RulesTest/PropertyConditions/ContentViewTest.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using static Axe.Windows.RulesTest.ControlType;
+using static Axe.Windows.RulesTests.ControlType;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class ContentViewTest

--- a/src/RulesTest/PropertyConditions/ControlViewTest.cs
+++ b/src/RulesTest/PropertyConditions/ControlViewTest.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using static Axe.Windows.RulesTest.ControlType;
+using static Axe.Windows.RulesTests.ControlType;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class ControlViewTest

--- a/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
+++ b/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
@@ -4,9 +4,9 @@ using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Linq;
-using static Axe.Windows.RulesTest.ControlType;
+using static Axe.Windows.RulesTests.ControlType;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class ElementGroupsTests

--- a/src/RulesTest/PropertyConditions/EnumPropertyUnitTests.cs
+++ b/src/RulesTest/PropertyConditions/EnumPropertyUnitTests.cs
@@ -6,7 +6,7 @@ using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class EnumPropertyUnitTests

--- a/src/RulesTest/PropertyConditions/IntPropertiesTests.cs
+++ b/src/RulesTest/PropertyConditions/IntPropertiesTests.cs
@@ -4,7 +4,7 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class IntPropertiesTests

--- a/src/RulesTest/PropertyConditions/IntPropertyTest.cs
+++ b/src/RulesTest/PropertyConditions/IntPropertyTest.cs
@@ -5,7 +5,7 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class IntPropertyTest

--- a/src/RulesTest/PropertyConditions/LandmarksTest.cs
+++ b/src/RulesTest/PropertyConditions/LandmarksTest.cs
@@ -4,7 +4,7 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class LandmarksTest

--- a/src/RulesTest/PropertyConditions/NameTest.cs
+++ b/src/RulesTest/PropertyConditions/NameTest.cs
@@ -5,10 +5,10 @@ using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
-using static Axe.Windows.RulesTest.ControlType;
+using static Axe.Windows.RulesTests.ControlType;
 using Misc = Axe.Windows.Rules.PropertyConditions.ElementGroups;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class NameTest

--- a/src/RulesTest/PropertyConditions/PatternsTest.cs
+++ b/src/RulesTest/PropertyConditions/PatternsTest.cs
@@ -4,7 +4,7 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class PatternsTest

--- a/src/RulesTest/PropertyConditions/PlatformPropertiesTests.cs
+++ b/src/RulesTest/PropertyConditions/PlatformPropertiesTests.cs
@@ -5,7 +5,7 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class PlatformPropertiesTests

--- a/src/RulesTest/PropertyConditions/RelationshipsTest.cs
+++ b/src/RulesTest/PropertyConditions/RelationshipsTest.cs
@@ -5,9 +5,9 @@ using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
-using static Axe.Windows.RulesTest.ControlType;
+using static Axe.Windows.RulesTests.ControlType;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class RelationshipsTest

--- a/src/RulesTest/PropertyConditions/ScrollPatternTest.cs
+++ b/src/RulesTest/PropertyConditions/ScrollPatternTest.cs
@@ -5,7 +5,7 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class ScrollPatternTest

--- a/src/RulesTest/PropertyConditions/SelectionItemPattern.cs
+++ b/src/RulesTest/PropertyConditions/SelectionItemPattern.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class SelectionItemPatternTests

--- a/src/RulesTest/PropertyConditions/SelectionPattern.cs
+++ b/src/RulesTest/PropertyConditions/SelectionPattern.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class SelectionPatternTests

--- a/src/RulesTest/PropertyConditions/StringPropertiesTest.cs
+++ b/src/RulesTest/PropertyConditions/StringPropertiesTest.cs
@@ -4,7 +4,7 @@ using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class StringPropertiesTest

--- a/src/RulesTest/PropertyConditions/ValueConditionUnitTests.cs
+++ b/src/RulesTest/PropertyConditions/ValueConditionUnitTests.cs
@@ -4,7 +4,7 @@ using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-namespace Axe.Windows.RulesTest.PropertyConditions
+namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
     public class ValueConditionUnitTests

--- a/src/RulesTest/RuleRunnerTests.cs
+++ b/src/RulesTest/RuleRunnerTests.cs
@@ -3,14 +3,13 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules;
-using Axe.Windows.RulesTest;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace RulesTests
+namespace Axe.Windows.RulesTests
 {
     [TestClass]
     public class RuleRunnerTests

--- a/src/RulesTest/RulesProviderTests.cs
+++ b/src/RulesTest/RulesProviderTests.cs
@@ -5,7 +5,7 @@ using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
-namespace Axe.Windows.RulesTest
+namespace Axe.Windows.RulesTests
 {
     [TestClass]
     public class RulesProviderTests

--- a/src/RulesTest/RulesTests.csproj
+++ b/src/RulesTest/RulesTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>Axe.Windows.RulesTests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#### Details

Normalize the namespaces in the RulesTests project and add the root so that classes added via the IDE are in the expected namespace.

##### Motivation

I recently added a new test via the IDE and ran into issues because the namespace didn't match the rest of the code. After chatting with @RobGallo, we've decided that the root namespace should be `Axe.Windows.RulesTests`, and that IDE-added classes should use that same naming pattern.

##### Context

It probably makes sense to have a separate PR that sets the RootNamespace property for all test projects (to put IDE-added classes into the expected namespaces), but that's for a separate PR. I included the change here since the default namespace was changing.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
