### PR TITLE
feat: Allow CLI to decouple screen captures from System.Drawing.Bitmap

### DIFF
--- a/src/Actions/Actions/DataManager.cs
+++ b/src/Actions/Actions/DataManager.cs
@@ -5,9 +5,9 @@ using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Actions.Enums;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
+using Axe.Windows.SystemAbstractions;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 
 namespace Axe.Windows.Actions
@@ -151,7 +151,7 @@ namespace Axe.Windows.Actions
         /// </summary>
         /// <param name="ecId"></param>
         /// <returns></returns>
-        public Bitmap GetScreenshot(Guid ecId)
+        public IBitmap GetScreenshot(Guid ecId)
         {
             var elementContext = GetElementContext(ecId);
             if (elementContext == null) return null;

--- a/src/Actions/Actions/LoadActionParts.cs
+++ b/src/Actions/Actions/LoadActionParts.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Desktop.Settings;
-using System.Drawing;
+using Axe.Windows.SystemAbstractions;
 
 namespace Axe.Windows.Actions
 {
@@ -19,12 +19,12 @@ namespace Axe.Windows.Actions
         /// <summary>
         /// Stored screenshot
         /// </summary>
-        public Bitmap Bmp { get; private set; }
+        public IBitmap Bmp { get; private set; }
 
         /// <summary>
         /// Synthesized screenshot
         /// </summary>
-        public Bitmap SynthesizedBmp { get; }
+        public IBitmap SynthesizedBmp { get; }
 
         /// <summary>
         /// Metadata
@@ -38,7 +38,7 @@ namespace Axe.Windows.Actions
         /// <param name="bmp">Actual screenshot</param>
         /// <param name="synthesizedBmp">Synthesized ("yellow box") bitmap</param>
         /// <param name="settings">Metadata about the snapshot</param>
-        public LoadActionParts(A11yElement el, Bitmap bmp, Bitmap synthesizedBmp, SnapshotMetaInfo settings)
+        public LoadActionParts(A11yElement el, IBitmap bmp, IBitmap synthesizedBmp, SnapshotMetaInfo settings)
         {
             this.Element = el;
             this.Bmp = bmp;

--- a/src/Actions/Actions/SaveAction.cs
+++ b/src/Actions/Actions/SaveAction.cs
@@ -64,7 +64,7 @@ namespace Axe.Windows.Actions
             {
                 using (MemoryStream mStrm = new MemoryStream())
                 {
-                    ec.DataContext.Screenshot.Save(mStrm, System.Drawing.Imaging.ImageFormat.Png);
+                    ec.DataContext.Screenshot.SavePngToStream(mStrm);
                     mStrm.Seek(0, SeekOrigin.Begin);
 
                     AddStream(package, mStrm, screenshotFileName);

--- a/src/Actions/Actions/ScreenShotAction.cs
+++ b/src/Actions/Actions/ScreenShotAction.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Actions.Attributes;
 using Axe.Windows.Actions.Enums;
 using Axe.Windows.Desktop.Drawing;
@@ -11,15 +12,15 @@ using System;
 namespace Axe.Windows.Actions
 {
     /// <summary>
-    /// Class SelectionAction
-    /// this class is to select unelement via focus or keyboard
+    /// ScreenshotAction: Class to capture a screenshot of a specified element
     /// </summary>
     [InteractionLevel(UxInteractionLevel.NoUxInteraction)]
     public static class ScreenShotAction
     {
-        // unit test hooks
+        // unit test hook
         internal static Func<DataManager> GetDataManager = () => DataManager.GetDefaultInstance();
-        internal static IBitmapCreator BitmapCreator = new FrameworkBitmapCreator();
+
+        private static readonly IBitmapCreator DefaultBitmapCreator = new FrameworkBitmapCreator();
 
         /// <summary>
         /// Take a screenshot of the given element's parent window, if it has one
@@ -28,6 +29,19 @@ namespace Axe.Windows.Actions
         /// <param name="ecId">Element Context Id</param>
         public static void CaptureScreenShot(Guid ecId)
         {
+            CaptureScreenShot(ecId, DefaultBitmapCreator);
+        }
+
+        /// <summary>
+        /// Take a screenshot of the given element's parent window, if it has one
+        ///     returns null if the bounding rectangle is 0-sized
+        /// </summary>
+        /// <param name="ecId">Element Context Id</param>
+        /// <param name="bitmapCreator">Object to use to capture the screenshot</param>
+        public static void CaptureScreenShot(Guid ecId, IBitmapCreator bitmapCreator)
+        {
+            if (bitmapCreator == null) throw new ArgumentNullException(nameof(bitmapCreator));
+
             try
             {
                 var ec = GetDataManager().GetElementContext(ecId);
@@ -41,7 +55,7 @@ namespace Axe.Windows.Actions
                     return; // no capture.
                 }
 
-                ec.DataContext.Screenshot = BitmapCreator.FromScreenRectangle(rect);
+                ec.DataContext.Screenshot = bitmapCreator.FromScreenRectangle(rect);
                 ec.DataContext.ScreenshotElementId = el.UniqueId;
             }
             catch(TypeInitializationException e)

--- a/src/Actions/Actions/ScreenShotAction.cs
+++ b/src/Actions/Actions/ScreenShotAction.cs
@@ -2,10 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Actions.Attributes;
 using Axe.Windows.Actions.Enums;
+using Axe.Windows.Desktop.Drawing;
 using Axe.Windows.Desktop.Utility;
+using Axe.Windows.SystemAbstractions;
 using Axe.Windows.Telemetry;
 using System;
-using System.Drawing;
 
 namespace Axe.Windows.Actions
 {
@@ -18,9 +19,7 @@ namespace Axe.Windows.Actions
     {
         // unit test hooks
         internal static Func<DataManager> GetDataManager = () => DataManager.GetDefaultInstance();
-        internal static Func<int, int, Bitmap> CreateBitmap = (width, height) => new Bitmap(width, height);
-        internal static readonly Action<Graphics, int, int, Size> DefaultCopyFromScreen = (g, x, y, s) => g.CopyFromScreen(x, y, 0, 0, s);
-        internal static Action<Graphics, int, int, Size> CopyFromScreen = DefaultCopyFromScreen;
+        internal static IBitmapCreator BitmapCreator = new FrameworkBitmapCreator();
 
         /// <summary>
         /// Take a screenshot of the given element's parent window, if it has one
@@ -42,12 +41,7 @@ namespace Axe.Windows.Actions
                     return; // no capture.
                 }
 
-                Bitmap bmp = CreateBitmap(rect.Width, rect.Height);
-                Graphics g = Graphics.FromImage(bmp);
-
-                CopyFromScreen(g, rect.X, rect.Y, rect.Size);
-
-                ec.DataContext.Screenshot = bmp;
+                ec.DataContext.Screenshot = BitmapCreator.FromScreenRectangle(rect);
                 ec.DataContext.ScreenshotElementId = el.UniqueId;
             }
             catch(TypeInitializationException e)

--- a/src/Actions/Contexts/ElementDataContext.cs
+++ b/src/Actions/Contexts/ElementDataContext.cs
@@ -4,9 +4,9 @@ using Axe.Windows.Actions.Enums;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;
+using Axe.Windows.SystemAbstractions;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 
 namespace Axe.Windows.Actions.Contexts
@@ -52,7 +52,7 @@ namespace Axe.Windows.Actions.Contexts
         /// <summary>
         /// Current screenshot
         /// </summary>
-        public Bitmap Screenshot { get; internal set; }
+        public IBitmap Screenshot { get; internal set; }
 
         /// <summary>
         /// Id of element which was used to grab the screenshot

--- a/src/ActionsTests/Actions/ScreenShotActionUnitTests.cs
+++ b/src/ActionsTests/Actions/ScreenShotActionUnitTests.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Actions;
 using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
-using Axe.Windows.Desktop.Drawing;
 using Axe.Windows.SystemAbstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -32,7 +32,14 @@ namespace Axe.Windows.ActionsTests.Actions
         public void TestCleanup()
         {
             ScreenShotAction.GetDataManager = () => DataManager.GetDefaultInstance();
-            ScreenShotAction.BitmapCreator = new FrameworkBitmapCreator();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void CaptureScreenShot_BitmapCreatorIsNull_ThrowsArgumentNullException()
+        {
+            ArgumentNullException e = Assert.ThrowsException<ArgumentNullException>(() => ScreenShotAction.CaptureScreenShot(Guid.Empty, null));
+            Assert.AreEqual("bitmapCreator", e.ParamName);
         }
 
         [TestMethod]
@@ -59,7 +66,7 @@ namespace Axe.Windows.ActionsTests.Actions
                 dm.AddElementContext(elementContext);
                 ScreenShotAction.GetDataManager = () => dm;
 
-                ScreenShotAction.CaptureScreenShot(elementContext.Id);
+                ScreenShotAction.CaptureScreenShot(elementContext.Id, bitmapCreatorMock.Object);
 
                 Assert.IsNull(dc.Screenshot);
                 Assert.AreEqual(default(int), dc.ScreenshotElementId);
@@ -94,9 +101,8 @@ namespace Axe.Windows.ActionsTests.Actions
 
                 ScreenShotAction.GetDataManager = () => dm;
                 bitmapCreatorMock.Setup(m => m.FromScreenRectangle(expectedRectangle)).Returns(bitmapMock.Object);
-                ScreenShotAction.BitmapCreator = bitmapCreatorMock.Object;
 
-                ScreenShotAction.CaptureScreenShot(elementContext.Id);
+                ScreenShotAction.CaptureScreenShot(elementContext.Id, bitmapCreatorMock.Object);
 
                 Assert.IsNotNull(dc.Screenshot);
                 Assert.AreEqual(element.UniqueId, dc.ScreenshotElementId);
@@ -131,9 +137,8 @@ namespace Axe.Windows.ActionsTests.Actions
 
                 ScreenShotAction.GetDataManager = () => dm;
                 bitmapCreatorMock.Setup(m => m.FromScreenRectangle(expectedRectangle)).Throws(new TypeInitializationException("Bitmap", null));
-                ScreenShotAction.BitmapCreator = bitmapCreatorMock.Object;
 
-                ScreenShotAction.CaptureScreenShot(elementContext.Id);
+                ScreenShotAction.CaptureScreenShot(elementContext.Id, bitmapCreatorMock.Object);
 
                 Assert.IsNull(dc.Screenshot);
                 Assert.AreEqual(default(int), dc.ScreenshotElementId);

--- a/src/Automation/AxeWindowsActions.cs
+++ b/src/Automation/AxeWindowsActions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Actions;
 using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Actions.Enums;
@@ -7,6 +8,7 @@ using Axe.Windows.Actions.Misc;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Desktop.Settings;
+using Axe.Windows.SystemAbstractions;
 using System;
 using System.Globalization;
 
@@ -14,6 +16,13 @@ namespace Axe.Windows.Automation
 {
     class AxeWindowsActions : IAxeWindowsActions
     {
+        private readonly IBitmapCreator _bitmapCreator;
+
+        public AxeWindowsActions(IBitmapCreator bitmapCreator)
+        {
+            _bitmapCreator = bitmapCreator ?? throw new ArgumentNullException(nameof(bitmapCreator));
+        }
+
         public ResultsT Scan<ResultsT>(A11yElement element, ScanActionCallback<ResultsT> scanCallback)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
@@ -51,7 +60,7 @@ namespace Axe.Windows.Automation
 
         public void CaptureScreenshot(Guid elementId)
         {
-            ScreenShotAction.CaptureScreenShot(elementId);
+            ScreenShotAction.CaptureScreenShot(elementId, _bitmapCreator);
         }
 
         public void SaveA11yTestFile(string path, A11yElement element, Guid elementId)

--- a/src/Automation/BitmapCreatorLocator.cs
+++ b/src/Automation/BitmapCreatorLocator.cs
@@ -3,6 +3,7 @@
 
 using Axe.Windows.SystemAbstractions;
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
@@ -10,21 +11,34 @@ namespace Axe.Windows.Automation
 {
     internal static class BitmapCreatorLocator
     {
-        public static IBitmapCreator GetBitmapCreator(string assemblyName)
+        /// <summary>
+        /// Given an assembly attempt to find the unique public implementation of IBitmapCreator
+        /// </summary>
+        /// <param name="assemblyName">Full path to the assembly to check</param>
+        /// <param name="creatorTypeCount">Returns the number of eligible implementations of IBitmapCreator. Provided for unit tests</param>
+        /// <returns>An instance of the located IBitmapCreator implementation</returns>
+        internal static IBitmapCreator GetBitmapCreator(string assemblyName, out int creatorTypeCount)
         {
-            var assembly = Assembly.LoadFrom(assemblyName);
-            var types = assembly.GetTypes();
+            creatorTypeCount = 0; // Set this value in case we throw while getting the types
+
+            Assembly assembly = Assembly.LoadFrom(assemblyName);
+            Type[] types = assembly.GetTypes();
             Type bitmapCreatorType = typeof(IBitmapCreator);
-            var creatorTypes = (from t in types
-                                where bitmapCreatorType != t && bitmapCreatorType.IsAssignableFrom(t)
-                                select t).ToArray();
+            Type[] creatorTypes = (from t in types
+                                   where t.IsPublic && bitmapCreatorType != t && bitmapCreatorType.IsAssignableFrom(t)
+                                   select t).ToArray();
 
-            if (creatorTypes.Any())
+            creatorTypeCount = creatorTypes.Length;
+            switch (creatorTypeCount)
             {
-                return Activator.CreateInstance(creatorTypes[0]) as IBitmapCreator;
+                case 1: // This is the only successful path
+                    return Activator.CreateInstance(creatorTypes[0]) as IBitmapCreator;
+                case 0:
+                    throw new ArgumentException("Unable to locate any candidate IBitmapCreator implementations in the specified assembly", nameof(assemblyName));
+                default:
+                    string message = string.Format(CultureInfo.InvariantCulture, "Unable to choose between {0} candidate IBitmapCreator implementations in the specified assembly", creatorTypeCount);
+                    throw new ArgumentException(message, nameof(assemblyName));
             }
-
-            throw new ArgumentException("Unable to locate IBitmapCreator implementation in specified assembly", nameof(assemblyName));
         }
     }
 }

--- a/src/Automation/BitmapCreatorLocator.cs
+++ b/src/Automation/BitmapCreatorLocator.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.SystemAbstractions;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Axe.Windows.Automation
+{
+    internal static class BitmapCreatorLocator
+    {
+        public static IBitmapCreator GetBitmapCreator(string assemblyName)
+        {
+            var assembly = Assembly.LoadFrom(assemblyName);
+            var types = assembly.GetTypes();
+            Type bitmapCreatorType = typeof(IBitmapCreator);
+            var creatorTypes = (from t in types
+                                where bitmapCreatorType != t && bitmapCreatorType.IsAssignableFrom(t)
+                                select t).ToArray();
+
+            if (creatorTypes.Any())
+            {
+                return Activator.CreateInstance(creatorTypes[0]) as IBitmapCreator;
+            }
+
+            throw new ArgumentException("Unable to locate IBitmapCreator implementation in specified assembly", nameof(assemblyName));
+        }
+    }
+}

--- a/src/Automation/Data/Config.cs
+++ b/src/Automation/Data/Config.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+
+using Axe.Windows.SystemAbstractions;
 
 namespace Axe.Windows.Automation
 {
@@ -27,6 +28,14 @@ namespace Axe.Windows.Automation
         /// No output files will be written if no errors were found during the automation session.
         /// </remarks>
         public string OutputDirectory { get; private set; }
+
+        /// <summary>
+        /// The assembly containing the IBitmapCreator implementation.
+        /// If this value is null, the default implementation will be used.
+        /// If this value is non-null, but does not expose an appropriate implementation,
+        /// an <see cref="AxeWindowsAutomationException"/> will be thrown.
+        /// </summary>
+        public string ScreenCaptureAssembly { get; private set; }
 
         /// <summary>
         /// Flags specifying the type of output file to create.
@@ -57,8 +66,7 @@ namespace Axe.Windows.Automation
             /// <summary>
             /// Create the builder for the specified process
             /// </summary>
-            /// <param name="processId"></param>
-            /// <returns></returns>
+            /// <param name="processId">The numeric process ID</param>
             public static Builder ForProcessId(int processId)
             {
                 return new Builder(processId);
@@ -67,8 +75,7 @@ namespace Axe.Windows.Automation
             /// <summary>
             /// Specify the directory where any output files should be written
             /// </summary>
-            /// <param name="directory"></param>
-            /// <returns></returns>
+            /// <param name="directory">The output directory</param>
             public Builder WithOutputDirectory(string directory)
             {
                 _config.OutputDirectory = directory;
@@ -78,8 +85,7 @@ namespace Axe.Windows.Automation
             /// <summary>
             /// Specify the type(s) of output files you wish AxeWindows to create
             /// </summary>
-            /// <param name="format"></param>
-            /// <returns></returns>
+            /// <param name="format">The output format</param>
             public Builder WithOutputFileFormat(OutputFileFormat format)
             {
                 _config.OutputFileFormat = format;
@@ -87,9 +93,18 @@ namespace Axe.Windows.Automation
             }
 
             /// <summary>
+            /// Specify the screen capture assembly override
+            /// </summary>
+            /// <param name="assemblyFullName">The full path and name of the assembly that exposes the <see cref="IBitmapCreator"></see> interface./></param>
+            public Builder WithScreenCaptureAssembly(string assemblyFullName)
+            {
+                _config.ScreenCaptureAssembly = assemblyFullName;
+                return this;
+            }
+
+            /// <summary>
             /// Build an instance of <see cref="Config"/>
             /// </summary>
-            /// <returns></returns>
             public Config Build()
             {
                 return new Config

--- a/src/Automation/Data/Config.cs
+++ b/src/Automation/Data/Config.cs
@@ -49,7 +49,17 @@ namespace Axe.Windows.Automation
         private Config()
         { }
 
-        #pragma warning disable CA1034 // Do not nest type
+        internal Config Clone()
+        {
+            Config output = new Config();
+            foreach (var property in typeof(Config).GetProperties())
+            {
+                property.SetValue(output, property.GetValue(this));
+            }
+            return output;
+        }
+
+#pragma warning disable CA1034 // Do not nest type
         /// <summary>
         /// Builds an instance of the <see cref="Config"/> class
         /// </summary>
@@ -107,12 +117,7 @@ namespace Axe.Windows.Automation
             /// </summary>
             public Config Build()
             {
-                return new Config
-                {
-                    ProcessId = _config.ProcessId,
-                    OutputFileFormat = _config.OutputFileFormat,
-                    OutputDirectory = _config.OutputDirectory,
-                };
+                return _config.Clone();
             }
         } // Builder
         #pragma warning restore CA1034

--- a/src/Automation/Factory.cs
+++ b/src/Automation/Factory.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Desktop.Drawing;
 using Axe.Windows.SystemAbstractions;
-using System;
 
 namespace Axe.Windows.Automation
 {
@@ -33,9 +34,12 @@ namespace Axe.Windows.Automation
             return new TargetElementLocator();
         }
 
-        public IAxeWindowsActions CreateAxeWindowsActions()
+        public IAxeWindowsActions CreateAxeWindowsActions(string bitmapCreatorAssemblyFullName)
         {
-            return new AxeWindowsActions();
+            IBitmapCreator bitmapCreator = bitmapCreatorAssemblyFullName == null ?
+                new FrameworkBitmapCreator() :
+                BitmapCreatorLocator.GetBitmapCreator(bitmapCreatorAssemblyFullName, out _);
+            return new AxeWindowsActions(bitmapCreator);
         }
 
         public INativeMethods CreateNativeMethods()

--- a/src/Automation/Interfaces/IFactory.cs
+++ b/src/Automation/Interfaces/IFactory.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.SystemAbstractions;
-using System;
 
 namespace Axe.Windows.Automation
 {
@@ -13,7 +11,7 @@ namespace Axe.Windows.Automation
         IOutputFileHelper CreateOutputFileHelper(string outputDirectory);
         IScanResultsAssembler CreateResultsAssembler();
         ITargetElementLocator CreateTargetElementLocator();
-        IAxeWindowsActions CreateAxeWindowsActions();
+        IAxeWindowsActions CreateAxeWindowsActions(string bitmapCreatorAssemblyFullName);
         INativeMethods CreateNativeMethods();
     } // interface
 } // namespace

--- a/src/Automation/Interfaces/IScanToolsBuilder.cs
+++ b/src/Automation/Interfaces/IScanToolsBuilder.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 
 namespace Axe.Windows.Automation
 {
     internal interface IScanToolsBuilder
     {
         IScanToolsBuilder WithOutputDirectory(string outputDirectory);
+        IScanToolsBuilder WithBitmapCreatorFrom(string assemblyFullName);
         IScanTools Build();
     } // interface
 } // namespace

--- a/src/Automation/ScanToolsBuilder.cs
+++ b/src/Automation/ScanToolsBuilder.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.Automation
@@ -8,6 +9,7 @@ namespace Axe.Windows.Automation
     {
         private IFactory _factory;
         private IOutputFileHelper _outputFileHelper;
+        private string _bitmapCreatorAssemblyFullName;
 
         public ScanToolsBuilder(IFactory factory)
         {
@@ -22,13 +24,19 @@ namespace Axe.Windows.Automation
             return this;
         }
 
+        public IScanToolsBuilder WithBitmapCreatorFrom(string assemblyFullName)
+        {
+            _bitmapCreatorAssemblyFullName = assemblyFullName;
+            return this;
+        }
+
         public IScanTools Build()
         {
             return new ScanTools(
                 _outputFileHelper ?? _factory.CreateOutputFileHelper(null),
                     _factory.CreateResultsAssembler(),
                     _factory.CreateTargetElementLocator(),
-                    _factory.CreateAxeWindowsActions(),
+                    _factory.CreateAxeWindowsActions(_bitmapCreatorAssemblyFullName),
                     _factory.CreateNativeMethods());
         }
     } // class

--- a/src/Automation/ScannerFactory.cs
+++ b/src/Automation/ScannerFactory.cs
@@ -19,7 +19,10 @@ namespace Axe.Windows.Automation
             if (config == null) throw new ArgumentNullException(nameof(config));
 
             var scanToolsBuilder = Factory.CreateScanToolsBuilder();
-            var scanTools = scanToolsBuilder.WithOutputDirectory(config.OutputDirectory).Build();
+            var scanTools = scanToolsBuilder
+                .WithOutputDirectory(config.OutputDirectory)
+                .WithBitmapCreatorFrom(config.ScreenCaptureAssembly)
+                .Build();
             return new Scanner(config, scanTools);
         }
     } // class

--- a/src/AutomationTests/BitmapCreatorLocatorUnitTests.cs
+++ b/src/AutomationTests/BitmapCreatorLocatorUnitTests.cs
@@ -1,4 +1,7 @@
-﻿using Axe.Windows.Automation;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Automation;
 using Axe.Windows.Desktop.Drawing;
 using Axe.Windows.SystemAbstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -11,6 +14,8 @@ namespace Axe.Windows.AutomationTests
     [TestClass]
     public class BitmapCreatorLocatorUnitTests
     {
+        const int Undefined = -1; // Any value that will never be returned as the count
+
         static string GetPathToAssembly(string assemblyName)
         {
             return Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), assemblyName);
@@ -19,32 +24,59 @@ namespace Axe.Windows.AutomationTests
         [TestMethod]
         public void GetBitmapCreator_NoAssemblyFound_ThrowsFileNotFoundException()
         {
+            int creatorTypeCount = Undefined;
             string path = GetPathToAssembly("NoSuchAssemblyExists.dll");
-            Assert.ThrowsException<FileNotFoundException>(() => BitmapCreatorLocator.GetBitmapCreator(path));
+
+            Assert.ThrowsException<FileNotFoundException>(() => BitmapCreatorLocator.GetBitmapCreator(path, out creatorTypeCount));
+
+            Assert.AreEqual(0, creatorTypeCount);
         }
 
         [TestMethod]
         public void GetBitmapCreator_NoRelatedClassesExist_ThrowsArgumentException()
         {
+            int creatorTypeCount = Undefined;
             string path = GetPathToAssembly("System.IO.Packaging.dll");
-            ArgumentException e = Assert.ThrowsException<ArgumentException>(() => BitmapCreatorLocator.GetBitmapCreator(path));
+
+            ArgumentException e = Assert.ThrowsException<ArgumentException>(() => BitmapCreatorLocator.GetBitmapCreator(path, out creatorTypeCount));
+
             Assert.AreEqual("assemblyName", e.ParamName);
+            Assert.AreEqual(0, creatorTypeCount);
         }
 
         [TestMethod]
-        public void GetBitmapCreator_NoDerivedClassesExist_ThrowsArgumentException()
+        public void GetBitmapCreator_ZeroDerivedClassesExist_ThrowsArgumentException()
         {
+            int creatorTypeCount = Undefined;
             string path = GetPathToAssembly("Axe.Windows.SystemAbstractions.dll");
-            ArgumentException e = Assert.ThrowsException<ArgumentException>(() => BitmapCreatorLocator.GetBitmapCreator(path));
+
+            ArgumentException e = Assert.ThrowsException<ArgumentException>(() => BitmapCreatorLocator.GetBitmapCreator(path, out creatorTypeCount));
+
             Assert.AreEqual("assemblyName", e.ParamName);
+            Assert.AreEqual(0, creatorTypeCount);
         }
 
         [TestMethod]
-        public void GetGitmapCreator_DerivedClassExists_CreatesObjectOfExpectedType()
+        public void GetBitmapCreator_OneDerivedClassExists_CreatesObjectOfExpectedType()
         {
             string path = GetPathToAssembly("Axe.Windows.Desktop.dll");
-            IBitmapCreator creator = BitmapCreatorLocator.GetBitmapCreator(path);
+
+            IBitmapCreator creator = BitmapCreatorLocator.GetBitmapCreator(path, out int creatorTypeCount);
+
             Assert.IsInstanceOfType(creator, typeof(FrameworkBitmapCreator));
+            Assert.AreEqual(1, creatorTypeCount);
+        }
+
+        [TestMethod]
+        public void GetBitmapCreator_TwoDerivedClassesExist_ThrowsArgumentException()
+        {
+            int creatorTypeCount = Undefined;
+            string path = Assembly.GetExecutingAssembly().Location;
+
+            ArgumentException e = Assert.ThrowsException<ArgumentException>(() => BitmapCreatorLocator.GetBitmapCreator(path, out creatorTypeCount));
+
+            Assert.AreEqual("assemblyName", e.ParamName);
+            Assert.AreEqual(2, creatorTypeCount);
         }
     }
 }

--- a/src/AutomationTests/BitmapCreatorLocatorUnitTests.cs
+++ b/src/AutomationTests/BitmapCreatorLocatorUnitTests.cs
@@ -1,0 +1,50 @@
+﻿using Axe.Windows.Automation;
+using Axe.Windows.Desktop.Drawing;
+using Axe.Windows.SystemAbstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace Axe.Windows.AutomationTests
+{
+    [TestClass]
+    public class BitmapCreatorLocatorUnitTests
+    {
+        static string GetPathToAssembly(string assemblyName)
+        {
+            return Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), assemblyName);
+        }
+
+        [TestMethod]
+        public void GetBitmapCreator_NoAssemblyFound_ThrowsFileNotFoundException()
+        {
+            string path = GetPathToAssembly("NoSuchAssemblyExists.dll");
+            Assert.ThrowsException<FileNotFoundException>(() => BitmapCreatorLocator.GetBitmapCreator(path));
+        }
+
+        [TestMethod]
+        public void GetBitmapCreator_NoRelatedClassesExist_ThrowsArgumentException()
+        {
+            string path = GetPathToAssembly("System.IO.Packaging.dll");
+            ArgumentException e = Assert.ThrowsException<ArgumentException>(() => BitmapCreatorLocator.GetBitmapCreator(path));
+            Assert.AreEqual("assemblyName", e.ParamName);
+        }
+
+        [TestMethod]
+        public void GetBitmapCreator_NoDerivedClassesExist_ThrowsArgumentException()
+        {
+            string path = GetPathToAssembly("Axe.Windows.SystemAbstractions.dll");
+            ArgumentException e = Assert.ThrowsException<ArgumentException>(() => BitmapCreatorLocator.GetBitmapCreator(path));
+            Assert.AreEqual("assemblyName", e.ParamName);
+        }
+
+        [TestMethod]
+        public void GetGitmapCreator_DerivedClassExists_CreatesObjectOfExpectedType()
+        {
+            string path = GetPathToAssembly("Axe.Windows.Desktop.dll");
+            IBitmapCreator creator = BitmapCreatorLocator.GetBitmapCreator(path);
+            Assert.IsInstanceOfType(creator, typeof(FrameworkBitmapCreator));
+        }
+    }
+}

--- a/src/AutomationTests/DummyBitmapCreators.cs
+++ b/src/AutomationTests/DummyBitmapCreators.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.SystemAbstractions;
+using System;
+using System.Drawing;
+
+namespace Axe.Windows.AutomationTests
+{
+    // These classes provide different scenarios (visibility and derivation) to test
+    // the BitmapCreatorLocator
+    public class DummyPublicBitmapCreator : IBitmapCreator
+    {
+        public IBitmap FromScreenRectangle(Rectangle rect)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IBitmap FromSystemDrawingBitmap(Bitmap bitmap)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class DummyPublicDerivedBitmapCreator : DummyPublicBitmapCreator { }
+
+    internal class DummyInternalDerivedBitmapCreator : DummyPublicBitmapCreator { }
+}

--- a/src/AutomationTests/ScanToolsBuilderUnitTests.cs
+++ b/src/AutomationTests/ScanToolsBuilderUnitTests.cs
@@ -13,16 +13,18 @@ namespace Axe.Windows.AutomationTests
         [Timeout(1000)]
         public void Build_CreatesExpectedObject()
         {
+            const string bitmapCreatorAssembly = @".\WidgetAssembly.dll";
+
             var mockRepository = new MockRepository(MockBehavior.Strict);
 
-            var actionsMock = mockRepository.Create<IAxeWindowsActions>();
-            var nativeMethodsMock = mockRepository.Create<INativeMethods>();
-            var outputFileHelperMock = mockRepository.Create<IOutputFileHelper>();
-            var resultsAssemblerMock = mockRepository.Create<IScanResultsAssembler>();
-            var targetElementLocatorMock = mockRepository.Create<ITargetElementLocator>();
+            var actionsMock = mockRepository.Create<IAxeWindowsActions>(MockBehavior.Strict);
+            var nativeMethodsMock = mockRepository.Create<INativeMethods>(MockBehavior.Strict);
+            var outputFileHelperMock = mockRepository.Create<IOutputFileHelper>(MockBehavior.Strict);
+            var resultsAssemblerMock = mockRepository.Create<IScanResultsAssembler>(MockBehavior.Strict);
+            var targetElementLocatorMock = mockRepository.Create<ITargetElementLocator>(MockBehavior.Strict);
 
-            var factoryMock = mockRepository.Create<IFactory>();
-            factoryMock.Setup(x => x.CreateAxeWindowsActions()).Returns(actionsMock.Object);
+            var factoryMock = mockRepository.Create<IFactory>(MockBehavior.Strict);
+            factoryMock.Setup(x => x.CreateAxeWindowsActions(bitmapCreatorAssembly)).Returns(actionsMock.Object);
             factoryMock.Setup(x => x.CreateNativeMethods()).Returns(nativeMethodsMock.Object);
             factoryMock.Setup(x => x.CreateResultsAssembler()).Returns(resultsAssemblerMock.Object);
             factoryMock.Setup(x => x.CreateTargetElementLocator()).Returns(targetElementLocatorMock.Object);
@@ -38,7 +40,10 @@ namespace Axe.Windows.AutomationTests
             var builder = new ScanToolsBuilder(factoryMock.Object);
 
             const string expectedPath = @"c:\_TestPath";
-            var scanTools = builder.WithOutputDirectory(expectedPath).Build();
+            var scanTools = builder
+                .WithOutputDirectory(expectedPath)
+                .WithBitmapCreatorFrom(bitmapCreatorAssembly)
+                .Build();
 
             Assert.IsNotNull(scanTools);
             Assert.IsNotNull(scanTools.Actions);
@@ -50,6 +55,7 @@ namespace Axe.Windows.AutomationTests
             Assert.AreEqual(expectedPath, scanTools.OutputFileHelper.GetNewA11yTestFilePath());
 
             factoryMock.VerifyAll();
+            outputFileHelperMock.VerifyAll();
         }
     } // class
 } // namespace

--- a/src/CI/Program.cs
+++ b/src/CI/Program.cs
@@ -1,67 +1,22 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Automation;
 using System;
-using System.Collections.Generic;
-using System.Globalization;
 
 namespace Axe.Windows.CI
 {
+    /// <summary>
+    /// This app exists as a way to gather the assemblies that will be packaged
+    /// into the NuGet package. To learn how to use the NuGet Package, please
+    /// refer either to the CLI project or AutomationReference.md in the docs
+    /// folder.
+    /// </summary>
     class Program
     {
-        /// <summary>
-        /// This entry point does not ship, but it makes for a quick and easy way to debug through the
-        /// automation code. One caveat--we intentionally don't build symbols for this app, so while you
-        /// can use it to to debug the automation code, breakpoints set in this class will be ignored.
-        /// </summary>
         static void Main(string[] args)
         {
-            Dictionary<string, string> parameters = new Dictionary<string, string>();
-            string secondaryConfigFile = string.Empty;
-
-            char[] delimiters = {'='};
-
-            foreach (string arg in args)
-            {
-                string[] pieces = arg.Split(delimiters);
-                if (pieces.Length == 2)
-                {
-                    string key = pieces[0].Trim();
-                    string value = pieces[1].Trim();
-
-                    if (!string.IsNullOrWhiteSpace(key) && !string.IsNullOrWhiteSpace(value))
-                    {
-                        // Special case for SecondaryConfigFile
-                        if (key.Equals("SecondaryConfigFile", StringComparison.OrdinalIgnoreCase))
-                            secondaryConfigFile = value;
-                        else
-                            parameters[key] = value;
-                        continue;
-                    }
-                }
-
-                Console.WriteLine("Ignoring malformed input: {0}", arg);
-            };
-
-            while (true)
-            {
-                Console.Write("Enter process ID to capture (blank to exit): ");
-                string input = Console.ReadLine();
-
-                if (string.IsNullOrEmpty(input))
-                    break;
-
-                if (!int.TryParse(input, out int processId))
-                {
-                    Console.WriteLine("Not a valid int: " + input);
-                    continue;
-                }
-
-                var config = Config.Builder.ForProcessId(Convert.ToInt32(input)).Build();
-                var scanner = ScannerFactory.CreateScanner(config);
-                var results = scanner.Scan();
-                Console.WriteLine(results);
-            }
+            Console.WriteLine("IScanner = {0}", typeof(IScanner).FullName);
         }
     }
 }

--- a/src/CLI/IOptions.cs
+++ b/src/CLI/IOptions.cs
@@ -11,5 +11,6 @@ namespace AxeWindowsCLI
         string ProcessName { get; }
         VerbosityLevel VerbosityLevel { get; }
         int DelayInSeconds { get; }
+        public string ScreenCaptureAssembly { get; }
     }
 }

--- a/src/CLI/Options.cs
+++ b/src/CLI/Options.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using CommandLine;
+using System;
 
 namespace AxeWindowsCLI
 {
@@ -28,7 +29,20 @@ namespace AxeWindowsCLI
         [Option(Required = false, HelpText = "How many seconds to delay before triggering the scan. Valid range is 0 to 60 seconds, with a default of 0.")]
         public int DelayInSeconds { get; set; }
 
+        [Option(Required = false, HelpText = "Full path to an assembly that exposes a public implementation of the IBitmapCreator interface for use with this scan.")]
+        public string ScreenCaptureAssembly { get; set; }
+
         // CommandLineParser will never set this value!
         public VerbosityLevel VerbosityLevel { get; set; } = VerbosityLevel.Default;
+
+        public Options Clone()
+        {
+            Options output = new Options();
+            foreach (var property in typeof(Options).GetProperties())
+            {
+                property.SetValue(output, property.GetValue(this));
+            }
+            return output;
+        }
     }
 }

--- a/src/CLI/OptionsEvaluator.cs
+++ b/src/CLI/OptionsEvaluator.cs
@@ -56,15 +56,13 @@ namespace AxeWindowsCLI
                 }
             }
 
