### PR TITLE
chore: Add delayed triggering to CLI scanner

### DIFF
--- a/src/CLI/IOptions.cs
+++ b/src/CLI/IOptions.cs
@@ -11,6 +11,5 @@ namespace AxeWindowsCLI
         string ProcessName { get; }
         VerbosityLevel VerbosityLevel { get; }
         int DelayInSeconds { get; }
-        bool ErrorOccurred { get; set; }
     }
 }

--- a/src/CLI/IOptions.cs
+++ b/src/CLI/IOptions.cs
@@ -10,5 +10,7 @@ namespace AxeWindowsCLI
         int ProcessId { get; }
         string ProcessName { get; }
         VerbosityLevel VerbosityLevel { get; }
+        int DelayInSeconds { get; }
+        bool ErrorOccurred { get; set; }
     }
 }

--- a/src/CLI/IScanDelay.cs
+++ b/src/CLI/IScanDelay.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace AxeWindowsCLI
+{
+    interface IScanDelay
+    {
+        void DelayWithCountdown(IOptions options);
+    }
+}

--- a/src/CLI/Options.cs
+++ b/src/CLI/Options.cs
@@ -25,7 +25,13 @@ namespace AxeWindowsCLI
         [Option(Required = false, HelpText = "Display Third Party Notices (opens file in browser without executing scan). If specified, all other options will be ignored.")]
         public bool ShowThirdPartyNotices { get; set; }
 
+        [Option(Required = false, HelpText = "How many seconds to delay before triggering the scan. Valid range is 0 to 60 seconds, with a default of 0.")]
+        public int DelayInSeconds { get; set; }
+
         // CommandLineParser will never set this value!
         public VerbosityLevel VerbosityLevel { get; set; } = VerbosityLevel.Default;
+
+        // CommandLineParser will never set this value!
+        public bool ErrorOccurred { get; set; }
     }
 }

--- a/src/CLI/Options.cs
+++ b/src/CLI/Options.cs
@@ -30,8 +30,5 @@ namespace AxeWindowsCLI
 
         // CommandLineParser will never set this value!
         public VerbosityLevel VerbosityLevel { get; set; } = VerbosityLevel.Default;
-
-        // CommandLineParser will never set this value!
-        public bool ErrorOccurred { get; set; }
     }
 }

--- a/src/CLI/OptionsEvaluator.cs
+++ b/src/CLI/OptionsEvaluator.cs
@@ -36,7 +36,7 @@ namespace AxeWindowsCLI
             else
             {
 #pragma warning disable CA1303 // Do not pass literals as localized parameters
-                throw new ParameterException("Please specify either processId or processName on the command line");
+                throw new ParameterException("Please specify either processId or processName on the command line.");
 #pragma warning restore CA1303 // Do not pass literals as localized parameters
             }
 
@@ -54,6 +54,12 @@ namespace AxeWindowsCLI
                 {
                     throw new ParameterException("Invalid verbosity level: " + verbosity);
                 }
+            }
+
+            // Prevent Quiet mode with the delay (scenario doesn't make sense)
+            if (delayInSeconds > 0 && verbosityLevel == VerbosityLevel.Quiet)
+            {
+                throw new ParameterException("Quiet verbosity and delay scanning are mutually exclusive.");
             }
 
             return new Options

--- a/src/CLI/OptionsEvaluator.cs
+++ b/src/CLI/OptionsEvaluator.cs
@@ -56,12 +56,6 @@ namespace AxeWindowsCLI
                 }
             }
 
-            // Prevent Quiet mode with the delay (scenario doesn't make sense)
-            if (delayInSeconds > 0 && verbosityLevel == VerbosityLevel.Quiet)
-            {
-                throw new ParameterException("Quiet verbosity and delay scanning are mutually exclusive.");
-            }
-
             return new Options
             {
                 OutputDirectory = rawInputs.OutputDirectory,

--- a/src/CLI/OptionsEvaluator.cs
+++ b/src/CLI/OptionsEvaluator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Globalization;
 using System.IO;
 
 namespace AxeWindowsCLI
@@ -12,6 +13,13 @@ namespace AxeWindowsCLI
         {
             if (rawInputs == null) throw new ArgumentNullException(nameof(rawInputs));
             if (processHelper == null) throw new ArgumentNullException(nameof(processHelper));
+
+            int delayInSeconds = rawInputs.DelayInSeconds;
+
+            if (delayInSeconds < 0 || delayInSeconds > 60)
+            {
+                throw new ParameterException(string.Format(CultureInfo.InvariantCulture, "Invalid delay: {0}. Please enter an integer value from 0 to 60.", delayInSeconds));
+            }
 
             int processId = rawInputs.ProcessId;
             string processName = rawInputs.ProcessName;
@@ -55,6 +63,7 @@ namespace AxeWindowsCLI
                 ProcessName = processName,
                 ScanId = rawInputs.ScanId,
                 VerbosityLevel = verbosityLevel,
+                DelayInSeconds = delayInSeconds,
             };
         }
 

