### PR TITLE
chore: Specify culture invariant

### DIFF
--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -5,6 +5,7 @@ using Axe.Windows.UnitTestSharedLibrary;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -159,7 +160,7 @@ namespace Axe.Windows.AutomationTests
             ProcessStartInfo startInfo = new ProcessStartInfo
             {
                 FileName = ValidationApp,
-                Arguments = string.Format(@"""{0}"" {1} {2}",
+                Arguments = string.Format(CultureInfo.InvariantCulture, @"""{0}"" {1} {2}",
                     scanResults.OutputFile.A11yTest, scanResults.ErrorCount, processId),
                 WorkingDirectory = ValidationAppFolder
             };

--- a/src/AutomationTests/OutputFileHelperUnitTests.cs
+++ b/src/AutomationTests/OutputFileHelperUnitTests.cs
@@ -5,6 +5,7 @@ using Axe.Windows.SystemAbstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
+using System.Globalization;
 using Path = System.IO.Path;
 
 namespace Axe.Windows.AutomationTests
@@ -86,7 +87,7 @@ namespace Axe.Windows.AutomationTests
             var phonyDirectory = "flub";
             Action action = () => new OutputFileHelper(phonyDirectory, mockSystem.Object);
             var ex = Assert.ThrowsException<AxeWindowsAutomationException>(action);
-            Assert.AreEqual(String.Format(DisplayStrings.ErrorDirectoryInvalid, phonyDirectory), ex.Message);
+            Assert.AreEqual(String.Format(CultureInfo.InvariantCulture, DisplayStrings.ErrorDirectoryInvalid, phonyDirectory), ex.Message);
 
             mockSystem.VerifyAll();
             mockIO.VerifyAll();

--- a/src/CLITests/OptionsUnitTests.cs
+++ b/src/CLITests/OptionsUnitTests.cs
@@ -5,6 +5,7 @@ using AxeWindowsCLI;
 using CommandLine;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace AxeWindowsCLITests
 {
@@ -64,7 +65,7 @@ namespace AxeWindowsCLITests
         [Timeout(1000)]
         public void ParseArguments_TargetByProcesssId_SucceedsWithCorrectProcessId()
         {
-            string[] args = { ProcessIdKey, TestProcessId.ToString() };
+            string[] args = { ProcessIdKey, TestProcessId.ToString(CultureInfo.InvariantCulture) };
 
             int parseResult = Parser.Default.ParseArguments<Options>(args)
                 .MapResult(

--- a/src/CLITests/OutputGeneratorUnitTests.cs
+++ b/src/CLITests/OutputGeneratorUnitTests.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 
 namespace AxeWindowsCLITests
@@ -242,7 +243,7 @@ namespace AxeWindowsCLITests
 
             for (int loop = 0; loop < propertyCount.Value; loop++)
             {
-                properties.Add(string.Format("Property{0}", loop), string.Format("Value{0}", loop));
+                properties.Add(string.Format(CultureInfo.InvariantCulture, "Property{0}", loop), string.Format(CultureInfo.InvariantCulture, "Value{0}", loop));
             }
 
             return properties;
@@ -257,7 +258,7 @@ namespace AxeWindowsCLITests
 
             for (int loop = 0; loop < patternCount.Value; loop++)
             {
-                patterns.Add(string.Format("Pattern{0}", loop));
+                patterns.Add(string.Format(CultureInfo.InvariantCulture, "Pattern{0}", loop));
             }
 
             return patterns;

--- a/src/Core/Bases/A11yPattern.cs
+++ b/src/Core/Bases/A11yPattern.cs
@@ -6,6 +6,7 @@ using Axe.Windows.Core.Types;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
@@ -143,7 +144,7 @@ namespace Axe.Windows.Core.Bases
 
         public override string ToString()
         {
-            return string.Format("{0}: {1}", this.Name, this.Properties.FirstOrDefault()?.Value);
+            return string.Format(CultureInfo.InvariantCulture, "{0}: {1}", this.Name, this.Properties.FirstOrDefault()?.Value);
         }
 
         #region IDisposable Support

--- a/src/Core/Bases/A11yPatternProperty.cs
+++ b/src/Core/Bases/A11yPatternProperty.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
+using System.Globalization;
 
 namespace Axe.Windows.Core.Bases
 {
@@ -19,10 +20,10 @@ namespace Axe.Windows.Core.Bases
             {
                 if (this.Value is string)
                 {
-                    return string.Format("{0} = \"{1}\"", this.Name, this.Value);
+                    return string.Format(CultureInfo.InvariantCulture, "{0} = \"{1}\"", this.Name, this.Value);
                 }
 
-                return string.Format("{0} = {1}", this.Name, this.Value);
+                return string.Format(CultureInfo.InvariantCulture, "{0} = {1}", this.Name, this.Value);
             }
         }
 

--- a/src/Core/Bases/A11yProperty.cs
+++ b/src/Core/Bases/A11yProperty.cs
@@ -5,6 +5,7 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.Win32;
 using Newtonsoft.Json;
 using System;
+using System.Globalization;
 
 namespace Axe.Windows.Core.Bases
 {
@@ -147,7 +148,7 @@ namespace Axe.Windows.Core.Bases
             if ((double)arr[2] < 0 || (double)arr[3] < 0)
             {
                 // the 3rd and 4th values in array are negative value, we need to show value in different format like l,t,w,h
-                text = string.Format("[l={0},t={1},w={2},h={3}]", arr[0], arr[1], arr[2], arr[3]);
+                text = string.Format(CultureInfo.InvariantCulture, "[l={0},t={1},w={2},h={3}]", arr[0], arr[1], arr[2], arr[3]);
             }
             else
             {

--- a/src/Core/Types/PatternType.cs
+++ b/src/Core/Types/PatternType.cs
@@ -80,7 +80,7 @@ namespace Axe.Windows.Core.Types
 
             sb.Replace("UIA_", "");
             sb.Replace("Id", "");
-            //sb.AppendFormat("({0})", id); // skip Id for now
+            // sb.Append(Invariant($" ({id})")); // skip id for now
 
             return sb.ToString();
         }

--- a/src/Core/Types/PlatformPropertyType.cs
+++ b/src/Core/Types/PlatformPropertyType.cs
@@ -51,7 +51,7 @@ namespace Axe.Windows.Core.Types
 
             sb.Replace("Platform_", "");
             sb.Replace("PropertyId", "");
-            //sb.AppendFormat("({0})", id);
+            // sb.Append(Invariant($" ({id})"));
 
             return sb.ToString();
         }

--- a/src/CurrentFileVersionCompatibilityTests/Assert.cs
+++ b/src/CurrentFileVersionCompatibilityTests/Assert.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Globalization;
 using System.IO;
 
 namespace CurrentFileVersionCompatibilityTests
@@ -16,6 +17,7 @@ namespace CurrentFileVersionCompatibilityTests
             if (expectedValue.Equals(actualValue))
             {
                 throw new InvalidDataException(string.Format(
+                    CultureInfo.InvariantCulture,
                     "Actual Value {0} must not match Value {1}",
                     actualValue, expectedValue));
             }
@@ -26,6 +28,7 @@ namespace CurrentFileVersionCompatibilityTests
             if (!expectedValue.Equals(actualValue))
             {
                 throw new InvalidDataException(string.Format(
+                    CultureInfo.InvariantCulture,
                     "Actual Value {0} must match Value {1}",
                     actualValue, expectedValue));
             }
@@ -44,6 +47,7 @@ namespace CurrentFileVersionCompatibilityTests
             if (actualValue != null)
             {
                 throw new InvalidDataException(string.Format(
+                    CultureInfo.InvariantCulture,
                     "Actual value {0} must be null", actualValue.ToString()));
             }
         }

--- a/src/Desktop/Styles/AnimationStyle.cs
+++ b/src/Desktop/Styles/AnimationStyle.cs
@@ -61,6 +61,7 @@ namespace Axe.Windows.Desktop.Styles
 
             sb.Replace(Prefix, "");
             sb.Append(Invariant($" ({id})"));
+
             return sb.ToString();
         }
     }

