### PR TITLE
fix: use StrongName-signed interop

### DIFF
--- a/src/Desktop/Desktop.csproj
+++ b/src/Desktop/Desktop.csproj
@@ -9,7 +9,7 @@
   <Import Project="..\..\build\NetStandardRelease.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Interop.UIAutomationCore" Version="10.19041.0" />
+    <PackageReference Include="Interop.UIAutomationCore.Signed" Version="10.19041.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
#### Details

#592 broke the signed build because the assembly from the [Interop.UIAutomationCore](https://www.nuget.org/packages/Interop.UIAutomationCore/) package is not StrongName signed. This PR simply changes to the [Interop.UIAutomationCore.Signed](https://www.nuget.org/packages/Interop.UIAutomationCore.Signed/) package, which is a StrongName signed version of the same assembly. The assembly itself is still named Interop.UIAutomationCore, so the only required change is to update the package reference. I queued a [validation build](https://mseng.visualstudio.com/1ES/_build/results?buildId=15448326&view=results), which completed successfully.

##### Motivation

Broken builds are very bad

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
