### PR TITLE
chore: minor refactor of how trackers remember selection

### DIFF
--- a/src/Actions/Trackers/BaseTracker.cs
+++ b/src/Actions/Trackers/BaseTracker.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Actions.Enums;
 using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Misc;
 using Axe.Windows.Desktop.UIAutomation;
 using System;
 using System.Drawing;
@@ -22,10 +23,10 @@ namespace Axe.Windows.Actions.Trackers
         /// <summary>
         /// keep track the Selected element RuntimeId
         /// </summary>
-        internal string SelectedElementRuntimeId;
-        internal Rectangle? SelectedBoundingRectangle;
-        internal int SelectedControlTypeId;
-        internal string SelectedName;
+        private string SelectedElementRuntimeId;
+        private Rectangle? SelectedBoundingRectangle;
+        private int SelectedControlTypeId;
+        private string SelectedName;
 
         /// <summary>
         /// Set the scope of selection
@@ -81,6 +82,28 @@ namespace Axe.Windows.Actions.Trackers
             }
 
             return e;
+        }
+
+        /// <summary>
+        /// Select the specified element if it meets all eligibilty requirements
+        /// </summary>
+        /// <param name="element">The potential element to select</param>
+        /// <param name="trackerSpecificCheck">A tracker-specific check that returns true if the element is eligible</param>
+        /// <returns>true if the element was selected</returns>
+        protected bool SelectElementIfItIsEligible(A11yElement element, Func<A11yElement, bool> trackerSpecificCheck)
+        {
+            if (element != null && !element.IsRootElement()
+                && (trackerSpecificCheck == null || trackerSpecificCheck(element))
+                && !element.IsSameUIElement(SelectedElementRuntimeId, SelectedBoundingRectangle, SelectedControlTypeId, SelectedName))
+            {
+                SelectedElementRuntimeId = element.RuntimeId;
+                SelectedBoundingRectangle = element.BoundingRectangle;
+                SelectedControlTypeId = element.ControlTypeId;
+                SelectedName = element.Name;
+                SetElement?.Invoke(element);
+                return true;
+            }
+            return false;
         }
 
         /// <summary>

--- a/src/Actions/Trackers/BaseTracker.cs
+++ b/src/Actions/Trackers/BaseTracker.cs
@@ -88,12 +88,10 @@ namespace Axe.Windows.Actions.Trackers
         /// Select the specified element if it meets all eligibilty requirements
         /// </summary>
         /// <param name="element">The potential element to select</param>
-        /// <param name="trackerSpecificCheck">A tracker-specific check that returns true if the element is eligible</param>
         /// <returns>true if the element was selected</returns>