--- a/src/CLI/OutputGenerator.cs
+++ b/src/CLI/OutputGenerator.cs
@@ -14,17 +14,14 @@ namespace AxeWindowsCLI
     internal class OutputGenerator : IOutputGenerator
     {
         private readonly TextWriter _writer;
-        private readonly IScanDelay _scanDelay;
 
         private bool _bannerHasBeenShown;
 
-        public OutputGenerator(TextWriter writer, IScanDelay scanDelay)
+        public OutputGenerator(TextWriter writer)
         {
             if (writer == null) throw new ArgumentNullException(nameof(writer));
-            if (scanDelay == null) throw new ArgumentNullException(nameof(scanDelay));
 
             _writer = writer;
-            _scanDelay = scanDelay;
         }
 
         public void WriteOutput(IOptions options, ScanResults scanResults, Exception caughtException)
@@ -94,8 +91,6 @@ namespace AxeWindowsCLI
                 {
                     _writer.WriteLine("Scan Id = {0}", options.ScanId);
                 }
-
-                _scanDelay.DelayWithCountdown(options);
 
                 _bannerHasBeenShown = true;
             }

--- a/src/CLI/OutputGenerator.cs
+++ b/src/CLI/OutputGenerator.cs
@@ -14,14 +14,17 @@ namespace AxeWindowsCLI
     internal class OutputGenerator : IOutputGenerator
     {
         private readonly TextWriter _writer;
+        private readonly Action _oneSecondDelay;
 
         private bool _bannerHasBeenShown;
 
-        public OutputGenerator(TextWriter writer)
+        public OutputGenerator(TextWriter writer, Action oneSecondDelay)
         {
             if (writer == null) throw new ArgumentNullException(nameof(writer));
+            if (oneSecondDelay == null) throw new ArgumentNullException(nameof(oneSecondDelay));
 
             _writer = writer;
+            _oneSecondDelay = oneSecondDelay;
         }
 
         public void WriteOutput(IOptions options, ScanResults scanResults, Exception caughtException)
@@ -90,6 +93,17 @@ namespace AxeWindowsCLI
                 if (!string.IsNullOrEmpty(options.ScanId))
                 {
                     _writer.WriteLine("Scan Id = {0}", options.ScanId);
+                }
+
+                if (!options.ErrorOccurred && options.DelayInSeconds > 0)
+                {
+                    _writer.WriteLine("Delaying {0} seconds before scanning.", options.DelayInSeconds);
+                    for (int secondsRemaining = options.DelayInSeconds; secondsRemaining > 0; secondsRemaining--)
+                    {
+                        _writer.WriteLine("  {0} second{1} before scan.", secondsRemaining, secondsRemaining == 1 ? "" : "s");
+                        _oneSecondDelay.Invoke();
+                    }
+                    _writer.WriteLine("Triggering scan");
                 }
 
                 _bannerHasBeenShown = true;

--- a/src/CLI/OutputGenerator.cs
+++ b/src/CLI/OutputGenerator.cs
@@ -14,17 +14,17 @@ namespace AxeWindowsCLI
     internal class OutputGenerator : IOutputGenerator
     {
         private readonly TextWriter _writer;
-        private readonly Action _oneSecondDelay;
+        private readonly IScanDelay _scanDelay;
 
         private bool _bannerHasBeenShown;
 
-        public OutputGenerator(TextWriter writer, Action oneSecondDelay)
+        public OutputGenerator(TextWriter writer, IScanDelay scanDelay)
         {
             if (writer == null) throw new ArgumentNullException(nameof(writer));
-            if (oneSecondDelay == null) throw new ArgumentNullException(nameof(oneSecondDelay));
+            if (scanDelay == null) throw new ArgumentNullException(nameof(scanDelay));
 
             _writer = writer;
-            _oneSecondDelay = oneSecondDelay;
+            _scanDelay = scanDelay;
         }
 
         public void WriteOutput(IOptions options, ScanResults scanResults, Exception caughtException)
@@ -65,7 +65,7 @@ namespace AxeWindowsCLI
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
 
-            if(!_bannerHasBeenShown && options.VerbosityLevel >= minimumVerbosity)
+            if (!_bannerHasBeenShown && options.VerbosityLevel >= minimumVerbosity)
             {
                 WriteAppBanner();
 
@@ -95,16 +95,7 @@ namespace AxeWindowsCLI
                     _writer.WriteLine("Scan Id = {0}", options.ScanId);
                 }
 
-                if (!options.ErrorOccurred && options.DelayInSeconds > 0)
-                {
-                    _writer.WriteLine("Delaying {0} seconds before scanning.", options.DelayInSeconds);
-                    for (int secondsRemaining = options.DelayInSeconds; secondsRemaining > 0; secondsRemaining--)
-                    {
-                        _writer.WriteLine("  {0} second{1} before scan.", secondsRemaining, secondsRemaining == 1 ? "" : "s");
-                        _oneSecondDelay.Invoke();
-                    }
-                    _writer.WriteLine("Triggering scan");
-                }
+                _scanDelay.DelayWithCountdown(options);
 
                 _bannerHasBeenShown = true;
             }

--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -37,7 +37,8 @@ namespace AxeWindowsCLI
         {
             TextWriter writer = Console.Out;
             IProcessHelper processHelper = new ProcessHelper(new ProcessAbstraction());
-            IOutputGenerator outputGenerator = new OutputGenerator(writer, () => Thread.Sleep(TimeSpan.FromSeconds(1)));
+            IScanDelay scanDelay = new ScanDelay(writer, () => Thread.Sleep(TimeSpan.FromSeconds(1)));
+            IOutputGenerator outputGenerator = new OutputGenerator(writer, scanDelay);
             IBrowserAbstraction browserAbstraction = new BrowserAbstraction();
 
             // We require some parameters, but don't have a clean way to tell CommandLineParser
@@ -64,14 +65,14 @@ namespace AxeWindowsCLI
 #pragma warning restore CA1031
             {
                 caughtException = e;
-                if (_options != null)
-                {
-                    _options.ErrorOccurred = true;
-                }
             }
 
             if (_options != null)
             {
+                if (caughtException != null)
+                {
+                    _options.ErrorOccurred = true;
+                }
                 _outputGenerator.WriteOutput(_options, _scanResults, caughtException);
             }
             return ReturnValueChooser.GetReturnValue(_scanResults, caughtException);

--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -5,7 +5,7 @@ using Axe.Windows.Automation;
 using CommandLine;
 using System;
 using System.IO;
-using System.Reflection;
+using System.Threading;
 
 namespace AxeWindowsCLI
 {
@@ -37,7 +37,7 @@ namespace AxeWindowsCLI
         {
             TextWriter writer = Console.Out;
             IProcessHelper processHelper = new ProcessHelper(new ProcessAbstraction());
-            IOutputGenerator outputGenerator = new OutputGenerator(writer);
+            IOutputGenerator outputGenerator = new OutputGenerator(writer, () => Thread.Sleep(TimeSpan.FromSeconds(1)));
             IBrowserAbstraction browserAbstraction = new BrowserAbstraction();
 
             // We require some parameters, but don't have a clean way to tell CommandLineParser
@@ -64,6 +64,10 @@ namespace AxeWindowsCLI
 #pragma warning restore CA1031
             {
                 caughtException = e;
+                if (_options != null)
+                {
+                    _options.ErrorOccurred = true;
+                }
             }
 
             if (_options != null)

--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -53,7 +53,7 @@ Parameter|Description
 |scanid|Identifies the specific ID of the scan. This allows you to preassign a name to the given scan (and output file). If omitted, an dynamic name in the format AxeWindows_YY-MM-DD_hh-mm-ss.fffffff will be used.|
 |verbosity|Identifies the level of detail you want in the output. Valid values are `quiet` (minimal output), `default` (typical output), or `verbose` (maximum output).
 |showThirdPartyNotices|If specified, displays the third party notices for components used by AxeWindowsCLI. This information is also available in the `thirdpartynotices.html` file that is installed with AxeWindowsCLI.
-|delayInSeconds|Optionally inserts a delay before triggering the scan. This allows transient controls (menus, drop-down-lists, etc.) to be scanned. Mutually exclusive with verbosity of `quiet`.
+|delayInSeconds|Optionally inserts a delay before triggering the scan. This allows transient controls (menus, drop-down-lists, etc.) to be scanned.
 
 ### Scan results
 A summary of scan results will be displayed after the scan is run. In addition, an A11yTest file will be generated if 1 or more errors were detected. The location of this file will be reported in the tool output (see the documentation of the `--outputDirectory` and `--scanId` parameters for ways to alter the name or location of the output file). This file can then be opened with **Accessibility Insights for Windows**, which is freely available at http://accessibilityinsights.io

--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -53,7 +53,7 @@ Parameter|Description
 |scanid|Identifies the specific ID of the scan. This allows you to preassign a name to the given scan (and output file). If omitted, an dynamic name in the format AxeWindows_YY-MM-DD_hh-mm-ss.fffffff will be used.|
 |verbosity|Identifies the level of detail you want in the output. Valid values are `quiet` (minimal output), `default` (typical output), or `verbose` (maximum output).
 |showThirdPartyNotices|If specified, displays the third party notices for components used by AxeWindowsCLI. This information is also available in the `thirdpartynotices.html` file that is installed with AxeWindowsCLI.
-|delayInSeconds|Optionally inserts a delay before triggering the scan. This allows transient controls (menus, drop-down-lists, etc.) to be scanned.
+|delayInSeconds|Optionally inserts a delay before triggering the scan. This allows transient controls (menus, drop-down-lists, etc.) to be scanned. Mutually exclusive with verbosity of `quiet`.
 
 ### Scan results
 A summary of scan results will be displayed after the scan is run. In addition, an A11yTest file will be generated if 1 or more errors were detected. The location of this file will be reported in the tool output (see the documentation of the `--outputDirectory` and `--scanId` parameters for ways to alter the name or location of the output file). This file can then be opened with **Accessibility Insights for Windows**, which is freely available at http://accessibilityinsights.io

--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -32,6 +32,10 @@ AxeWindowsCLI.exe
                              without executing scan). If specified, all other
                              options will be ignored.
 
+  --delayinseconds           How many seconds to delay before triggering the
+                             scan. Valid range is 0 to 60 seconds, with a
+                             default of 0.
+
   --help                     Display this help screen.
 
   --version                  Display version information.
@@ -49,6 +53,7 @@ Parameter|Description
 |scanid|Identifies the specific ID of the scan. This allows you to preassign a name to the given scan (and output file). If omitted, an dynamic name in the format AxeWindows_YY-MM-DD_hh-mm-ss.fffffff will be used.|
 |verbosity|Identifies the level of detail you want in the output. Valid values are `quiet` (minimal output), `default` (typical output), or `verbose` (maximum output).
 |showThirdPartyNotices|If specified, displays the third party notices for components used by AxeWindowsCLI. This information is also available in the `thirdpartynotices.html` file that is installed with AxeWindowsCLI.
+|delayInSeconds|Optionally inserts a delay before triggering the scan. This allows transient controls (menus, drop-down-lists, etc.) to be scanned.
 
 ### Scan results
 A summary of scan results will be displayed after the scan is run. In addition, an A11yTest file will be generated if 1 or more errors were detected. The location of this file will be reported in the tool output (see the documentation of the `--outputDirectory` and `--scanId` parameters for ways to alter the name or location of the output file). This file can then be opened with **Accessibility Insights for Windows**, which is freely available at http://accessibilityinsights.io

--- a/src/CLI/ScanDelay.cs
+++ b/src/CLI/ScanDelay.cs
@@ -23,15 +23,31 @@ namespace AxeWindowsCLI
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
 
-            if (!options.ErrorOccurred && options.DelayInSeconds > 0)
+            if (options.DelayInSeconds > 0)
             {
-                _writer.WriteLine("Delaying {0} second{1} before scanning.", options.DelayInSeconds, PluralSuffix(options.DelayInSeconds));
+                ConditionallyWriteMessageWithCount(options, "Delaying {0} second{1} before scanning.", options.DelayInSeconds);
                 for (int secondsRemaining = options.DelayInSeconds; secondsRemaining > 0; secondsRemaining--)
                 {
-                    _writer.WriteLine("  {0} second{1} before scan.", secondsRemaining, PluralSuffix(secondsRemaining));
+                    ConditionallyWriteMessageWithCount(options, "  {0} second{1} before scan.", secondsRemaining);
                     _oneSecondDelay.Invoke();
                 }
-                _writer.WriteLine("Triggering scan");
+                ConditionallyWriteMessage(options, "Triggering scan");
+            }
+        }
+
+        private void ConditionallyWriteMessageWithCount(IOptions options, string format, int count)
+        {
+            if (options.VerbosityLevel > VerbosityLevel.Quiet)
+            {
+                _writer.WriteLine(format, count, PluralSuffix(count));
+            }
+        }
+
+        private void ConditionallyWriteMessage(IOptions options, string message)
+        {
+            if (options.VerbosityLevel > VerbosityLevel.Quiet)
+            {
+                _writer.WriteLine(message);
             }
         }
 

--- a/src/CLI/ScanDelay.cs
+++ b/src/CLI/ScanDelay.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.IO;
+
+namespace AxeWindowsCLI
+{
+    class ScanDelay : IScanDelay
+    {
+        private readonly TextWriter _writer;
+        private readonly Action _oneSecondDelay;
+
+        internal ScanDelay(TextWriter writer, Action oneSecondDelay)
+        {
+            if (writer == null) throw new ArgumentNullException(nameof(writer));
+            if (oneSecondDelay == null) throw new ArgumentNullException(nameof(oneSecondDelay));
+
+            _writer = writer;
+            _oneSecondDelay = oneSecondDelay;
+        }
+
+        public void DelayWithCountdown(IOptions options)
+        {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+
+            if (!options.ErrorOccurred && options.DelayInSeconds > 0)
+            {
+                _writer.WriteLine("Delaying {0} second{1} before scanning.", options.DelayInSeconds, PluralSuffix(options.DelayInSeconds));
+                for (int secondsRemaining = options.DelayInSeconds; secondsRemaining > 0; secondsRemaining--)
+                {
+                    _writer.WriteLine("  {0} second{1} before scan.", secondsRemaining, PluralSuffix(secondsRemaining));
+                    _oneSecondDelay.Invoke();
+                }
+                _writer.WriteLine("Triggering scan");
+            }
+        }
+
+        private static string PluralSuffix(int count)
+        {
+            return count > 1 ? "s" : "";
+        }
+    }
+}

--- a/src/CLITests/OptionsEvaluatorUnitTests.cs
+++ b/src/CLITests/OptionsEvaluatorUnitTests.cs
@@ -67,7 +67,7 @@ namespace CLITests
             Options input = new Options();
             ParameterException e = Assert.ThrowsException<ParameterException>(() =>
                 OptionsEvaluator.ProcessInputs(input, _processHelperMock.Object));
-            Assert.AreEqual("Please specify either processId or processName on the command line", e.Message);
+            Assert.AreEqual("Please specify either processId or processName on the command line.", e.Message);
             VerifyAllMocks();
         }
 
@@ -262,6 +262,25 @@ namespace CLITests
             };
             ValidateOptions(OptionsEvaluator.ProcessInputs(input, _processHelperMock.Object),
                 processId: TestProcessId, delayInSeconds: expectedDelay);