-            return new Options
-            {
-                OutputDirectory = rawInputs.OutputDirectory,
-                ProcessId = processId,
-                ProcessName = processName,
-                ScanId = rawInputs.ScanId,
-                VerbosityLevel = verbosityLevel,
-                DelayInSeconds = delayInSeconds,
-            };
+            Options evaluatedOptions = rawInputs.Clone();
+            evaluatedOptions.ProcessId = processId;
+            evaluatedOptions.ProcessName = processName;
+            evaluatedOptions.VerbosityLevel = verbosityLevel;
+            evaluatedOptions.DelayInSeconds = delayInSeconds;
+
+            return evaluatedOptions;
         }
 
         private static string TrimProcessName(string processName)

--- a/src/CLI/ScanRunner.cs
+++ b/src/CLI/ScanRunner.cs
@@ -17,10 +17,9 @@ namespace AxeWindowsCLI
         {
             Config.Builder builder = Config.Builder
                 .ForProcessId(options.ProcessId)
+                .WithScreenCaptureAssembly(options.ScreenCaptureAssembly)
+                .WithOutputDirectory(options.OutputDirectory)
                 .WithOutputFileFormat(OutputFileFormat.A11yTest);
-
-            if (!string.IsNullOrEmpty(options.OutputDirectory))
-                builder = builder.WithOutputDirectory(options.OutputDirectory);
 
             return ScannerFactory.CreateScanner(builder.Build());
         }

