### PR TITLE
feat(custom-uia): remove Validate() methods and perform field validation on property setters

### DIFF
--- a/src/Core/CustomObjects/Config.cs
+++ b/src/Core/CustomObjects/Config.cs
@@ -15,21 +15,8 @@ namespace Axe.Windows.Core.CustomObjects
         public CustomProperty[] Properties { get; set; }
 #pragma warning restore CA1819 // Properties should not return arrays: represents a JSON collection
 
-        public static Config ReadFromText(string text)
-        {
-            Config conf = JsonConvert.DeserializeObject<Config>(text);
-            conf.Validate();
-            // We made it here, so config must be valid.
-            return conf;
-        }
+        public static Config ReadFromText(string text) { return JsonConvert.DeserializeObject<Config>(text); }
 
         public static Config ReadFromFile(string path) { return Config.ReadFromText(File.ReadAllText(path)); }
-
-        private void Validate()
-        {
-            if (Properties == null || !Properties.Any()) throw new InvalidDataException("Empty or missing definition of custom properties.");
-            foreach (CustomProperty p in Properties) 
-                p.Validate();
-        }
     }
 }

--- a/src/Core/CustomObjects/CustomProperty.cs
+++ b/src/Core/CustomObjects/CustomProperty.cs
@@ -10,54 +10,53 @@ namespace Axe.Windows.Core.CustomObjects
 {
     public class CustomProperty
     {
+#pragma warning disable CA1720 // Identifier contains type name: name from JSON
+        private Guid _Guid;
         /// <summary>The RFC4122 globally unique identifier of this property.</summary>
         [JsonProperty("guid")]
-#pragma warning disable CA1720 // Identifier contains type name: name from JSON
-        public Guid Guid { get; set; }
+        public Guid Guid {
+            get { return _Guid; }
+            set
+            {
+                if (value == Guid.Empty) throw new InvalidDataException("Missing GUID in custom property definition.");
+                _Guid = value;
+            }
+        }
 #pragma warning restore CA1720 // Identifier contains type name: name from JSON
+
+        private string _ProgrammaticName;
         /// <summary>A textual description of this property.</summary>
         [JsonProperty("programmaticName")]
-        public string ProgrammaticName { get; set; }
-
-        /// <summary>The data type of this property's value as specified by the user, one of string, int, bool, double, point, or element.</summary>
-        // TODO Bill: add enum (with values member)
-        [JsonProperty("uiaType")]
-        public string DataType { get; set; }
-
-        /// <summary>A type converter for this property, providing string rendering.</summary>
-        [JsonIgnore]
-        public ITypeConverter TypeConverter { get; private set; }
-
-        /// <summary>The dynamic ID assigned to this property by the system.</summary>
-        [JsonIgnore]
-        public int DynamicId { get; set; }
-
-        internal void Validate()
-        {
-            if (Guid == Guid.Empty) throw new InvalidDataException("Missing GUID in custom property definition.");
-            if (ProgrammaticName == null) throw new InvalidDataException("Missing programmatic name in custom property definition.");
-            if (DataType == null) throw new InvalidDataException("Missing type in custom property definition.");
-            TypeConverter = CreateTypeConverter();
+        public string ProgrammaticName {
+            get { return _ProgrammaticName; }
+            set
+            {
+                if (value == null) throw new InvalidDataException("Missing programmatic name in custom property definition.");
+                _ProgrammaticName = value;
+            }
         }
 
-        internal ITypeConverter CreateTypeConverter()
+        private string _DataType;
+        /// <summary>The data type of this property's value as specified by the user, one of string, int, bool, double, point, or element.</summary>
+        [JsonProperty("uiaType")]
+        public string DataType
         {
-            switch (DataType)
+            get { return _DataType; }
+            set
             {
-                case "string":
-                    return new StringTypeConverter();
-                case "int":
-                    return new IntTypeConverter();
-                case "bool":
-                    return new BoolTypeConverter();
-                case "double":
-                    return new DoubleTypeConverter();
-                case "point":
-                    return new PointTypeConverter();
-                case "element":
-                    return new ElementTypeConverter();
-                default:
-                    throw new InvalidDataException($"Unknown type {DataType}.");
+                switch (value)
+                {
+                    case "string":
+                    case "int":
+                    case "bool":
+                    case "double":
+                    case "point":
+                    case "element":
+                        _DataType = value;
+                        break;
+                    default:
+                        throw new InvalidDataException("Type in custom property definition is missing or invalid.");
+                }
             }
         }
     }

--- a/src/Core/CustomObjects/CustomProperty.cs
+++ b/src/Core/CustomObjects/CustomProperty.cs
@@ -52,7 +52,7 @@ namespace Axe.Windows.Core.CustomObjects
                         Type = CustomUIAPropertyType.Element;
                         break;
                     default:
-                        throw new InvalidDataException("Type in custom property definition is missing or invalid.");
+                        throw new ArgumentException($"'${value}' is not a supported type", nameof(value));
                 }
                 _configType = value;
             }

