### PR TITLE
feat(custom-uia): Load and validate custom properties from disk

### DIFF
--- a/src/Desktop/UIAutomation/CustomObjects/Config.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Config.cs
@@ -25,7 +25,8 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
         private void Validate()
         {
             if (this.Properties == null || this.Properties.Length < 1) throw new ArgumentException("Empty or missing definition of custom properties.");
-            foreach (CustomProperty p in this.Properties) p.Validate();
+            foreach (CustomProperty p in this.Properties) 
+                p.Validate();
         }
     }
 }

--- a/src/Desktop/UIAutomation/CustomObjects/Config.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Config.cs
@@ -12,7 +12,7 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
         [JsonProperty("properties")]
         public CustomProperty[] Properties { get; set; }
 
-        public static Config FromText(string text)
+        public static Config ReadFromText(string text)
         {
             Config conf = JsonConvert.DeserializeObject<Config>(text);
             conf.Validate();
@@ -20,12 +20,12 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
             return conf;
         }
 
-        public static Config FromFile(string path) { return Config.FromText(File.ReadAllText(path)); }
+        public static Config ReadFromFile(string path) { return Config.ReadFromText(File.ReadAllText(path)); }
 
         private void Validate()
         {
-            if (this.Properties == null || this.Properties.Length < 1) throw new ArgumentException("Empty or missing definition of custom properties.");
-            foreach (CustomProperty p in this.Properties) 
+            if (Properties == null || Properties.Length < 1) throw new ArgumentException("Empty or missing definition of custom properties.");
+            foreach (CustomProperty p in Properties) 
                 p.Validate();
         }
     }

--- a/src/Desktop/UIAutomation/CustomObjects/Config.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Config.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+using System;
+using System.IO;
+
+namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
+{
+    class Config
+    {
+        [JsonProperty("properties")]
+        public CustomProperty[] Properties { get; set; }
+
+        public static Config FromText(string text)
+        {
+            Config conf = JsonConvert.DeserializeObject<Config>(text);
+            conf.Validate();
+            // We made it here, so config must be valid.
+            return conf;
+        }
+
+        public static Config FromFile(string path) { return Config.FromText(File.ReadAllText(path)); }
+
+        private void Validate()
+        {
+            if (this.Properties == null || this.Properties.Length < 1) throw new ArgumentException("Empty or missing definition of custom properties.");
+            foreach (CustomProperty p in this.Properties) p.Validate();
+        }
+    }
+}

--- a/src/Desktop/UIAutomation/CustomObjects/Config.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Config.cs
@@ -25,7 +25,7 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
 
         private void Validate()
         {
-            if (Properties == null || !Properties.Any()) throw new ArgumentException("Empty or missing definition of custom properties.");
+            if (Properties == null || !Properties.Any()) throw new InvalidDataException("Empty or missing definition of custom properties.");
             foreach (CustomProperty p in Properties) 
                 p.Validate();
         }

--- a/src/Desktop/UIAutomation/CustomObjects/Config.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Config.cs
@@ -4,6 +4,7 @@
 using Newtonsoft.Json;
 using System;
 using System.IO;
