### PR TITLE
chore: Add Interop.UIAutomationCore from NuGet package

### DIFF
--- a/src/Desktop/Desktop.csproj
+++ b/src/Desktop/Desktop.csproj
@@ -9,6 +9,7 @@
   <Import Project="..\..\build\NetStandardRelease.targets" />
 
   <ItemGroup>
+    <PackageReference Include="Interop.UIAutomationCore" Version="10.19041.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Desktop/Desktop.csproj
+++ b/src/Desktop/Desktop.csproj
@@ -43,6 +43,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="Interop.UIAutomationCore">
+      <HintPath>Interop.UIAutomationCore.dll</HintPath>
+      <EmbedInteropTypes>true</EmbedInteropTypes>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Update="Resources\ErrorMessages.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -9,21 +9,21 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
 {
     public class Registrar : IDisposable
     {
-        CUIAutomationRegistrarClass _uiaRegistrar = new CUIAutomationRegistrarClass();
+        CUIAutomationRegistrar _uiaRegistrar = new CUIAutomationRegistrar();
         private bool disposedValue;
 
-        public int Test()
+        public int RegisterCustomProperty(Guid id, string name, UIAutomationType type)
         {
             UIAutomationPropertyInfo info = new UIAutomationPropertyInfo
             {
-                guid = Guid.Empty,
-                pProgrammaticName = "Some property",
-                type = UIAutomationType.UIAutomationType_Bool,
+                guid = id,
+                pProgrammaticName = name,
+                type = type,
             };
 
-            _uiaRegistrar.RegisterProperty(ref info, out int dynamicProperty);
+            _uiaRegistrar.RegisterProperty(ref info, out int dynamicId);
 
-            return dynamicProperty;
+            return dynamicId;
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -1,4 +1,7 @@
-﻿using Interop.UIAutomationCore;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Interop.UIAutomationCore;
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -1,0 +1,56 @@
+﻿using Interop.UIAutomationCore;
+using System;
+using System.Runtime.InteropServices;
+
+namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
+{
+    public class Registrar : IDisposable
+    {
+        CUIAutomationRegistrarClass _uiaRegistrar = new CUIAutomationRegistrarClass();
+        private bool disposedValue;
+
+        public int Test()
+        {
+            UIAutomationPropertyInfo info = new UIAutomationPropertyInfo
+            {
+                guid = Guid.Empty,
+                pProgrammaticName = "Some property",
+                type = UIAutomationType.UIAutomationType_Bool,
+            };
+
+            _uiaRegistrar.RegisterProperty(ref info, out int dynamicProperty);
+
+            return dynamicProperty;
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects)
+                }
+
+                // Free unmanaged resources (unmanaged objects) and set large fields to null
+                Marshal.ReleaseComObject(_uiaRegistrar);
+                _uiaRegistrar = null;
+
+                disposedValue = true;
+            }
+        }
+
+        ~Registrar()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: false);
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Desktop.UIAutomation.CustomObjects;
+using Interop.UIAutomationCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
+{
+    [TestClass]
+    public class RegistrarTests
+    {
+        // Note: We normally avoid Guid.NewGuid() to make tests more consistently reproducible. This class
+        // intentionally uses Guid.NewGuid to reduce the risk of the UIA state contamination between test runs.
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void RegisterCustomProperty_ReturnsNonZeroValue()
+        {
+            using (Registrar r = new Registrar())
+            {
+                int dynamicId = r.RegisterCustomProperty(Guid.NewGuid(), "This is a name", UIAutomationType.UIAutomationType_Double);
+                Assert.AreNotEqual(0, dynamicId);
+            }
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void RegisterCustomProperty_SamePropertyTwise_ReturnsSameNonZeroValue()
+        {
+            using (Registrar r = new Registrar())
+            {
+                Guid id = Guid.NewGuid();
+                const string name = "My property name";
+                const UIAutomationType type = UIAutomationType.UIAutomationType_Bool;
+
+                int dynamicId1 = r.RegisterCustomProperty(id, name, type);
+                int dynamicId2 = r.RegisterCustomProperty(id, name, type);
+                Assert.AreNotEqual(0, dynamicId1);
+                Assert.AreEqual(dynamicId1, dynamicId2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Details

Consume an interop assembly from a NuGet package. Includes a class that calls into the interop, just as a POC. We embed the interop so we don't change our set of files, and unit tests exercise the interop and ensure that it works as expected, including proper disposal of the `CUIAutomationRegistrar` object.

##### Motivation

Provide a sustainable way to consume the needed interop from a NuGet package. This Interop is MIT licensed and comes from https://github.com/FlaUI/UIAutomation-Interop. It's been published 4 times since 2019, so it's reasonably well supported (and we could incorporate it into our repo should we ever have a need).

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