--- a/src/Core/CustomObjects/CustomProperty.cs
+++ b/src/Core/CustomObjects/CustomProperty.cs
@@ -11,40 +11,24 @@ namespace Axe.Windows.Core.CustomObjects
     public class CustomProperty
     {
 #pragma warning disable CA1720 // Identifier contains type name: name from JSON
-        private Guid _Guid;
         /// <summary>The RFC4122 globally unique identifier of this property.</summary>
         [JsonProperty("guid")]
-        public Guid Guid {
-            get { return _Guid; }
-            set
-            {
-                if (value == Guid.Empty) throw new InvalidDataException("Missing GUID in custom property definition.");
-                _Guid = value;
-            }
-        }
+        public Guid Guid { get; set; }
 #pragma warning restore CA1720 // Identifier contains type name: name from JSON
 
-        private string _ProgrammaticName;
         /// <summary>A textual description of this property.</summary>
         [JsonProperty("programmaticName")]
-        public string ProgrammaticName {
-            get { return _ProgrammaticName; }
-            set
-            {
-                if (value == null) throw new InvalidDataException("Missing programmatic name in custom property definition.");
-                _ProgrammaticName = value;
-            }
-        }
+        public string ProgrammaticName { get; set; }
 
         ///  <summary>An internal representation of this property's type. For performance reasons, calling code should always use this property in place of the config representation.s</summary>
         public CustomUIAPropertyType Type { get; private set; }
 
-        private string _ConfigType;
+        private string _configType;
         /// <summary>The data type of this property's value as specified in user configuration, one of string, int, bool, double, point, or element.</summary>
         [JsonProperty("uiaType")]
         public string ConfigType
         {
-            get { return _ConfigType; }
+            get { return _configType; }
             set
             {
                 switch (value)
@@ -70,7 +54,7 @@ namespace Axe.Windows.Core.CustomObjects
                     default:
                         throw new InvalidDataException("Type in custom property definition is missing or invalid.");
                 }
-                _ConfigType = value;
+                _configType = value;
             }
         }
     }

--- a/src/Core/CustomObjects/CustomProperty.cs
+++ b/src/Core/CustomObjects/CustomProperty.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Axe.Windows.Core.CustomObjects.Converters;
+using Axe.Windows.Core.Enums;
 using Newtonsoft.Json;
 using System;
 using System.IO;
@@ -36,27 +36,41 @@ namespace Axe.Windows.Core.CustomObjects
             }
         }
 
-        private string _DataType;
-        /// <summary>The data type of this property's value as specified by the user, one of string, int, bool, double, point, or element.</summary>
+        ///  <summary>An internal representation of this property's type. For performance reasons, calling code should always use this property in place of the config representation.s</summary>
+        public CustomUIAPropertyType Type { get; private set; }
+
+        private string _ConfigType;
+        /// <summary>The data type of this property's value as specified in user configuration, one of string, int, bool, double, point, or element.</summary>
         [JsonProperty("uiaType")]
-        public string DataType
+        public string ConfigType
         {
-            get { return _DataType; }
+            get { return _ConfigType; }
             set
             {
                 switch (value)
                 {
                     case "string":
+                        Type = CustomUIAPropertyType.String;
+                        break;
                     case "int":
+                        Type = CustomUIAPropertyType.Int;
+                        break;
                     case "bool":
+                        Type = CustomUIAPropertyType.Bool;
+                        break;
                     case "double":
+                        Type = CustomUIAPropertyType.Double;
+                        break;
                     case "point":
+                        Type = CustomUIAPropertyType.Point;
+                        break;
                     case "element":
-                        _DataType = value;
+                        Type = CustomUIAPropertyType.Element;
                         break;
                     default:
                         throw new InvalidDataException("Type in custom property definition is missing or invalid.");
                 }
+                _ConfigType = value;
             }
         }
     }