-        protected bool SelectElementIfItIsEligible(A11yElement element, Func<A11yElement, bool> trackerSpecificCheck)
+        protected bool SelectElementIfItIsEligible(A11yElement element)
         {
             if (element != null && !element.IsRootElement()
-                && (trackerSpecificCheck == null || trackerSpecificCheck(element))
                 && !element.IsSameUIElement(SelectedElementRuntimeId, SelectedBoundingRectangle, SelectedControlTypeId, SelectedName))
             {
                 SelectedElementRuntimeId = element.RuntimeId;

--- a/src/Actions/Trackers/FocusTracker.cs
+++ b/src/Actions/Trackers/FocusTracker.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
-using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.Types;
 using Axe.Windows.Desktop.UIAutomation.EventHandlers;
@@ -67,17 +66,7 @@ namespace Axe.Windows.Actions.Trackers
                 if (IsStarted && message.Element != null)
                 {
                     var element = GetElementBasedOnScope(message.Element);
-
-                    if( element != null && element.IsRootElement() == false
-                        && element.ControlTypeId != ControlType.UIA_ToolTipControlTypeId
-                        && element.IsSameUIElement(this.SelectedElementRuntimeId, this.SelectedBoundingRectangle, this.SelectedControlTypeId, this.SelectedName) == false)
-                    {
-                        this.SelectedElementRuntimeId = element.RuntimeId;
-                        this.SelectedBoundingRectangle = element.BoundingRectangle;
-                        this.SelectedControlTypeId = element.ControlTypeId;
-                        this.SelectedName = element.Name;
-                        this.SetElement?.Invoke(element);
-                    }
+                    SelectElementIfItIsEligible(element, e => e.ControlTypeId != ControlType.UIA_ToolTipControlTypeId);
                 }
                 else
                 {

--- a/src/Actions/Trackers/FocusTracker.cs
+++ b/src/Actions/Trackers/FocusTracker.cs
@@ -66,7 +66,10 @@ namespace Axe.Windows.Actions.Trackers
                 if (IsStarted && message.Element != null)
                 {
                     var element = GetElementBasedOnScope(message.Element);
-                    SelectElementIfItIsEligible(element, e => e.ControlTypeId != ControlType.UIA_ToolTipControlTypeId);
+                    if (element?.ControlTypeId != ControlType.UIA_ToolTipControlTypeId)
+                    {
+                        SelectElementIfItIsEligible(element);
+                    }
                 }
                 else
                 {

--- a/src/Actions/Trackers/MouseTracker.cs
+++ b/src/Actions/Trackers/MouseTracker.cs
@@ -114,7 +114,7 @@ namespace Axe.Windows.Actions.Trackers
                     if (LastMousePoint.Equals(p) && !this.POIPoint.Equals(p))
                     {
                         var element = GetElementBasedOnScope(A11yAutomation.NormalizedElementFromPoint(p.X, p.Y, this.TreeViewMode));
-                        if (!SelectElementIfItIsEligible(element, null))
+                        if (!SelectElementIfItIsEligible(element))
                         {
                             element?.Dispose();
                         }

--- a/src/Actions/Trackers/MouseTracker.cs
+++ b/src/Actions/Trackers/MouseTracker.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
-using Axe.Windows.Core.Misc;
 using Axe.Windows.Desktop.UIAutomation;
 using Axe.Windows.Win32;
 using System;
@@ -112,24 +111,13 @@ namespace Axe.Windows.Actions.Trackers
                 {
                     NativeMethods.GetCursorPos(out Point p);
 
-                    if (LastMousePoint.Equals(p) && this.POIPoint.Equals(p) == false)
+                    if (LastMousePoint.Equals(p) && !this.POIPoint.Equals(p))
                     {
                         var element = GetElementBasedOnScope(A11yAutomation.NormalizedElementFromPoint(p.X, p.Y, this.TreeViewMode));
-
-                        if (element != null && element.IsRootElement() == false && element.IsSameUIElement(this.SelectedElementRuntimeId, this.SelectedBoundingRectangle, this.SelectedControlTypeId, this.SelectedName) == false && !POIPoint.Equals(p))
-                        {
-                            this.SelectedElementRuntimeId = element.RuntimeId;
-                            this.SelectedBoundingRectangle = element.BoundingRectangle;
-                            this.SelectedControlTypeId = element.ControlTypeId;
-                            this.SelectedName = element.Name;
-                            this.SetElement?.Invoke(element);
-                        }
-                        else
+                        if (!SelectElementIfItIsEligible(element, null))
                         {
                             element?.Dispose();
-                            element = null;
                         }
-
                         POIPoint = p;
                     }
 


### PR DESCRIPTION
#### Details

MouseTracker.cs and FocusTracker.cs have some commonality in how they remember the selected element, but different code to implement it. This does the following:

* It brings the common code into a single location
* It allows the fields that track the selected state to become private instead of internal
* It converts some code from `condition == false` to `!condition`, which is handy for long lines
* It removes some unneeded code from MouseTracker (one check was performed twice, and we needlessly set `element` to null at the end)

##### Motivation

Improved clarity and encapsulation. I had to debug the MouseTracker code today and it took longer than it should have to discern the intent of the code.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
I considered renaming the now-private fields in BaseTracker to the underscore syntax, but thought it would be simpler to compare without it.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