+            VerifyAllMocks();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ProcessInputs_SpecifiesValidDelayAndQuietMode_ThrowsParameterException()
+        {
+            const string verbosity = "quiet";
+            const int expectedDelay = 60;
+            _processHelperMock.Setup(x => x.ProcessIdFromName(TestProcessName)).Returns(TestProcessId);
+            Options input = new Options
+            {
+                ProcessName = TestProcessName,
+                DelayInSeconds = expectedDelay,
+                Verbosity = verbosity,
+            };
+            ParameterException e = Assert.ThrowsException<ParameterException>(() => OptionsEvaluator.ProcessInputs(
+                input, _processHelperMock.Object));
+            Assert.AreEqual("Quiet verbosity and delay scanning are mutually exclusive.", e.Message);
             VerifyAllMocks();
         }
     }

--- a/src/CLITests/OptionsEvaluatorUnitTests.cs
+++ b/src/CLITests/OptionsEvaluatorUnitTests.cs
@@ -37,7 +37,6 @@ namespace CLITests
             Assert.AreEqual(outputDirectory, options.OutputDirectory);
             Assert.AreEqual(verbosityLevel, options.VerbosityLevel);
             Assert.AreEqual(delayInSeconds, options.DelayInSeconds);
-            Assert.IsFalse(options.ErrorOccurred);
         }
 
         [TestMethod]