--- a/src/Desktop/Drawing/FrameworkBitmap.cs
+++ b/src/Desktop/Drawing/FrameworkBitmap.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.SystemAbstractions;
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+
+namespace Axe.Windows.Desktop.Drawing
+{
+    /// <summary>
+    /// Implementation of <see cref="IBitmap"/> using System.Drawing.Common
+    /// </summary>
+    internal class FrameworkBitmap : IBitmap
+    {
+        private Bitmap _bitmap;
+
+        #region IDisposable Support
+        private bool disposedValue; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    _bitmap.Dispose();
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        ~FrameworkBitmap()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(false);
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Testable ctor
+        /// </summary>
+        internal FrameworkBitmap(Bitmap bitmap)
+        {
+            _bitmap = bitmap ?? throw new ArgumentNullException(nameof(bitmap));
+        }
+
+        /// <summary>
+        /// Implementation of <see cref="IBitmap.SavePngToStream(Stream)"/>
+        /// </summary>
+        public void SavePngToStream(Stream stream)
+        {
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+
+            _bitmap.Save(stream, ImageFormat.Png);
+        }
+
+        /// <summary>
+        /// Implementation of <see cref="IBitmap.ToSystemDrawingBitmap()"/>
+        /// </summary>
+        public Bitmap ToSystemDrawingBitmap()
+        {
+            return _bitmap;
+        }
+    }
+}