+using System.Linq;
 
 namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
 {
@@ -24,7 +25,7 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
 
         private void Validate()
         {
-            if (Properties == null || Properties.Length < 1) throw new ArgumentException("Empty or missing definition of custom properties.");
+            if (Properties == null || !Properties.Any()) throw new ArgumentException("Empty or missing definition of custom properties.");
             foreach (CustomProperty p in Properties) 
                 p.Validate();
         }

--- a/src/Desktop/UIAutomation/CustomObjects/CustomProperty.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/CustomProperty.cs
@@ -10,9 +10,9 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
     {
         /// <summary>The RFC4122 globally unique identifier of this property.</summary>
         [JsonProperty("guid")]
-        #pragma warning disable CA1720 // Identifier contains type name: name from JSON
+#pragma warning disable CA1720 // Identifier contains type name: name from JSON
         public Guid Guid { get; set; }
-        #pragma warning restore CA1720 // Identifier contains type name: name from JSON
+#pragma warning restore CA1720 // Identifier contains type name: name from JSON
         /// <summary>A textual description of this property.</summary>
         [JsonProperty("programmaticName")]
         public string ProgrammaticName { get; set; }
@@ -20,7 +20,7 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
         /// <summary>The data type of this property's value as specified by the user, one of string, int, bool, double, point, or element.</summary>
         // TODO Bill: add enum (with values member)
         [JsonProperty("uiaType")]
-        public string UserType { get; set; }
+        public string DataType { get; set; }
 
         /// <summary>The dynamic ID assigned to this property by the system.</summary>
         [JsonIgnore]
@@ -30,8 +30,13 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
         {
             if (Guid == Guid.Empty) throw new ArgumentException("Missing GUID in custom property definition.");
             if (ProgrammaticName == null) throw new ArgumentException("Missing programmatic name in custom property definition.");
-            if (UserType == null) throw new ArgumentException("Missing type in custom property definition.");
-            switch (UserType)
+            if (DataType == null) throw new ArgumentException("Missing type in custom property definition.");
+            ValidateType();
+        }
+
+        internal void ValidateType()
+        {
+            switch (DataType)
             {
                 case "string":
                     // Valid type, further processing in a subsequent PR.
@@ -52,7 +57,7 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
                     // Valid type, further processing in a subsequent PR.
                     break;
                 default:
-                    throw new ArgumentException($"Unknown type {this.UserType}.");
+                    throw new ArgumentException($"Unknown type {this.DataType}.");
             }
         }
     }

--- a/src/Desktop/UIAutomation/CustomObjects/CustomProperty.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/CustomProperty.cs
@@ -3,6 +3,7 @@
 
 using Newtonsoft.Json;
 using System;
+using System.IO;
 
 namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
 {
@@ -28,9 +29,9 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
 
         internal void Validate()
         {
-            if (Guid == Guid.Empty) throw new ArgumentException("Missing GUID in custom property definition.");
-            if (ProgrammaticName == null) throw new ArgumentException("Missing programmatic name in custom property definition.");
-            if (DataType == null) throw new ArgumentException("Missing type in custom property definition.");
+            if (Guid == Guid.Empty) throw new InvalidDataException("Missing GUID in custom property definition.");
+            if (ProgrammaticName == null) throw new InvalidDataException("Missing programmatic name in custom property definition.");
+            if (DataType == null) throw new InvalidDataException("Missing type in custom property definition.");
             ValidateType();
         }
 
@@ -57,7 +58,7 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
                     // Valid type, further processing in a subsequent PR.
                     break;
                 default:
-                    throw new ArgumentException($"Unknown type {this.DataType}.");
+                    throw new InvalidDataException($"Unknown type {DataType}.");
             }
         }
     }

--- a/src/Desktop/UIAutomation/CustomObjects/CustomProperty.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/CustomProperty.cs
@@ -11,7 +11,7 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
         /// <summary>The RFC4122 globally unique identifier of this property.</summary>
         [JsonProperty("guid")]
         #pragma warning disable CA1720 // Identifier contains type name: name from JSON
-        public Guid? Guid { get; set; }
+        public Guid Guid { get; set; }
         #pragma warning restore CA1720 // Identifier contains type name: name from JSON
         /// <summary>A textual description of this property.</summary>
         [JsonProperty("programmaticName")]