@@ -262,25 +261,6 @@ namespace CLITests
             };
             ValidateOptions(OptionsEvaluator.ProcessInputs(input, _processHelperMock.Object),
                 processId: TestProcessId, delayInSeconds: expectedDelay);
-            VerifyAllMocks();
-        }
-
-        [TestMethod]
-        [Timeout(1000)]
-        public void ProcessInputs_SpecifiesValidDelayAndQuietMode_ThrowsParameterException()
-        {
-            const string verbosity = "quiet";
-            const int expectedDelay = 60;
-            _processHelperMock.Setup(x => x.ProcessIdFromName(TestProcessName)).Returns(TestProcessId);
-            Options input = new Options
-            {
-                ProcessName = TestProcessName,
-                DelayInSeconds = expectedDelay,
-                Verbosity = verbosity,
-            };
-            ParameterException e = Assert.ThrowsException<ParameterException>(() => OptionsEvaluator.ProcessInputs(
-                input, _processHelperMock.Object));
-            Assert.AreEqual("Quiet verbosity and delay scanning are mutually exclusive.", e.Message);
             VerifyAllMocks();
         }
     }

--- a/src/CLITests/OptionsUnitTests.cs
+++ b/src/CLITests/OptionsUnitTests.cs
@@ -43,7 +43,6 @@ namespace CLITests
             Assert.AreEqual(VerbosityLevel.Default, options.VerbosityLevel);
             Assert.AreEqual(showThirdPartyNotices, options.ShowThirdPartyNotices);
             Assert.AreEqual(delayInSeconds, options.DelayInSeconds);