--- a/src/Core/Enums/CustomUIAPropertyType.cs
+++ b/src/Core/Enums/CustomUIAPropertyType.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Axe.Windows.Core.Enums
+{
+    public enum CustomUIAPropertyType
+    {
+        Unset = 0,
+#pragma warning disable CA1720 // Identifier contains type name: type names from JSON
+        String,
+        Int,
+        Bool,
+        Double,
+        Point,
+        Element
+#pragma warning restore CA1720 // Identifier contains type name: type names from JSON
+    }
+}

--- a/src/CoreTests/CustomObjects/ConfigTests.cs
+++ b/src/CoreTests/CustomObjects/ConfigTests.cs
@@ -5,7 +5,6 @@ using Axe.Windows.Core.CustomObjects;
 using Axe.Windows.Core.Enums;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.IO;
 
 namespace Axe.Windows.CoreTests.CustomObjects
 {

--- a/src/CoreTests/CustomObjects/ConfigTests.cs
+++ b/src/CoreTests/CustomObjects/ConfigTests.cs
@@ -70,41 +70,5 @@ namespace Axe.Windows.CoreTests.CustomObjects
             }
             catch (Exception) { }
         }
-
-        [TestMethod, Timeout(1000)]
-        public void MissingGuidConfigTest()
-        {
-            const string MissingGuidConfig = "{\"properties\": [{\"programmaticName\": \"AreGridlinesVisible\", \"uiaType\": \"bool\"}]}";
-            try
-            {
-                Config.ReadFromText(MissingGuidConfig);
-                Assert.Fail("Failed to throw exception.");
-            }
-            catch (Exception) { }
-        }
-
-        [TestMethod, Timeout(1000)]
-        public void MissingNameConfigTest()
-        {
-            const string MissingNameConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"uiaType\": \"bool\"}]}";
-            try
-            {
-                Config.ReadFromText(MissingNameConfig);
-                Assert.Fail("Failed to throw exception.");
-            }
-            catch (Exception) { }
-        }
-
-        [TestMethod, Timeout(1000)]
-        public void MissingTypeConfigTest()
-        {
-            const string MissingTypeConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"programmaticName\": \"AreGridlinesVisible\"}]}";
-            try
-            {
-                Config.ReadFromText(MissingTypeConfig);
-                Assert.Fail("Failed to throw exception.");
-            }
-            catch (Exception) { }
-        }
     }
 }

--- a/src/CoreTests/CustomObjects/ConfigTests.cs
+++ b/src/CoreTests/CustomObjects/ConfigTests.cs
@@ -24,12 +24,6 @@ namespace Axe.Windows.CoreTests.CustomObjects
         }
 
         [TestMethod, Timeout(1000)]
-        public void EmptyConfigTest()
-        {
-            Assert.ThrowsException<InvalidDataException>(() => Config.ReadFromText("{}"));
-        }
-
-        [TestMethod, Timeout(1000)]
         public void NullConfigTest()
         {
             try
@@ -67,28 +61,48 @@ namespace Axe.Windows.CoreTests.CustomObjects
         public void BadTypeConfigTest()
         {
             const string BadTypeConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"programmaticName\": \"AreGridlinesVisible\", \"uiaType\": \"Excel\"}]}";
-            Assert.ThrowsException<InvalidDataException>(() => Config.ReadFromText(BadTypeConfig));
+            try
+            {
+                Config.ReadFromText(BadTypeConfig);
+                Assert.Fail("Failed to throw exception.");
+            }
+            catch (Exception) { }
         }
 
         [TestMethod, Timeout(1000)]
         public void MissingGuidConfigTest()
         {
             const string MissingGuidConfig = "{\"properties\": [{\"programmaticName\": \"AreGridlinesVisible\", \"uiaType\": \"bool\"}]}";
-            Assert.ThrowsException<InvalidDataException>(() => Config.ReadFromText(MissingGuidConfig));
+            try
+            {
+                Config.ReadFromText(MissingGuidConfig);
+                Assert.Fail("Failed to throw exception.");
+            }
+            catch (Exception) { }
         }
 
         [TestMethod, Timeout(1000)]
         public void MissingNameConfigTest()
         {
             const string MissingNameConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"uiaType\": \"bool\"}]}";
-            Assert.ThrowsException<InvalidDataException>(() => Config.ReadFromText(MissingNameConfig));
+            try
+            {
+                Config.ReadFromText(MissingNameConfig);
+                Assert.Fail("Failed to throw exception.");
+            }
+            catch (Exception) { }
         }
 
         [TestMethod, Timeout(1000)]
         public void MissingTypeConfigTest()
         {
             const string MissingTypeConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"programmaticName\": \"AreGridlinesVisible\"}]}";
-            Assert.ThrowsException<InvalidDataException>(() => Config.ReadFromText(MissingTypeConfig));
+            try
+            {
+                Config.ReadFromText(MissingTypeConfig);
+                Assert.Fail("Failed to throw exception.");
+            }
+            catch (Exception) { }
         }
     }
 }