--- a/src/Desktop/Styles/BulletStyle.cs
+++ b/src/Desktop/Styles/BulletStyle.cs
@@ -60,6 +60,7 @@ namespace Axe.Windows.Desktop.Styles
 
             sb.Replace(Prefix, "");
             sb.Append(Invariant($" ({id})"));
+
             return sb.ToString();
         }
     }

--- a/src/Desktop/Styles/CapStyle.cs
+++ b/src/Desktop/Styles/CapStyle.cs
@@ -61,6 +61,7 @@ namespace Axe.Windows.Desktop.Styles
 
             sb.Replace(Prefix, "");
             sb.Append(Invariant($" ({id})"));
+
             return sb.ToString();
         }
     }

--- a/src/Desktop/UIAutomation/DesktopElement.cs
+++ b/src/Desktop/UIAutomation/DesktopElement.cs
@@ -6,6 +6,7 @@ using Axe.Windows.Telemetry;
 using Axe.Windows.Win32;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using UIAutomationClient;
 
@@ -126,7 +127,7 @@ namespace Axe.Windows.Desktop.UIAutomation
 
         private static string GetHeaderOfLabelBy(IUIAutomationElement e)
         {
-            return string.Format("{1} \"{0}\"", GetPropertyValue(e, PropertyType.UIA_NamePropertyId), GetPropertyValue(e, PropertyType.UIA_LocalizedControlTypePropertyId));
+            return string.Format(CultureInfo.InvariantCulture, "{1} \"{0}\"", GetPropertyValue(e, PropertyType.UIA_NamePropertyId), GetPropertyValue(e, PropertyType.UIA_LocalizedControlTypePropertyId));
         }
         #endregion
 


### PR DESCRIPTION
#### Details

Specify CultureInfo.InvariantCulture when rendering strings.

##### Motivation

This is part of the GlobalReadiness work for the compliance feature. Only 1 change (called out in the code) is likely to have any real impact to the shipping code.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
