### PR TITLE
Fix: Issue 540

### DIFF
--- a/src/Rules/Library/BoundingRectangleCompletelyObscuresContainer.cs
+++ b/src/Rules/Library/BoundingRectangleCompletelyObscuresContainer.cs
@@ -36,7 +36,7 @@ namespace Axe.Windows.Rules.Library
         protected override Condition CreateCondition()
         {
             // Windows and dialogs can be any size, regardless of their parents
-var isDialog = Pane & IsDialog;
+            var isDialog = Pane & IsDialog;
 
             //  Light dismiss buttons cover the whole window so that clicking dismisses the combo box
             var isLightDismissButton = Button & IsNotKeyboardFocusable & XAML & ClassName.Is("ComboBoxLightDismiss");

--- a/src/Rules/Library/BoundingRectangleCompletelyObscuresContainer.cs
+++ b/src/Rules/Library/BoundingRectangleCompletelyObscuresContainer.cs
@@ -8,7 +8,9 @@ using Axe.Windows.Rules.Resources;
 using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
+using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.Rules.Library
 {
@@ -34,8 +36,10 @@ namespace Axe.Windows.Rules.Library
         protected override Condition CreateCondition()
         {
             // Windows and dialogs can be any size, regardless of their parents
+var isDialog = Pane & IsDialog;
 
-            var isDialog = Pane & IsDialog;
+            //  Light dismiss buttons cover the whole window so that clicking dismisses the combo box
+            var isLightDismissButton = Button & IsNotKeyboardFocusable & XAML & ClassName.Is("ComboBoxLightDismiss");
 
             return ~Window
                 & ~isDialog
@@ -43,7 +47,8 @@ namespace Axe.Windows.Rules.Library
                 & BoundingRectangle.Valid
                 & ParentExists
                 & Parent(IsNotDesktop)
-                & Parent(BoundingRectangle.Valid);
+                & Parent(BoundingRectangle.Valid)
+                & ~isLightDismissButton;
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/BoundingRectangleCompletelyObscuresContainerTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleCompletelyObscuresContainerTest.cs
@@ -208,5 +208,44 @@ namespace Axe.Windows.RulesTests.Library
 
             Assert.IsFalse(Rule.Condition.Matches(e));
         }
+
+        [TestMethod]
+        public void BoundingRectangleCompletelyObscuresContainer_LightDismissButton_NotApplicable()
+        {
+            var e = CreateLightDismissButton();
+            Assert.IsFalse(Rule.Condition.Matches(e));
+
+            e.IsKeyboardFocusable = true;
+            Assert.IsTrue(Rule.Condition.Matches(e));
+
+            e = CreateLightDismissButton();
+            e.ClassName = "AnotherClass";
+            Assert.IsTrue(Rule.Condition.Matches(e));
+
+            e = CreateLightDismissButton();
+            e.Framework = "AnotherFramework";
+            Assert.IsTrue(Rule.Condition.Matches(e));
+
+            e = CreateLightDismissButton();
+            e.ControlTypeId = 0 ;
+            Assert.IsTrue(Rule.Condition.Matches(e));
+        }
+
+        private static MockA11yElement CreateLightDismissButton()
+        {
+            var e = new MockA11yElement();
+            var parent = new MockA11yElement();
+
+            parent.BoundingRectangle = TestRect;
+
+            e.BoundingRectangle = TestRect;
+            e.Parent = parent;
+            e.ControlTypeId = ControlType.Button;
+            e.Framework = Core.Enums.FrameworkId.XAML;
+            e.ClassName = "ComboBoxLightDismiss";
+            e.IsKeyboardFocusable = false;
+
+            return e;
+        }
     } // class
 } // namespace


### PR DESCRIPTION
#### Details

Address [BUG] ComboBox "An element's BoundingRectangle must not obscure its container element" · Issue #540

##### Context

The light dismiss button is not intended to ever have focus and has little to no value for magnification users. It is also designed specifically to eclipse its parent window. Therefore, we will not check for BoundingRectangleCompletelyObscuresContainer on the light dismiss button.