### PR TITLE
chore: Tweak placeholder

### DIFF
--- a/src/props/version.props
+++ b/src/props/version.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SemVerNumber Condition="$(SemVerNumber) == ''">1.0.7</SemVerNumber>
+    <SemVerNumber Condition="$(SemVerNumber) == ''">1.0.8</SemVerNumber>
     <SemVerSuffix></SemVerSuffix>
   </PropertyGroup>
 </Project>

--- a/src/props/version.props
+++ b/src/props/version.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SemVerNumber Condition="$(SemVerNumber) == ''">1.0.8</SemVerNumber>
+    <SemVerNumber Condition="$(SemVerNumber) == ''">1.0.7</SemVerNumber>
     <SemVerSuffix></SemVerSuffix>
   </PropertyGroup>
 </Project>

--- a/thirdpartynotices.html
+++ b/thirdpartynotices.html
@@ -18,7 +18,6 @@ Licensed under the MIT License.
         <h1>PLACEHOLDER NOTICES AND INFORMATION</h1>
         <h2>Should appear in development builds only</h2>
         <p>
-		                                                                                          X
             This is a placeholder version of the thirdpartynotices.html file that is generated
             during release CI builds of Axe.Windows. It follows the same format as the real,
             generated file. The real file links to

--- a/thirdpartynotices.html
+++ b/thirdpartynotices.html
@@ -18,9 +18,10 @@ Licensed under the MIT License.
         <h1>PLACEHOLDER NOTICES AND INFORMATION</h1>
         <h2>Should appear in development builds only</h2>
         <p>
-            This is a placeholder version of the NOTICE.html file that is generated during release
-            CI builds of Accessibility Insights. It follows the same format as the real, generated
-            file. The real file links to
+		                                                                                          X
+            This is a placeholder version of the thirdpartynotices.html file that is generated
+            during release CI builds of Axe.Windows. It follows the same format as the real,
+            generated file. The real file links to
             <a href="https://3rdpartysource.microsoft.com">https://3rdpartysource.microsoft.com</a>
             and enumerates the licenses of all transitive dependencies we distribute.
         </p>


### PR DESCRIPTION
#### Details

This tweaks the wording of the placeholder to better reflect both the name of the file (thirdpartynotices.html instead of NOTICES.html) and the name of the pipeline (Axe.Windows instead of Accessibility Insights).

##### Motivation

Accuracy is nice, even in a placeholder

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