@@ -28,7 +28,7 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
 
         internal void Validate()
         {
-            if (Guid == null) throw new ArgumentException("Missing GUID in custom property definition.");
+            if (Guid == Guid.Empty) throw new ArgumentException("Missing GUID in custom property definition.");
             if (ProgrammaticName == null) throw new ArgumentException("Missing programmatic name in custom property definition.");
             if (UserType == null) throw new ArgumentException("Missing type in custom property definition.");
             switch (UserType)

--- a/src/Desktop/UIAutomation/CustomObjects/CustomProperty.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/CustomProperty.cs
@@ -28,10 +28,10 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
 
         internal void Validate()
         {
-            if (this.Guid == null) throw new ArgumentException("Missing GUID in custom property definition.");
-            if (this.ProgrammaticName == null) throw new ArgumentException("Missing programmatic name in custom property definition.");
-            if (this.UserType == null) throw new ArgumentException("Missing type in custom property definition.");
-            switch (this.UserType)
+            if (Guid == null) throw new ArgumentException("Missing GUID in custom property definition.");
+            if (ProgrammaticName == null) throw new ArgumentException("Missing programmatic name in custom property definition.");
+            if (UserType == null) throw new ArgumentException("Missing type in custom property definition.");
+            switch (UserType)
             {
                 case "string":
                     // Valid type, further processing in a subsequent PR.

--- a/src/Desktop/UIAutomation/CustomObjects/CustomProperty.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/CustomProperty.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+using System;
+
+namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
+{
+    public class CustomProperty
+    {
+        /// <summary>The RFC4122 globally unique identifier of this property.</summary>
+        [JsonProperty("guid")]
+        #pragma warning disable CA1720 // Identifier contains type name: name from JSON
+        public Guid? Guid { get; set; }
+        #pragma warning restore CA1720 // Identifier contains type name: name from JSON
+        /// <summary>A textual description of this property.</summary>
+        [JsonProperty("programmaticName")]
+        public string ProgrammaticName { get; set; }
+
+        /// <summary>The data type of this property's value as specified by the user, one of string, int, bool, double, point, or element.</summary>
+        // TODO Bill: add enum (with values member)
+        [JsonProperty("uiaType")]
+        public string UserType { get; set; }
+
+        /// <summary>The dynamic ID assigned to this property by the system.</summary>
+        [JsonIgnore]
+        public int DynamicId { get; set; }
+
+        internal void Validate()
+        {
+            if (this.Guid == null) throw new ArgumentException("Missing GUID in custom property definition.");
+            if (this.ProgrammaticName == null) throw new ArgumentException("Missing programmatic name in custom property definition.");
+            if (this.UserType == null) throw new ArgumentException("Missing type in custom property definition.");
+            switch (this.UserType)
+            {
+                case "string":
+                    // Valid type, further processing in a subsequent PR.
+                    break;
+                case "int":
+                    // Valid type, further processing in a subsequent PR.
+                    break;
+                case "bool":
+                    // Valid type, further processing in a subsequent PR.
+                    break;
+                case "double":
+                    // Valid type, further processing in a subsequent PR.
+                    break;
+                case "point":
+                    // Valid type, further processing in a subsequent PR.
+                    break;
+                case "element":
+                    // Valid type, further processing in a subsequent PR.
+                    break;
+                default:
+                    throw new ArgumentException($"Unknown type {this.UserType}.");
+            }
+        }
+    }
+}

--- a/src/DesktopTests/UIAutomation/CustomObjects/ConfigTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/ConfigTests.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
             CustomProperty prop = conf.Properties[0];
             Assert.AreEqual(new Guid("4BB56516-F354-44CF-A5AA-96B52E968CFD"), prop.Guid);
             Assert.AreEqual("AreGridlinesVisible", prop.ProgrammaticName);
-            Assert.AreEqual("bool", prop.UserType);
+            Assert.AreEqual("bool", prop.DataType);
         }
 
         [TestMethod, Timeout(1000)]

--- a/src/DesktopTests/UIAutomation/CustomObjects/ConfigTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/ConfigTests.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Desktop.UIAutomation.CustomObjects;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
+{
+    [TestClass()]
+    public class ConfigTests
+    {
+        [TestMethod, Timeout(1000)]
+        public void SimpleConfigTest()
+        {
+            const string SimpleConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"programmaticName\": \"AreGridlinesVisible\", \"uiaType\": \"bool\"}]}";
+            Config conf = Config.FromText(SimpleConfig);
+            Assert.AreEqual(1, conf.Properties.Length);
+            CustomProperty prop = conf.Properties[0];
+            Assert.AreEqual(new Guid("4BB56516-F354-44CF-A5AA-96B52E968CFD"), prop.Guid);
+            Assert.AreEqual("AreGridlinesVisible", prop.ProgrammaticName);
+            Assert.AreEqual("bool", prop.UserType);
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void EmptyConfigTest()
+        {
+            Assert.ThrowsException<ArgumentException>(() => Config.FromText("{}"));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void BadGuidConfigTest()
+        {
+            const string BadGuidConfig = "{\"properties\": [{\"guid\": \"1999-10-22\", \"programmaticName\": \"AreGridlinesVisible\", \"uiaType\": \"bool\"}]}";
+            try
+            {
+                Config.FromText(BadGuidConfig);
+                Assert.Fail("Failed to throw exception.");
+            }
+            catch (Exception) { }
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void BadTypeConfigTest()
+        {
+            const string BadTypeConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"programmaticName\": \"AreGridlinesVisible\", \"uiaType\": \"Excel\"}]}";
+            Assert.ThrowsException<ArgumentException>(() => Config.FromText(BadTypeConfig));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void MissingGuidConfigTest()
+        {
+            const string MissingGuidConfig = "{\"properties\": [{\"programmaticName\": \"AreGridlinesVisible\", \"uiaType\": \"bool\"}]}";
+            Assert.ThrowsException<ArgumentException>(() => Config.FromText(MissingGuidConfig));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void MissingNameConfigTest()
+        {
+            const string MissingNameConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"uiaType\": \"bool\"}]}";
+            Assert.ThrowsException<ArgumentException>(() => Config.FromText(MissingNameConfig));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void MissingTypeConfigTest()
+        {
+            const string MissingTypeConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"programmaticName\": \"AreGridlinesVisible\"}]}";
+            Assert.ThrowsException<ArgumentException>(() => Config.FromText(MissingTypeConfig));
+        }
+    }
+}

--- a/src/DesktopTests/UIAutomation/CustomObjects/ConfigTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/ConfigTests.cs
@@ -4,6 +4,7 @@
 using Axe.Windows.Desktop.UIAutomation.CustomObjects;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.IO;
 
 namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
 {
@@ -25,7 +26,29 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
         [TestMethod, Timeout(1000)]
         public void EmptyConfigTest()
         {
-            Assert.ThrowsException<ArgumentException>(() => Config.ReadFromText("{}"));
+            Assert.ThrowsException<InvalidDataException>(() => Config.ReadFromText("{}"));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void NullConfigTest()
+        {
+            try
+            {
+                Config.ReadFromText(null);
+                Assert.Fail("Failed to throw exception.");
+            }
+            catch (Exception) { }
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void EmptyStringConfigTest()
+        {
+            try
+            {
+                Config.ReadFromText(String.Empty);
+                Assert.Fail("Failed to throw exception.");
+            }
+            catch (Exception) { }
         }
 
         [TestMethod, Timeout(1000)]
@@ -44,28 +67,28 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
         public void BadTypeConfigTest()
         {
             const string BadTypeConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"programmaticName\": \"AreGridlinesVisible\", \"uiaType\": \"Excel\"}]}";
-            Assert.ThrowsException<ArgumentException>(() => Config.ReadFromText(BadTypeConfig));
+            Assert.ThrowsException<InvalidDataException>(() => Config.ReadFromText(BadTypeConfig));
         }
 
         [TestMethod, Timeout(1000)]
         public void MissingGuidConfigTest()
         {
             const string MissingGuidConfig = "{\"properties\": [{\"programmaticName\": \"AreGridlinesVisible\", \"uiaType\": \"bool\"}]}";
-            Assert.ThrowsException<ArgumentException>(() => Config.ReadFromText(MissingGuidConfig));
+            Assert.ThrowsException<InvalidDataException>(() => Config.ReadFromText(MissingGuidConfig));
         }
 
         [TestMethod, Timeout(1000)]
         public void MissingNameConfigTest()
         {
             const string MissingNameConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"uiaType\": \"bool\"}]}";
-            Assert.ThrowsException<ArgumentException>(() => Config.ReadFromText(MissingNameConfig));
+            Assert.ThrowsException<InvalidDataException>(() => Config.ReadFromText(MissingNameConfig));
         }
 
         [TestMethod, Timeout(1000)]
         public void MissingTypeConfigTest()
         {
             const string MissingTypeConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"programmaticName\": \"AreGridlinesVisible\"}]}";
-            Assert.ThrowsException<ArgumentException>(() => Config.ReadFromText(MissingTypeConfig));
+            Assert.ThrowsException<InvalidDataException>(() => Config.ReadFromText(MissingTypeConfig));
         }
     }
 }

--- a/src/DesktopTests/UIAutomation/CustomObjects/ConfigTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/ConfigTests.cs
@@ -14,7 +14,7 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
         public void SimpleConfigTest()
         {
             const string SimpleConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"programmaticName\": \"AreGridlinesVisible\", \"uiaType\": \"bool\"}]}";
-            Config conf = Config.FromText(SimpleConfig);
+            Config conf = Config.ReadFromText(SimpleConfig);
             Assert.AreEqual(1, conf.Properties.Length);
             CustomProperty prop = conf.Properties[0];
             Assert.AreEqual(new Guid("4BB56516-F354-44CF-A5AA-96B52E968CFD"), prop.Guid);
@@ -25,7 +25,7 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
         [TestMethod, Timeout(1000)]
         public void EmptyConfigTest()
         {
-            Assert.ThrowsException<ArgumentException>(() => Config.FromText("{}"));
+            Assert.ThrowsException<ArgumentException>(() => Config.ReadFromText("{}"));
         }
 
         [TestMethod, Timeout(1000)]
@@ -34,7 +34,7 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
             const string BadGuidConfig = "{\"properties\": [{\"guid\": \"1999-10-22\", \"programmaticName\": \"AreGridlinesVisible\", \"uiaType\": \"bool\"}]}";
             try
             {
-                Config.FromText(BadGuidConfig);
+                Config.ReadFromText(BadGuidConfig);
                 Assert.Fail("Failed to throw exception.");
             }
             catch (Exception) { }
@@ -44,28 +44,28 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
         public void BadTypeConfigTest()
         {
             const string BadTypeConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"programmaticName\": \"AreGridlinesVisible\", \"uiaType\": \"Excel\"}]}";
-            Assert.ThrowsException<ArgumentException>(() => Config.FromText(BadTypeConfig));
+            Assert.ThrowsException<ArgumentException>(() => Config.ReadFromText(BadTypeConfig));
         }
 
         [TestMethod, Timeout(1000)]
         public void MissingGuidConfigTest()
         {
             const string MissingGuidConfig = "{\"properties\": [{\"programmaticName\": \"AreGridlinesVisible\", \"uiaType\": \"bool\"}]}";
-            Assert.ThrowsException<ArgumentException>(() => Config.FromText(MissingGuidConfig));
+            Assert.ThrowsException<ArgumentException>(() => Config.ReadFromText(MissingGuidConfig));
         }
 
         [TestMethod, Timeout(1000)]
         public void MissingNameConfigTest()
         {
             const string MissingNameConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"uiaType\": \"bool\"}]}";
-            Assert.ThrowsException<ArgumentException>(() => Config.FromText(MissingNameConfig));
+            Assert.ThrowsException<ArgumentException>(() => Config.ReadFromText(MissingNameConfig));
         }
 
         [TestMethod, Timeout(1000)]
         public void MissingTypeConfigTest()
         {
             const string MissingTypeConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"programmaticName\": \"AreGridlinesVisible\"}]}";
-            Assert.ThrowsException<ArgumentException>(() => Config.FromText(MissingTypeConfig));
+            Assert.ThrowsException<ArgumentException>(() => Config.ReadFromText(MissingTypeConfig));
         }
     }
 }


### PR DESCRIPTION
#### Details
This PR adds classes and unit tests for reading and validating custom UIA properties defined in JSON according to the specification defined in #587.

##### Motivation
Part of feature 1845247 (internal access required to view).

##### Context
Later PRs to handle the "enum" type, custom property registration, and data rendering.

This PR assumes that a non-empty "properties" collection will *always* be defined. This might not be the case if custom annotations/patterns are later added, so this constraint may need to be relaxed later (and `EmptyConfigTest` possibly updated to reflect this).

#### Pull request checklist
- [ ] Addresses an existing issue: #0000: N/A