--- a/src/Desktop/Drawing/FrameworkBitmapCreator.cs
+++ b/src/Desktop/Drawing/FrameworkBitmapCreator.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.SystemAbstractions;
+using System;
+using System.Drawing;
+
+namespace Axe.Windows.Desktop.Drawing
+{
+    /// <summary>
+    /// Implementation of <see cref="IBitmapCreator"/> using System.Drawing.Common
+    /// </summary>
+    public class FrameworkBitmapCreator : IBitmapCreator
+    {
+        internal delegate void ScreenCapture(Bitmap bitmap, Rectangle rect);
+
+        private readonly ScreenCapture _screenCapture;
+
+        /// <summary>
+        /// Production ctor
+        /// </summary>
+        public FrameworkBitmapCreator()
+            : this(CaptureScreenRect)
+        {
+        }
+
+        /// <summary>
+        /// Testable ctor
+        /// </summary>
+        /// <param name="screenCapture">The method that gets called to capture the screenshot region</param>
+        internal FrameworkBitmapCreator(ScreenCapture screenCapture)
+        {
+            _screenCapture = screenCapture ?? throw new ArgumentNullException(nameof(screenCapture));
+        }
+
+        private static void CaptureScreenRect(Bitmap bitmap, Rectangle rect)
+        {
+            using (Graphics g = Graphics.FromImage(bitmap))
+            {
+                g.CopyFromScreen(rect.X, rect.Y, 0, 0, rect.Size);
+            }
+        }
+
+        /// <summary>
+        /// Implementation of <see cref="IBitmapCreator.FromScreenRectangle(Rectangle)"/>
+        /// </summary>
+        public IBitmap FromScreenRectangle(Rectangle rect)
+        {
+            Bitmap bmp = new Bitmap(rect.Width, rect.Height);
+            _screenCapture(bmp, rect);
+            return new FrameworkBitmap(bmp);
+        }
+
+        /// <summary>
+        /// Implementation of <see cref="IBitmapCreator.FromSystemDrawingBitmap(Bitmap)"/>
+        /// </summary>
+        public IBitmap FromSystemDrawingBitmap(Bitmap bitmap)
+        {
+            return new FrameworkBitmap(bitmap);
+        }
+    }
+}