--- a/src/CoreTests/CustomObjects/ConfigTests.cs
+++ b/src/CoreTests/CustomObjects/ConfigTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Core.CustomObjects;
+using Axe.Windows.Core.Enums;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
@@ -20,7 +21,8 @@ namespace Axe.Windows.CoreTests.CustomObjects
             CustomProperty prop = conf.Properties[0];
             Assert.AreEqual(new Guid("4BB56516-F354-44CF-A5AA-96B52E968CFD"), prop.Guid);
             Assert.AreEqual("AreGridlinesVisible", prop.ProgrammaticName);
-            Assert.AreEqual("bool", prop.DataType);
+            Assert.AreEqual("bool", prop.ConfigType);
+            Assert.AreEqual(CustomUIAPropertyType.Bool, prop.Type);
         }
 
         [TestMethod, Timeout(1000)]

--- a/src/CoreTests/CustomObjects/ConfigTests.cs
+++ b/src/CoreTests/CustomObjects/ConfigTests.cs
@@ -58,17 +58,5 @@ namespace Axe.Windows.CoreTests.CustomObjects
             }
             catch (Exception) { }
         }
-
-        [TestMethod, Timeout(1000)]
-        public void BadTypeConfigTest()
-        {
-            const string BadTypeConfig = "{\"properties\": [{\"guid\": \"4BB56516-F354-44CF-A5AA-96B52E968CFD\", \"programmaticName\": \"AreGridlinesVisible\", \"uiaType\": \"Excel\"}]}";
-            try
-            {
-                Config.ReadFromText(BadTypeConfig);
-                Assert.Fail("Failed to throw exception.");
-            }
-            catch (Exception) { }
-        }
     }
 }