-            Assert.IsFalse(options.ErrorOccurred);
             return ExpectedParseSuccess;
         }
 
@@ -136,24 +135,6 @@ namespace CLITests
                     FailIfCalled);
 
             Assert.AreEqual(ExpectedParseSuccess, parseResult);
-        }
-
-        [TestMethod]
-        [Timeout(1000)]
-        public void ErrorOccurred_ToggleState_StatePersists()
-        {
-            string[] args = { };
-
-            int parseResult = Parser.Default.ParseArguments<Options>(args)
-                .MapResult(
-                    (o) =>
-                    {
-                        Assert.IsFalse(o.ErrorOccurred);
-                        o.ErrorOccurred = true;
-                        Assert.IsTrue(o.ErrorOccurred);
-                        return 0;
-                    },
-                    FailIfCalled);
         }
     }
 }

--- a/src/CLITests/OptionsUnitTests.cs
+++ b/src/CLITests/OptionsUnitTests.cs
@@ -19,15 +19,10 @@ namespace CLITests
         const string VerbosityKey = "--verbosity";
         const string ScanIdKey = "--scanid";
         const string ShowThirdPartyNoticesKey = "--showthirdpartynotices";
+        const string DelayInSecondsKey = "--delayinseconds";
 
         const string TestProcessName = "MyProcess";
         const int TestProcessId = 42;