--- a/src/DesktopTests/Drawing/FrameworkBitmapCreatorTests.cs
+++ b/src/DesktopTests/Drawing/FrameworkBitmapCreatorTests.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Desktop.Drawing;
+using Axe.Windows.SystemAbstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+
+namespace Axe.Windows.DesktopTests.Drawing
+{
+    [TestClass]
+    public class FrameworkBitmapCreatorTests
+    {
+        Bitmap GetBitmapForTest()
+        {
+            const int testWidth = 20;
+            const int testHeight = 40;
+            const PixelFormat testFormat = PixelFormat.Format8bppIndexed;
+
+            return new Bitmap(testWidth, testHeight, testFormat);
+        }
+
+        private void FailingScreenCapture(Bitmap bitmap, Rectangle rect)
+        {
+            Assert.Fail("This method should never get called!");
+        }
+
+        [TestMethod]
+        public void Ctor_DefaultVersion_DoesNotThrow()
+        {
+            IBitmapCreator testSubject = new FrameworkBitmapCreator();
+            Assert.IsInstanceOfType(testSubject, typeof(FrameworkBitmapCreator));
+        }
+
+        [TestMethod]
+        public void Ctor_ScreenCaptureIsNull_ThrowsArgumentNullException()
+        {
+            ArgumentNullException e = Assert.ThrowsException<ArgumentNullException>(() => new FrameworkBitmapCreator(null));
+            Assert.AreEqual("screenCapture", e.ParamName);
+        }
+
+        [TestMethod]
+        public void FromSystemDrawingBitmap_ReturnsCorrectType()
+        {
+            IBitmapCreator testSubject = new FrameworkBitmapCreator(FailingScreenCapture);
+            using (IBitmap createdBitmap = testSubject.FromSystemDrawingBitmap(GetBitmapForTest()))
+            {
+                Assert.IsInstanceOfType(createdBitmap, typeof(FrameworkBitmap));
+            }
+        }
+
+        [TestMethod]
+        public void FromScreenRectangle_CallsScreenCaptureWithExpectedParameters_ReturnsCorrectType()
+        {
+            Bitmap actualBitmap = null;
+            Rectangle actualRectangle = new Rectangle();
+            Rectangle expectedRectangle = new Rectangle(20, 30, 100, 300);
+            IBitmapCreator testSubject = new FrameworkBitmapCreator((bitmap, rect) =>
+            {
+                actualBitmap = bitmap;
+                actualRectangle = rect;
+            });
+            Assert.AreNotEqual(expectedRectangle, actualRectangle);
+
+            using (IBitmap createdBitmap = testSubject.FromScreenRectangle(expectedRectangle))
+            {
+                Assert.IsInstanceOfType(createdBitmap, typeof(FrameworkBitmap));
+                Assert.IsNotNull(actualBitmap);
+                Assert.AreEqual(expectedRectangle.Width, actualBitmap.Width);
+                Assert.AreEqual(expectedRectangle.Height, actualBitmap.Height);
+                Assert.AreEqual(expectedRectangle, actualRectangle);
+            }
+        }
+    }
+}

