### PR TITLE
chore: Normalize test namespaces

### DIFF
--- a/src/ActionsTests/ActionsTests.csproj
+++ b/src/ActionsTests/ActionsTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>Axe.Windows.ActionsTests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ActionsTests/Misc/ExtensionMethodsTests.cs
+++ b/src/ActionsTests/Misc/ExtensionMethodsTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Actions.Misc;
 using Axe.Windows.Core.Bases;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -8,7 +9,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
-namespace Axe.Windows.Actions.Misc.Tests
+namespace Axe.Windows.ActionsTests.Misc
 {
     [TestClass()]
     public class ExtensionMethodsTests

--- a/src/AutomationTests/AutomationTests.csproj
+++ b/src/AutomationTests/AutomationTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>Axe.Windows.AutomationTests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CLITests/CLITests.csproj
+++ b/src/CLITests/CLITests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>AxeWindowsCLITests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CLITests/OptionsEvaluatorUnitTests.cs
+++ b/src/CLITests/OptionsEvaluatorUnitTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 
-namespace CLITests
+namespace AxeWindowsCLITests
 {
     [TestClass]
     public class OptionEvaluatorUnitTests

--- a/src/CLITests/OptionsUnitTests.cs
+++ b/src/CLITests/OptionsUnitTests.cs
@@ -6,7 +6,7 @@ using CommandLine;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 
-namespace CLITests
+namespace AxeWindowsCLITests
 {
     [TestClass]
     public class OptionUnitTests

--- a/src/CLITests/OutputGeneratorUnitTests.cs
+++ b/src/CLITests/OutputGeneratorUnitTests.cs
@@ -10,7 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
-namespace CLITests
+namespace AxeWindowsCLITests
 {
     [TestClass]
     public class OutputGeneratorUnitTests

--- a/src/CLITests/ProcessHelperUnitTests.cs
+++ b/src/CLITests/ProcessHelperUnitTests.cs
@@ -7,7 +7,7 @@ using Moq;
 using System;
 using System.Diagnostics;
 
-namespace CLITests
+namespace AxeWindowsCLITests
 {
     [TestClass]
     public class ProcessHelperUnitTests

--- a/src/CLITests/ScanDelayUnitTests.cs
+++ b/src/CLITests/ScanDelayUnitTests.cs
@@ -7,7 +7,7 @@ using Moq;
 using System;
 using System.IO;
 
-namespace CLITests
+namespace AxeWindowsCLITests
 {
     [TestClass]
     public class ScanDelayUnitTests

--- a/src/CLITests/TextWriterVerifier.cs
+++ b/src/CLITests/TextWriterVerifier.cs
@@ -6,7 +6,7 @@ using Moq;
 using System.Collections.Generic;
 using System.IO;
 
-namespace CLITests
+namespace AxeWindowsCLITests
 {
     internal enum WriteSource
     {

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>Axe.Windows.CoreTests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CoreTests/Results/ScanMetaInfoTests.cs
+++ b/src/CoreTests/Results/ScanMetaInfoTests.cs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Results;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 
-namespace Axe.Windows.Core.Results.Tests
+namespace Axe.Windows.CoreTests.Results
 {
     [TestClass()]
     public class ScanMetaInfoTests

--- a/src/CoreTests/Types/ControlTypesTests.cs
+++ b/src/CoreTests/Types/ControlTypesTests.cs
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 
-namespace Axe.Windows.Core.Types.Tests
+namespace Axe.Windows.CoreTests.Types
 {
     [TestClass()]
     public class ControlTypesTest

--- a/src/CoreTests/Types/HeadingLevelTypeTests.cs
+++ b/src/CoreTests/Types/HeadingLevelTypeTests.cs
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.Core.Types.Tests
+namespace Axe.Windows.CoreTests.Types
 {
     /// <summary>
     /// Tests for HeadingLevelType class

--- a/src/CoreTests/Types/PatternTypesTests.cs
+++ b/src/CoreTests/Types/PatternTypesTests.cs
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.Core.Types.Tests
+namespace Axe.Windows.CoreTests.Types
 {
     [TestClass()]
     public class PatternTypesTests

--- a/src/CoreTests/Types/PropertyTypesTests.cs
+++ b/src/CoreTests/Types/PropertyTypesTests.cs
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.Core.Types.Tests
+namespace Axe.Windows.CoreTests.Types
 {
     /// <summary>
     /// For PropertyTypes and PlatformPropertyTypes

--- a/src/CoreTests/Types/TypeBaseTests.cs
+++ b/src/CoreTests/Types/TypeBaseTests.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
 
-namespace CoreTests.Types
+namespace Axe.Windows.CoreTests.Types
 {
     [TestClass]
     public class TypeBaseTests

--- a/src/DesktopTests/ColorContrastAnalyzer/ImageTests.cs
+++ b/src/DesktopTests/ColorContrastAnalyzer/ImageTests.cs
@@ -21,7 +21,7 @@ namespace Axe.Windows.DesktopTests.ColorContrastAnalyzer
         public static BitmapCollection LoadFromResources(string name)
         {
             Assembly myAssembly = Assembly.GetExecutingAssembly();
-            Stream myStream = myAssembly.GetManifestResourceStream("DesktopTests.TestImages." + name);
+            Stream myStream = myAssembly.GetManifestResourceStream("Axe.Windows.DesktopTests.TestImages." + name);
             Bitmap bmp = new Bitmap(myStream);
             return new BitmapCollection(bmp, new DefaultColorContrastConfig());
         }

--- a/src/DesktopTests/DesktopTests.csproj
+++ b/src/DesktopTests/DesktopTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>Axe.Windows.DesktopTests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DesktopTests/Styles/StyleIdTests.cs
+++ b/src/DesktopTests/Styles/StyleIdTests.cs
@@ -3,7 +3,7 @@
 using Axe.Windows.Desktop.Styles;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Axe.Windows.DesktopTests.Styles.Tests
+namespace Axe.Windows.DesktopTests.Styles
 {
     /// <summary>
     /// Tests for StyleId class

--- a/src/DesktopTests/Types/TextAttributeTemplateTests.cs
+++ b/src/DesktopTests/Types/TextAttributeTemplateTests.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
 
-namespace DesktopTests.Types
+namespace Axe.Windows.DesktopTests.Types
 {
     [TestClass]
     public class TextAttributeTemplateTests

--- a/src/DesktopTests/Utility/SupportedEventsTests.cs
+++ b/src/DesktopTests/Utility/SupportedEventsTests.cs
@@ -2,10 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.Types;
+using Axe.Windows.Desktop.Utility;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 
-namespace Axe.Windows.Desktop.Utility.Tests
+namespace Axe.Windows.DesktopTests.Utility
 {
     [TestClass()]
     public class SupportedEventsTests

--- a/src/OldFileVersionCompatibilityTests/OldFileVersionCompatibilityTests.csproj
+++ b/src/OldFileVersionCompatibilityTests/OldFileVersionCompatibilityTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>Axe.Windows.OldFileVersionCompatibilityTests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RuleSelectionTests/ReferenceLinksTests.cs
+++ b/src/RuleSelectionTests/ReferenceLinksTests.cs
@@ -5,7 +5,7 @@ using Axe.Windows.RuleSelection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-namespace RuleSelectionTests
+namespace Axe.Windows.RuleSelectionTests
 {
     [TestClass]
     public class ReferenceLinksTests

--- a/src/RuleSelectionTests/RuleSelectionTests.csproj
+++ b/src/RuleSelectionTests/RuleSelectionTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>Axe.Windows.RuleSelectionTests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SystemAbstractionsTests/MicrosoftUnitTests.cs
+++ b/src/SystemAbstractionsTests/MicrosoftUnitTests.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Win32;
 using Moq;
 
-namespace SystemAbstractionsTests
+namespace Axe.Windows.SystemAbstractionsTests
 {
     [TestClass]
     public class MicrosoftUnitTests

--- a/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
+++ b/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>Axe.Windows.SystemAbstractionsTests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SystemAbstractionsTests/SystemUnitTests.cs
+++ b/src/SystemAbstractionsTests/SystemUnitTests.cs
@@ -4,7 +4,7 @@ using Axe.Windows.SystemAbstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
-namespace SystemAbstractionsTests
+namespace Axe.Windows.SystemAbstractionsTests
 {
     using Path = System.IO.Path;
 

--- a/src/TelemetryTests/TelemetryTests.csproj
+++ b/src/TelemetryTests/TelemetryTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>Axe.Windows.TelemetryTests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Win32Tests/Win32Tests.csproj
+++ b/src/Win32Tests/Win32Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>Axe.Windows.Win32Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#### Details

If you use the IDE to add a new test to one of our test projects, the test class ends up in a different namespace that other test classes in that folder. In addition, our current test namespaces are very inconsistent. This PR normalizes the namespaces and ensures that IDE-added classes follow the same pattern.

##### Motivation

Make it easier to work with tests (both creating and viewing the results) in the IDE.

##### Context

To test this, I added a new test class to each test assembly and confirmed that the new tests get added in the correct namespace. I never committed these files. I also broke up the commits per project, in case there's any desire to review these individually.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