-
-        private int FailIfCalled(Options options)
-        {
-            Assert.Fail("This method should never be called");
-            return UnexpectedFailure;
-        }
 
         private int FailIfCalled(IEnumerable<Error> errors)
         {
@@ -37,7 +32,8 @@ namespace CLITests
 
         private int ValidateOptions(Options options, string processName = null,
             int processId = 0, string outputDirectory = null, string scanId = null,
-            string verbosity = null, bool showThirdPartyNotices = false)
+            string verbosity = null, bool showThirdPartyNotices = false,
+            int delayInSeconds = 0)
         {
             Assert.AreEqual(processName, options.ProcessName);
             Assert.AreEqual(processId, options.ProcessId);
@@ -46,6 +42,8 @@ namespace CLITests
             Assert.AreEqual(verbosity, options.Verbosity);
             Assert.AreEqual(VerbosityLevel.Default, options.VerbosityLevel);
             Assert.AreEqual(showThirdPartyNotices, options.ShowThirdPartyNotices);
+            Assert.AreEqual(delayInSeconds, options.DelayInSeconds);
+            Assert.IsFalse(options.ErrorOccurred);
             return ExpectedParseSuccess;
         }
 
@@ -121,6 +119,41 @@ namespace CLITests
                     FailIfCalled);
 
             Assert.AreEqual(ExpectedParseSuccess, parseResult);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ParseArguments_DelayInSeconds_SucceedsWithDelayInSecondsSet()