--- a/src/CoreTests/CustomObjects/CustomPropertyTests.cs
+++ b/src/CoreTests/CustomObjects/CustomPropertyTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Core.CustomObjects;
+using Axe.Windows.Core.Enums;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace Axe.Windows.CoreTests.CustomObjects
+{
+    [TestClass()]
+    public class CustomPropertyTests
+    {
+        [TestMethod, Timeout(1000)]
+        public void StringConfigTest()
+        {
+            CustomProperty prop = new CustomProperty();
+            prop.ConfigType = "string";
+            Assert.AreEqual(CustomUIAPropertyType.String, prop.Type);
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void IntConfigTest()
+        {
+            CustomProperty prop = new CustomProperty();
+            prop.ConfigType = "int";
+            Assert.AreEqual(CustomUIAPropertyType.Int, prop.Type);
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void BoolConfigTest()
+        {
+            CustomProperty prop = new CustomProperty();
+            prop.ConfigType = "bool";
+            Assert.AreEqual(CustomUIAPropertyType.Bool, prop.Type);
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void DoubleConfigTest()
+        {
+            CustomProperty prop = new CustomProperty();
+            prop.ConfigType = "double";
+            Assert.AreEqual(CustomUIAPropertyType.Double, prop.Type);
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void PointConfigTest()
+        {
+            CustomProperty prop = new CustomProperty();
+            prop.ConfigType = "point";
+            Assert.AreEqual(CustomUIAPropertyType.Point, prop.Type);
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void ElementConfigTest()
+        {
+            CustomProperty prop = new CustomProperty();
+            prop.ConfigType = "element";
+            Assert.AreEqual(CustomUIAPropertyType.Element, prop.Type);
+        }
+    }
+}

--- a/src/CoreTests/CustomObjects/CustomPropertyTests.cs
+++ b/src/CoreTests/CustomObjects/CustomPropertyTests.cs
@@ -5,7 +5,6 @@ using Axe.Windows.Core.CustomObjects;
 using Axe.Windows.Core.Enums;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.IO;
 
 namespace Axe.Windows.CoreTests.CustomObjects
 {
@@ -26,7 +25,7 @@ namespace Axe.Windows.CoreTests.CustomObjects
         public void BadTypePropertyTest()
         {
             CustomProperty prop = new CustomProperty();
-            Assert.ThrowsException<InvalidDataException>(() => prop.ConfigType = "Excel");
+            Assert.ThrowsException<ArgumentException>(() => prop.ConfigType = "Excel");
         }
 
         [TestMethod, Timeout(1000)]

--- a/src/CoreTests/CustomObjects/CustomPropertyTests.cs
+++ b/src/CoreTests/CustomObjects/CustomPropertyTests.cs
@@ -13,7 +13,24 @@ namespace Axe.Windows.CoreTests.CustomObjects
     public class CustomPropertyTests
     {
         [TestMethod, Timeout(1000)]
-        public void StringConfigTest()
+        public void DefaultsPropertyTest()
+        {
+            CustomProperty prop = new CustomProperty();
+            Assert.AreEqual(Guid.Empty, prop.Guid);
+            Assert.AreEqual(null, prop.ProgrammaticName);
+            Assert.AreEqual(null, prop.ConfigType);
+            Assert.AreEqual(CustomUIAPropertyType.Unset, prop.Type);
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void BadTypePropertyTest()
+        {
+            CustomProperty prop = new CustomProperty();
+            Assert.ThrowsException<InvalidDataException>(() => prop.ConfigType = "Excel");
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void StringPropertyTest()
         {
             CustomProperty prop = new CustomProperty();
             prop.ConfigType = "string";
@@ -21,7 +38,7 @@ namespace Axe.Windows.CoreTests.CustomObjects
         }
 
         [TestMethod, Timeout(1000)]
-        public void IntConfigTest()
+        public void IntPropertyTest()
         {
             CustomProperty prop = new CustomProperty();
             prop.ConfigType = "int";
@@ -29,7 +46,7 @@ namespace Axe.Windows.CoreTests.CustomObjects
         }
 
         [TestMethod, Timeout(1000)]
-        public void BoolConfigTest()
+        public void BoolPropertyTest()
         {
             CustomProperty prop = new CustomProperty();
             prop.ConfigType = "bool";
@@ -37,7 +54,7 @@ namespace Axe.Windows.CoreTests.CustomObjects
         }
 
         [TestMethod, Timeout(1000)]
-        public void DoubleConfigTest()
+        public void DoublePropertyTest()
         {
             CustomProperty prop = new CustomProperty();
             prop.ConfigType = "double";
@@ -45,7 +62,7 @@ namespace Axe.Windows.CoreTests.CustomObjects
         }
 
         [TestMethod, Timeout(1000)]
-        public void PointConfigTest()
+        public void PointPropertyTest()
         {
             CustomProperty prop = new CustomProperty();
             prop.ConfigType = "point";
@@ -53,7 +70,7 @@ namespace Axe.Windows.CoreTests.CustomObjects
         }
 
         [TestMethod, Timeout(1000)]
-        public void ElementConfigTest()
+        public void ElementPropertyTest()
         {
             CustomProperty prop = new CustomProperty();
             prop.ConfigType = "element";


### PR DESCRIPTION
#### Details
This PR removes the `Config.Validate()` and `CustomProprty.Validate()` methods, instead validating at the attribute level. It also relaxes the requirement for the JSON file to have custom properties, or any contents at all, defined as this may be useful for follow-up work on annotations/patterns. `DataType` has been renamed `ConfigType` (as it is the type from the user configuration) to distinguish it with a newly-added `Type` attribute containing an enum value kept in sync with the `ConfigType` property via setters. The new `Type` attribute should be used in calling code for faster performance, but `ConfigType` must be public for the benefit of Newtonsoft. Since Newtonsoft catches all exceptions thrown by calling code and re-throws its own, tests expecting our `InvalidDataException` were modified accordingly.

##### Motivation
Part of custom UIA extensions (internal access required to view).

##### Context
Further work to follow in subsequent PRs.

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000