### PR TITLE
feat(custom-uia): add "type converters" for rendering and registration

### DIFF
--- a/src/Desktop/UIAutomation/CustomObjects/Converters/BoolTypeConverter.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Converters/BoolTypeConverter.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Interop.UIAutomationCore;
+using System;
+using System.Globalization;
+
+namespace Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters
+{
+    class BoolTypeConverter : ITypeConverter
+    {
+        public UIAutomationType UnderlyingUiaType => UIAutomationType.UIAutomationType_Bool;
+
+        public string Render(dynamic value)
+        {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+            return ((bool)value).ToString(CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/src/Desktop/UIAutomation/CustomObjects/Converters/BoolTypeConverter.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Converters/BoolTypeConverter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Interop.UIAutomationCore;
 using System;
 using System.Globalization;
 
@@ -9,8 +8,6 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters
 {
     class BoolTypeConverter : ITypeConverter
     {
-        public UIAutomationType UnderlyingUiaType => UIAutomationType.UIAutomationType_Bool;
-
         public string Render(dynamic value)
         {
             if (value == null) throw new ArgumentNullException(nameof(value));

--- a/src/Desktop/UIAutomation/CustomObjects/Converters/DoubleTypeConverter.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Converters/DoubleTypeConverter.cs
@@ -12,7 +12,6 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters
         {
             if (value == null) throw new ArgumentNullException(nameof(value));
             return ((double)value).ToString(CultureInfo.InvariantCulture);
-
         }
     }
 }

--- a/src/Desktop/UIAutomation/CustomObjects/Converters/DoubleTypeConverter.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Converters/DoubleTypeConverter.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Interop.UIAutomationCore;
+using System;
+using System.Globalization;
+
+namespace Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters
+{
+    class DoubleTypeConverter : ITypeConverter
+    {
+        public UIAutomationType UnderlyingUiaType => UIAutomationType.UIAutomationType_Double;
+
+        public string Render(dynamic value)
+        {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+            return ((double)value).ToString(CultureInfo.InvariantCulture);
+
+        }
+    }
+}

--- a/src/Desktop/UIAutomation/CustomObjects/Converters/DoubleTypeConverter.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Converters/DoubleTypeConverter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Interop.UIAutomationCore;
 using System;
 using System.Globalization;
 
@@ -9,8 +8,6 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters
 {
     class DoubleTypeConverter : ITypeConverter
     {
-        public UIAutomationType UnderlyingUiaType => UIAutomationType.UIAutomationType_Double;
-
         public string Render(dynamic value)
         {
             if (value == null) throw new ArgumentNullException(nameof(value));

--- a/src/Desktop/UIAutomation/CustomObjects/Converters/ElementTypeConverter.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Converters/ElementTypeConverter.cs
@@ -2,15 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Core.Bases;
-using Interop.UIAutomationCore;
 using System;
 
 namespace Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters
 {
     class ElementTypeConverter : ITypeConverter
     {
-        public UIAutomationType UnderlyingUiaType => UIAutomationType.UIAutomationType_Element;
-
         public string Render(dynamic value)
         {
             if (value == null) throw new ArgumentNullException(nameof(value));

--- a/src/Desktop/UIAutomation/CustomObjects/Converters/ElementTypeConverter.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Converters/ElementTypeConverter.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Core.Bases;
+using Interop.UIAutomationCore;
+using System;
+
+namespace Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters
+{
+    class ElementTypeConverter : ITypeConverter
+    {
+        public UIAutomationType UnderlyingUiaType => UIAutomationType.UIAutomationType_Element;
+
+        public string Render(dynamic value)
+        {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+            return ((A11yElement)value).Glimpse;
+        }
+    }
+}

--- a/src/Desktop/UIAutomation/CustomObjects/Converters/ITypeConverter.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Converters/ITypeConverter.cs
@@ -1,14 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Interop.UIAutomationCore;
-
 namespace Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters
 {
     public interface ITypeConverter
     {
-        UIAutomationType UnderlyingUiaType { get; }
-
         string Render(dynamic value);
     }
 }

--- a/src/Desktop/UIAutomation/CustomObjects/Converters/ITypeConverter.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Converters/ITypeConverter.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Interop.UIAutomationCore;
+
+namespace Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters
+{
+    public interface ITypeConverter
+    {
+        UIAutomationType UnderlyingUiaType { get; }
+
+        string Render(dynamic value);
+    }
+}

--- a/src/Desktop/UIAutomation/CustomObjects/Converters/IntTypeConverter.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Converters/IntTypeConverter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Interop.UIAutomationCore;
 using System;
 using System.Globalization;
 
@@ -9,8 +8,6 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters
 {
     class IntTypeConverter : ITypeConverter
     {
-        public UIAutomationType UnderlyingUiaType => UIAutomationType.UIAutomationType_Int;
-
         public string Render(dynamic value)
         {
             if (value == null) throw new ArgumentNullException(nameof(value));

--- a/src/Desktop/UIAutomation/CustomObjects/Converters/IntTypeConverter.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Converters/IntTypeConverter.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Interop.UIAutomationCore;
+using System;
+using System.Globalization;
+
+namespace Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters
+{
+    class IntTypeConverter : ITypeConverter
+    {
+        public UIAutomationType UnderlyingUiaType => UIAutomationType.UIAutomationType_Int;
+
+        public string Render(dynamic value)
+        {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+            return ((int)value).ToString(CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/src/Desktop/UIAutomation/CustomObjects/Converters/PointTypeConverter.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Converters/PointTypeConverter.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Interop.UIAutomationCore;
 using System;
 
 namespace Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters
 {
     class PointTypeConverter : ITypeConverter
     {
-        public UIAutomationType UnderlyingUiaType => UIAutomationType.UIAutomationType_OutPoint;
-
         public string Render(dynamic value)
         {
             if (value == null) throw new ArgumentNullException(nameof(value));

--- a/src/Desktop/UIAutomation/CustomObjects/Converters/PointTypeConverter.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Converters/PointTypeConverter.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Interop.UIAutomationCore;
+using System;
+
+namespace Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters
+{
+    class PointTypeConverter : ITypeConverter
+    {
+        public UIAutomationType UnderlyingUiaType => UIAutomationType.UIAutomationType_OutPoint;
+
+        public string Render(dynamic value)
+        {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+            double[] arr = (double[])value;
+            return $"[x={arr[0]},y={arr[1]}]";
+        }
+    }
+}

--- a/src/Desktop/UIAutomation/CustomObjects/Converters/StringTypeConverter.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Converters/StringTypeConverter.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Interop.UIAutomationCore;
 using System;
 
 namespace Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters
 {
     class StringTypeConverter : ITypeConverter
     {
-        public UIAutomationType UnderlyingUiaType => UIAutomationType.UIAutomationType_OutString;
-
         public string Render(dynamic value)
         {
             if (value == null) throw new ArgumentNullException(nameof(value));

--- a/src/Desktop/UIAutomation/CustomObjects/Converters/StringTypeConverter.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Converters/StringTypeConverter.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Interop.UIAutomationCore;
+using System;
+
+namespace Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters
+{
+    class StringTypeConverter : ITypeConverter
+    {
+        public UIAutomationType UnderlyingUiaType => UIAutomationType.UIAutomationType_OutString;
+
+        public string Render(dynamic value)
+        {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+            return ((string)value);
+        }
+    }
+}

--- a/src/Desktop/UIAutomation/CustomObjects/CustomProperty.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/CustomProperty.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters;
 using Newtonsoft.Json;
 using System;
 using System.IO;
@@ -23,6 +24,10 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
         [JsonProperty("uiaType")]
         public string DataType { get; set; }
 
+        /// <summary>A type converter for this property, representing its underlying UIA type and providing string rendering.</summary>
+        [JsonIgnore]
+        public ITypeConverter TypeConverter { get; private set; }
+
         /// <summary>The dynamic ID assigned to this property by the system.</summary>
         [JsonIgnore]
         public int DynamicId { get; set; }
@@ -32,31 +37,25 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
             if (Guid == Guid.Empty) throw new InvalidDataException("Missing GUID in custom property definition.");
             if (ProgrammaticName == null) throw new InvalidDataException("Missing programmatic name in custom property definition.");
             if (DataType == null) throw new InvalidDataException("Missing type in custom property definition.");
-            ValidateType();
+            TypeConverter = CreateTypeConverter();
         }
 
-        internal void ValidateType()
+        internal ITypeConverter CreateTypeConverter()
         {
             switch (DataType)
             {
                 case "string":
-                    // Valid type, further processing in a subsequent PR.
-                    break;
+                    return new StringTypeConverter();
                 case "int":
-                    // Valid type, further processing in a subsequent PR.
-                    break;
+                    return new IntTypeConverter();
                 case "bool":
-                    // Valid type, further processing in a subsequent PR.
-                    break;
+                    return new BoolTypeConverter();
                 case "double":
-                    // Valid type, further processing in a subsequent PR.
-                    break;
+                    return new DoubleTypeConverter();
                 case "point":
-                    // Valid type, further processing in a subsequent PR.
-                    break;
+                    return new PointTypeConverter();
                 case "element":
-                    // Valid type, further processing in a subsequent PR.
-                    break;
+                    return new ElementTypeConverter();
                 default:
                     throw new InvalidDataException($"Unknown type {DataType}.");
             }

--- a/src/Desktop/UIAutomation/CustomObjects/CustomProperty.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/CustomProperty.cs
@@ -24,7 +24,7 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
         [JsonProperty("uiaType")]
         public string DataType { get; set; }
 
-        /// <summary>A type converter for this property, representing its underlying UIA type and providing string rendering.</summary>
+        /// <summary>A type converter for this property, providing string rendering.</summary>
         [JsonIgnore]
         public ITypeConverter TypeConverter { get; private set; }
 

--- a/src/DesktopTests/UIAutomation/CustomObjects/Converters/BoolConverterTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/Converters/BoolConverterTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects.Converters
+{
+    [TestClass()]
+    public class BoolConverterTests
+    {
+        [TestMethod, Timeout(1000)]
+        public void TrueRenderTest()
+        {
+            Assert.AreEqual("True", new BoolTypeConverter().Render(true));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void FalseRenderTest()
+        {
+            Assert.AreEqual("False", new BoolTypeConverter().Render(false));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void NullRenderTest()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => new BoolTypeConverter().Render(null));
+        }
+    }
+}

--- a/src/DesktopTests/UIAutomation/CustomObjects/Converters/DoubleConverterTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/Converters/DoubleConverterTests.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects.Converters
+{
+    [TestClass()]
+    public class DoubleConverterTests
+    {
+        [TestMethod, Timeout(1000)]
+        public void RenderTest()
+        {
+            Assert.AreEqual("0", new DoubleTypeConverter().Render(0.0));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void NullRenderTest()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => new DoubleTypeConverter().Render(null));
+        }
+    }
+}

--- a/src/DesktopTests/UIAutomation/CustomObjects/Converters/ElementConverterTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/Converters/ElementConverterTests.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects.Converters
+{
+    [TestClass()]
+    public class ElementConverterTests
+    {
+        [TestMethod, Timeout(1000)]
+        public void RenderTest()
+        {
+            A11yElement elem = new A11yElement();
+            elem.Glimpse = "the glimpse";
+            Assert.AreEqual("the glimpse", new ElementTypeConverter().Render(elem));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void NullRenderTest()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => new ElementTypeConverter().Render(null));
+        }
+    }
+}

--- a/src/DesktopTests/UIAutomation/CustomObjects/Converters/IntConverterTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/Converters/IntConverterTests.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects.Converters
+{
+    [TestClass()]
+    public class IntConverterTests
+    {
+        [TestMethod, Timeout(1000)]
+        public void RenderTest()
+        {
+            Assert.AreEqual("42", new IntTypeConverter().Render(42));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void NullRenderTest()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => new IntTypeConverter().Render(null));
+        }
+    }
+}

--- a/src/DesktopTests/UIAutomation/CustomObjects/Converters/PointConverterTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/Converters/PointConverterTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects.Converters
+{
+    [TestClass()]
+    public class PointConverterTests
+    {
+        [TestMethod, Timeout(1000)]
+        public void RenderTest()
+        {
+            dynamic value=new double[2] { 42.0, 42.0 };
+            Assert.AreEqual("[x=42,y=42]", new PointTypeConverter().Render(value));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void NullRenderTest()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => new PointTypeConverter().Render(null));
+        }
+    }
+}

--- a/src/DesktopTests/UIAutomation/CustomObjects/Converters/StringConverterTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/Converters/StringConverterTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Desktop.UIAutomation.CustomObjects.Converters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects.Converters
+{
+    [TestClass()]
+    public class StringConverterTests
+    {
+        [TestMethod, Timeout(1000)]
+        public void RenderTest()
+        {
+            Assert.AreEqual("test", new StringTypeConverter().Render("test"));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void NullRenderTest()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => new StringTypeConverter().Render(null));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void EmptyRenderTest()
+        {
+            Assert.AreEqual(String.Empty, new StringTypeConverter().Render(String.Empty));
+        }
+    }
+}


### PR DESCRIPTION
#### Details
Repeatedly checking the JSON type string (`CustomProperty.DataType`) at registration and runtime is expensive, and the `enum` type requires special handling. This PR therefore adds a new `iTypeConverter` interface and `TypeConverter` classes which encapsulate type information for custom properties and streamline rendering.

##### Motivation
Part of feature 1845247 (internal access required to view).

##### Context
* The `enum` type is out-of-scope for this PR.
* Commit 1bf2a0c922192f65d4a45611042beec7e6f9a468 (removal of `UnderlyingUIAType` property used to aid registration) to be reverted after merge of #592 (in a subsequent PR).

#### Pull request checklist
- [ ] Addresses an existing issue: #0000: N/A