--- a/src/DesktopTests/Drawing/FrameworkBitmapTests.cs
+++ b/src/DesktopTests/Drawing/FrameworkBitmapTests.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Desktop.Drawing;
+using Axe.Windows.SystemAbstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+
+namespace Axe.Windows.DesktopTests.Drawing
+{
+    [TestClass]
+    public class FrameworkBitmapTests
+    {
+        Bitmap GetBitmapForTest()
+        {
+            const int testWidth = 20;
+            const int testHeight = 40;
+            const PixelFormat testFormat = PixelFormat.Format8bppIndexed;
+
+            return new Bitmap(testWidth, testHeight, testFormat);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void Ctor_BitmapIsNull_ThrowsArgumentNullException()
+        {
+            ArgumentNullException e = Assert.ThrowsException<ArgumentNullException>(() => new FrameworkBitmap(null));
+            Assert.AreEqual("bitmap", e.ParamName);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ToSystemDrawingBitmap_ReturnsOriginalBitmap()
+        {
+            Bitmap expectedBitmap = GetBitmapForTest();
+
+            using (IBitmap testSubject = new FrameworkBitmap(expectedBitmap))
+            {
+                Bitmap actualBitmap = testSubject.ToSystemDrawingBitmap();
+                Assert.AreEqual(expectedBitmap, actualBitmap);
+                Assert.AreEqual(expectedBitmap.Width, actualBitmap.Width);
+                Assert.AreEqual(expectedBitmap.Height, actualBitmap.Height);
+                Assert.AreEqual(expectedBitmap.PixelFormat, actualBitmap.PixelFormat);
+            }
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void SavePngToStream_StreamIsNull_ThrowsArgumentNullException()
+        {
+            Bitmap expectedBitmap = GetBitmapForTest();
+
+            using (IBitmap testSubject = new FrameworkBitmap(expectedBitmap))
+            {
+                ArgumentNullException e = Assert.ThrowsException<ArgumentNullException>(() => testSubject.SavePngToStream(null));
+                Assert.AreEqual("stream", e.ParamName);
+            }
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void SavePngToStream_StreamIsValid_StreamContentIsCorrect()
+        {
+            Bitmap expectedBitmap = GetBitmapForTest();
+            byte[] expectedContent;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                expectedBitmap.Save(stream, ImageFormat.Png);
+                expectedContent = stream.ToArray();
+            }
+
+            using (IBitmap testSubject = new FrameworkBitmap(expectedBitmap))
+            using (MemoryStream stream = new MemoryStream())
+            {
+                testSubject.SavePngToStream(stream);
+                stream.Seek(0, SeekOrigin.Begin);
+                byte[] actualContent = stream.ToArray();
+
+                Assert.AreEqual(expectedContent.Length, actualContent.Length);
+                for (int loop = 0; loop < expectedContent.Length; loop++)
+                {
+                    Assert.AreEqual(expectedContent[loop], actualContent[loop]);
+                }
+            }
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void Dispose_DisposesBitmap()
+        {
+            Bitmap expectedBitmap = GetBitmapForTest();
+            using (IBitmap testSubject = new FrameworkBitmap(expectedBitmap))
+            {
+                Assert.AreNotEqual(IntPtr.Zero, expectedBitmap.GetHbitmap());
+            }
+            ArgumentException e = Assert.ThrowsException<ArgumentException>(() => expectedBitmap.GetHbitmap());
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void Dispose_CalledTwice_DoesNotThrow()
+        {
+            Bitmap expectedBitmap = GetBitmapForTest();
+            IBitmap testSubject = new FrameworkBitmap(expectedBitmap);
+            testSubject.Dispose();
+            testSubject.Dispose();
+        }
+    }
+}

--- a/src/SystemAbstractions/Abstractions/IBitmap.cs
+++ b/src/SystemAbstractions/Abstractions/IBitmap.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Drawing;
+using System.IO;
+
+namespace Axe.Windows.SystemAbstractions
+{
+    /// <summary>
+    /// Interface to encapsulate Bitmap-related operations
+    /// </summary>
+    public interface IBitmap : IDisposable
+    {
+        /// <summary>
+        /// Save the current contents to the provided stream, in PNG format
+        /// </summary>
+        /// <param name="stream">The stream to receive the PNG data</param>
+        void SavePngToStream(Stream stream);
+
+        /// <summary>
+        /// Convert the current contents to a System.Drawing.Bitmap object.
+        /// This is *not* used during capture, so capture-only implementations
+        /// should simply throw a NotImplementedException.
+        /// </summary>
+        /// <returns></returns>
+        Bitmap ToSystemDrawingBitmap();
+    }
+}

--- a/src/SystemAbstractions/Abstractions/IBitmapCreator.cs
+++ b/src/SystemAbstractions/Abstractions/IBitmapCreator.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Drawing;
+using System.IO;
+
+namespace Axe.Windows.SystemAbstractions
+{
+    /// <summary>
+    /// Interface to encapsulate creation of IBitmap objects
+    /// </summary>
+    public interface IBitmapCreator
+    {
+        /// <summary>
+        /// Given a screen rectangle, capture the contents and return them
+        /// in an IBitmap object
+        /// </summary>
+        /// <param name="rect">The screen coordinates</param>
+        /// <returns>An IBitmap object containing the data.</returns>
+        IBitmap FromScreenRectangle(Rectangle rect);
+
+        /// <summary>
+        /// Given a System.Drawing.Bitmap object, create a corresponding IBitmap
+        /// object. This is not necessary for capture-only implementations, which
+        /// should simply throw a NotImplementedException
+        /// </summary>
+        /// <param name="bitmap">The System.Drawing.Bitmap object</param>
+        /// <returns>An IBitmap object containing equivalent data.</returns>
+        IBitmap FromSystemDrawingBitmap(Bitmap bitmap);
+    }
+}

--- a/src/SystemAbstractions/Abstractions/IBitmapCreator.cs
+++ b/src/SystemAbstractions/Abstractions/IBitmapCreator.cs
@@ -2,12 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Drawing;
-using System.IO;
 
 namespace Axe.Windows.SystemAbstractions
 {
     /// <summary>
-    /// Interface to encapsulate creation of IBitmap objects
+    /// Interface to encapsulate creation of IBitmap objects. To work correctly,
+    /// implementions of this interface MUST have a parameterless constructor
     /// </summary>
     public interface IBitmapCreator
     {

--- a/src/SystemAbstractions/Abstractions/IBitmapCreator.cs
+++ b/src/SystemAbstractions/Abstractions/IBitmapCreator.cs
@@ -7,7 +7,8 @@ namespace Axe.Windows.SystemAbstractions
 {
     /// <summary>
     /// Interface to encapsulate creation of IBitmap objects. To work correctly,
-    /// implementions of this interface MUST be public and have a parameterless constructor
+    /// implementations of this interface MUST be public and have a parameterless
+    /// constructor.
     /// </summary>
     public interface IBitmapCreator
     {

--- a/src/SystemAbstractions/Abstractions/IBitmapCreator.cs
+++ b/src/SystemAbstractions/Abstractions/IBitmapCreator.cs
@@ -7,7 +7,7 @@ namespace Axe.Windows.SystemAbstractions
 {
     /// <summary>
     /// Interface to encapsulate creation of IBitmap objects. To work correctly,
-    /// implementions of this interface MUST have a parameterless constructor
+    /// implementions of this interface MUST be public and have a parameterless constructor
     /// </summary>
     public interface IBitmapCreator
     {

--- a/src/SystemAbstractions/SystemAbstractions.csproj
+++ b/src/SystemAbstractions/SystemAbstractions.csproj
@@ -22,6 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
     <PackageReference Include="Text.Analyzers" Version="2.6.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
#### Details

We know that Windows 10X doesn't include GDIPlus.dll, which means that we can't rely on `System.Drawing.Bitmap` to represent the screen capture (the version in `System.Drawing.Common` is just a port of `System.Drawing` and still relies on GDIPlus.dll). Creating one-off screen capture tech isn't part of our charter, but we can create an abstraction that will allow others to implement screen capture if they desire. With that in mind, here are the basic steps in this PR:

1. Create a pair of interfaces to decouple screen captures from `System.Drawing.Bitmap`. These interfaces represent all of the `System.Drawing.Bitmap` functionality needed within the CLI's operation:
  -  `Axe.Windows.SystemAbstractions.IBitmapCreator` implements a `FromScreenRectangle` method, which returns an `Axe.Windows.SystemAbstractions.IBitmap` object.
  - `Axe.Windows.SystemAbstractions.IBitmap` implements a `SavePngToStream` method. 
2. Create a pair of classes (`Axe.Windows.Desktop.IBitmapCreator` and `Axe.Windows.Desktop.IBitmap`) to provide implementations of the abstractions, using `System.Drawing.Bitmap` inside the abstraction.
3. Replace the `System.Drawing.Bitmap` in the `DataContext` class with an `IBitmap`. 
4. Update other pieces in Axe.Windows to be able to accommodate the change in `DataContext`. This meant adding a new method to each of the interfaces--`IBitmap` gets a `ToSystemDrawingBitmap` method to expose a `System.Drawing.Bitmap` from an `IBitmap`, and `IBitmapCreator` gets a `FromSystemDrawingBitmap` method to create an `IBitmap` from a `System.Drawing.Bitmap`. Crucially, neither of these last 2 methods are used by the CLI.
5. Update the CLI to allow a user to specify an assembly that exposes a public implementation of `IBitmapCreator`. We then use reflection to find the implementation, create it, and use it for the screen capture.
6. (not in this PR). Because of the change in the `DataContext` class, we'll need to update AIWin to call `IBitmap.ToSystemDrawingBitmap` and `IBitmapCreator.FromSystemDrawingBitmap` in a few places.

##### Motivation

Enable Windows 10X team to implement screen capture as an independent component.

##### Context

The PrivacyExtensions create the "yellow box" screen representation that we currently use as a fallback when loading a file without a screenshot. I considered using `IBitmap` instead of `System.Drawing.Bitmap` within that class, but didn't like the result, and since this code is only used when _loading_ a file (i.e., not when creating it), I decided to keep `IBitmap` as small as possible.

As called out above, there will need to be a separate PR in AIWin when we pick up the version of Axe.Windows that contains these changes.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