+        {
+            const string delayArg = "15";
+            const int delayInt = 15;
+
+            string[] args = { DelayInSecondsKey, delayArg };
+
+            int parseResult = Parser.Default.ParseArguments<Options>(args)
+                .MapResult(
+                    (o) => ValidateOptions(o, delayInSeconds: delayInt),
+                    FailIfCalled);
+
+            Assert.AreEqual(ExpectedParseSuccess, parseResult);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ErrorOccurred_ToggleState_StatePersists()
+        {
+            string[] args = { };
+
+            int parseResult = Parser.Default.ParseArguments<Options>(args)
+                .MapResult(
+                    (o) =>
+                    {
+                        Assert.IsFalse(o.ErrorOccurred);
+                        o.ErrorOccurred = true;
+                        Assert.IsTrue(o.ErrorOccurred);
+                        return 0;
+                    },
+                    FailIfCalled);
         }
     }
 }

--- a/src/CLITests/ScanDelayUnitTests.cs
+++ b/src/CLITests/ScanDelayUnitTests.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using AxeWindowsCLI;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.IO;
+
+namespace CLITests
+{
+    [TestClass]
+    public class ScanDelayUnitTests
+    {
+        const string DelayHeaderStart = "Delaying {0} second{1}";
+        const string CountdownStart = "  {0} second{1}";
+        const string TriggeringStart = "Triggering scan";
+
+        private Mock<TextWriter> _writerMock;
+        private Mock<Action> _oneSecondDelayMock;
+        private Mock<IOptions> _optionsMock;
+        private IScanDelay _testSubject;
+
+        [TestInitialize]
+        public void BeforeEachTest()
+        {
+            _writerMock = new Mock<TextWriter>(MockBehavior.Strict);
+            _oneSecondDelayMock = new Mock<Action>(MockBehavior.Strict);
+
+            _testSubject = new ScanDelay(_writerMock.Object, _oneSecondDelayMock.Object);
+
+            _optionsMock = new Mock<IOptions>(MockBehavior.Strict);
+        }
+
+        private void VerifyWriterAndOptionsMocks()
+        {
+            _writerMock.VerifyAll();
+            _optionsMock.VerifyAll();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void Ctor_WriterIsNull_ThrowsArgumentNullException()
+        {
+            ArgumentNullException e = Assert.ThrowsException<ArgumentNullException>(
+                () => new ScanDelay(null, _oneSecondDelayMock.Object));
+            Assert.AreEqual("writer", e.ParamName);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void Ctor_OneSecondDelayIsNull_ThrowsArgumentNullException()
+        {
+            ArgumentNullException e = Assert.ThrowsException<ArgumentNullException>(
+                () => new ScanDelay(_writerMock.Object, null));
+            Assert.AreEqual("oneSecondDelay", e.ParamName);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void DelayWithCountdown_OptionsIsNull_ThrowsArgrumentNullException()
+        {
+            ArgumentNullException e = Assert.ThrowsException<ArgumentNullException>(
+                () => _testSubject.DelayWithCountdown(null));
+            Assert.AreEqual("options", e.ParamName);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void DelayWithCountdown_ErrorHasOccurred_NoOutputNoDelay()
+        {
+            _optionsMock.Setup(m => m.ErrorOccurred).Returns(true);
+
+            _testSubject.DelayWithCountdown(_optionsMock.Object);
+
+            VerifyWriterAndOptionsMocks();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void DelayWithCountdown_DelayIsZero_NoOutputNoDelay()
+        {
+            _optionsMock.Setup(m => m.ErrorOccurred).Returns(false);
+            _optionsMock.Setup(m => m.DelayInSeconds).Returns(0);
+
+            _testSubject.DelayWithCountdown(_optionsMock.Object);
+
+            VerifyWriterAndOptionsMocks();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void DelayWithCountdown_DelayIsNotZero_HasOutputAndDelay()
+        {
+            const int delayInSeconds = 3;
+
+            _optionsMock.Setup(m => m.ErrorOccurred).Returns(false);
+            _optionsMock.Setup(m => m.DelayInSeconds).Returns(delayInSeconds);
+            _oneSecondDelayMock.Setup(m => m.Invoke());
+
+            WriteCall[] expectedCalls =
+            {
+                new WriteCall(DelayHeaderStart, WriteSource.WriteLineTwoParams),
+                new WriteCall(CountdownStart, WriteSource.WriteLineTwoParams),
+                new WriteCall(CountdownStart, WriteSource.WriteLineTwoParams),
+                new WriteCall(CountdownStart, WriteSource.WriteLineTwoParams),
+                new WriteCall(TriggeringStart, WriteSource.WriteLineStringOnly),
+            };
+            TextWriterVerifier textWriterVerifier = new TextWriterVerifier(_writerMock, expectedCalls);
+
+            _testSubject.DelayWithCountdown(_optionsMock.Object);
+
+            textWriterVerifier.VerifyAll();
+            _oneSecondDelayMock.Verify(m => m.Invoke(), Times.Exactly(delayInSeconds));
+            VerifyWriterAndOptionsMocks();
+        }
+    }
+}

--- a/src/CLITests/ScanDelayUnitTests.cs
+++ b/src/CLITests/ScanDelayUnitTests.cs
@@ -67,20 +67,8 @@ namespace CLITests
 
         [TestMethod]
         [Timeout(1000)]
-        public void DelayWithCountdown_ErrorHasOccurred_NoOutputNoDelay()
-        {
-            _optionsMock.Setup(m => m.ErrorOccurred).Returns(true);
-
-            _testSubject.DelayWithCountdown(_optionsMock.Object);
-
-            VerifyWriterAndOptionsMocks();
-        }
-
-        [TestMethod]
-        [Timeout(1000)]
         public void DelayWithCountdown_DelayIsZero_NoOutputNoDelay()
         {
-            _optionsMock.Setup(m => m.ErrorOccurred).Returns(false);
             _optionsMock.Setup(m => m.DelayInSeconds).Returns(0);
 
             _testSubject.DelayWithCountdown(_optionsMock.Object);
@@ -90,12 +78,28 @@ namespace CLITests
 
         [TestMethod]
         [Timeout(1000)]
-        public void DelayWithCountdown_DelayIsNotZero_HasOutputAndDelay()
+        public void DelayWithCountdown_DelayIsNotZero_VerbosityIsNotQuiet_HasDelayWithoutOutput()
+        {
+            const int delayInSeconds = 60;
+
+            _optionsMock.Setup(m => m.DelayInSeconds).Returns(delayInSeconds);
+            _optionsMock.Setup(m => m.VerbosityLevel).Returns(VerbosityLevel.Quiet);
+            _oneSecondDelayMock.Setup(m => m.Invoke());
+
+            _testSubject.DelayWithCountdown(_optionsMock.Object);
+
+            _oneSecondDelayMock.Verify(m => m.Invoke(), Times.Exactly(delayInSeconds));
+            VerifyWriterAndOptionsMocks();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void DelayWithCountdown_DelayIsNotZero_VerbosityIsNotQuiet_HasDelayWithOutput()
         {
             const int delayInSeconds = 3;
 
-            _optionsMock.Setup(m => m.ErrorOccurred).Returns(false);
             _optionsMock.Setup(m => m.DelayInSeconds).Returns(delayInSeconds);
+            _optionsMock.Setup(m => m.VerbosityLevel).Returns(VerbosityLevel.Default);
             _oneSecondDelayMock.Setup(m => m.Invoke());
 
             WriteCall[] expectedCalls =


### PR DESCRIPTION
#### Details

The current CLI doesn't provide a way to scan transient controls. This PR adds the ability to delay up to 60 seconds to allow the user to get the app UI into the correct configuration for scanning.

##### Motivation

I needed this ability for testing #561, then realized that it might be useful in general.

##### Context

To facilitate unit testing, I implemented the 1 second delay via an `Action` that gets passed in from the Program. 

I changed `OutputGeneratorUnitTests` to use a test fixture. I was going to have to modify the constructor anyway, so I just went ahead and moved to a test fixture while I was at it.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
