### PR TITLE
feat(custom-uia): Finish the registrar and initial rendering support

### DIFF
--- a/src/Core/Bases/A11yProperty.cs
+++ b/src/Core/Bases/A11yProperty.cs
@@ -124,8 +124,10 @@ namespace Axe.Windows.Core.Bases
                         txt = this.Value != 0 ? LandmarkType.GetInstance().GetNameById(this.Value) : null; // 0 is default value.
                         break;
                     default:
-                        if (TypeConverterMap.ContainsKey(Id))
-                            txt = TypeConverterMap[Id].Render(Value);
+                        if (TypeConverterMap.TryGetValue(Id, out ITypeConverter converter))
+                        {
+                            txt = converter.Render(Value);
+                        }
                         else if (this.Value is Int32[])
                         {
                             txt = ((Int32[])this.Value).ConvertInt32ArrayToString();
@@ -145,7 +147,7 @@ namespace Axe.Windows.Core.Bases
         }
 
         /// <summary>
-        /// Get proper bounding rectangle text based on teh date
+        /// Get proper bounding rectangle text based on the data
         /// </summary>
         /// <returns></returns>
         private string GetBoundingRectangleText()
@@ -166,7 +168,10 @@ namespace Axe.Windows.Core.Bases
             return text;
         }
 
-        public static void HandleCustomPropertyRegistration(int dynamicId, ITypeConverter converter) { TypeConverterMap.Add(dynamicId, converter); }
+        public static void RegisterCustomProperty(int dynamicId, ITypeConverter converter) 
+        {
+            TypeConverterMap[dynamicId] = converter; 
+        }
 
         #region IDisposable Support
         private bool disposedValue; // To detect redundant calls

--- a/src/Core/Bases/A11yProperty.cs
+++ b/src/Core/Bases/A11yProperty.cs
@@ -1,10 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Core.CustomObjects.Converters;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Win32;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 
 namespace Axe.Windows.Core.Bases
@@ -18,6 +21,7 @@ namespace Axe.Windows.Core.Bases
         /// Property Id
         /// </summary>
         public int Id { get; set; }
+
         /// <summary>
         /// Property Name
         /// </summary>
@@ -42,6 +46,8 @@ namespace Axe.Windows.Core.Bases
                 return this.ToString();
             }
         }
+
+        static Dictionary<int, ITypeConverter> TypeConverterMap = new Dictionary<int, ITypeConverter>();
 
         /// <summary>
         /// Constructor with normal case
@@ -118,11 +124,13 @@ namespace Axe.Windows.Core.Bases
                         txt = this.Value != 0 ? LandmarkType.GetInstance().GetNameById(this.Value) : null; // 0 is default value.
                         break;
                     default:
-                        if(this.Value is Int32[])
+                        if (TypeConverterMap.ContainsKey(Id))
+                            txt = TypeConverterMap[Id].Render(Value);
+                        else if (this.Value is Int32[])
                         {
                             txt = ((Int32[])this.Value).ConvertInt32ArrayToString();
                         }
-                        else if(this.Value is Double[])
+                        else if (this.Value is Double[])
                         {
                             txt = ((Double[])this.Value).ConvertDoubleArrayToString();
                         }
@@ -157,6 +165,8 @@ namespace Axe.Windows.Core.Bases
 
             return text;
         }
+
+        public static void HandleCustomPropertyRegistration(int dynamicId, ITypeConverter converter) { TypeConverterMap.Add(dynamicId, converter); }
 
         #region IDisposable Support
         private bool disposedValue; // To detect redundant calls

--- a/src/Core/CustomObjects/Converters/BoolTypeConverter.cs
+++ b/src/Core/CustomObjects/Converters/BoolTypeConverter.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 
 namespace Axe.Windows.Core.CustomObjects.Converters
 {
-    class BoolTypeConverter : ITypeConverter
+    public class BoolTypeConverter : ITypeConverter
     {
         public string Render(dynamic value)
         {

--- a/src/Core/CustomObjects/Converters/DoubleTypeConverter.cs
+++ b/src/Core/CustomObjects/Converters/DoubleTypeConverter.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 
 namespace Axe.Windows.Core.CustomObjects.Converters
 {
-    class DoubleTypeConverter : ITypeConverter
+    public class DoubleTypeConverter : ITypeConverter
     {
         public string Render(dynamic value)
         {

--- a/src/Core/CustomObjects/Converters/ElementTypeConverter.cs
+++ b/src/Core/CustomObjects/Converters/ElementTypeConverter.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Axe.Windows.Core.CustomObjects.Converters
 {
-    class ElementTypeConverter : ITypeConverter
+    public class ElementTypeConverter : ITypeConverter
     {
         public string Render(dynamic value)
         {

--- a/src/Core/CustomObjects/Converters/IntTypeConverter.cs
+++ b/src/Core/CustomObjects/Converters/IntTypeConverter.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 
 namespace Axe.Windows.Core.CustomObjects.Converters
 {
-    class IntTypeConverter : ITypeConverter
+    public class IntTypeConverter : ITypeConverter
     {
         public string Render(dynamic value)
         {

--- a/src/Core/CustomObjects/Converters/PointTypeConverter.cs
+++ b/src/Core/CustomObjects/Converters/PointTypeConverter.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Axe.Windows.Core.CustomObjects.Converters
 {
-    class PointTypeConverter : ITypeConverter
+    public class PointTypeConverter : ITypeConverter
     {
         public string Render(dynamic value)
         {

--- a/src/Core/CustomObjects/Converters/StringTypeConverter.cs
+++ b/src/Core/CustomObjects/Converters/StringTypeConverter.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Axe.Windows.Core.CustomObjects.Converters
 {
-    class StringTypeConverter : ITypeConverter
+    public class StringTypeConverter : ITypeConverter
     {
         public string Render(dynamic value)
         {

--- a/src/CoreTests/Bases/A11yPropertyTests.cs
+++ b/src/CoreTests/Bases/A11yPropertyTests.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.CustomObjects.Converters;
 using Axe.Windows.Core.Types;
 using Axe.Windows.UnitTestSharedLibrary;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 
 namespace Axe.Windows.CoreTests.Bases
 {
@@ -40,6 +43,28 @@ namespace Axe.Windows.CoreTests.Bases
 
             kpVal = ke.Properties[PropertyType.UIA_HasKeyboardFocusPropertyId].ToString();
             Assert.AreEqual("False", kpVal);
+        }
+
+        [TestMethod()]
+        public void SimpleCustomPropertyTest() {
+            const int testId = 42;
+            dynamic testValue = 1;
+            const string expectedRendering = "1";
+            A11yProperty.RegisterCustomProperty(testId, new IntTypeConverter());
+            A11yProperty kp = new A11yProperty(testId, testValue);
+            Assert.AreEqual(expectedRendering, kp.ToString());
+        }
+
+        [TestMethod()]
+        public void RegisterTwiceCustomPropertyTest()
+        {
+            const int testId = 42;
+            dynamic testValue = 1;
+            const string expectedRendering = "1";
+            A11yProperty.RegisterCustomProperty(testId, new PointTypeConverter()); // First registration, should be dropped.
+            A11yProperty.RegisterCustomProperty(testId, new IntTypeConverter()); // Second registration, last one wins.
+            A11yProperty kp = new A11yProperty(testId, testValue);
+            Assert.AreEqual(expectedRendering, kp.ToString());
         }
     }
 }

--- a/src/CoreTests/Bases/A11yPropertyTests.cs
+++ b/src/CoreTests/Bases/A11yPropertyTests.cs
@@ -46,7 +46,8 @@ namespace Axe.Windows.CoreTests.Bases
         }
 
         [TestMethod()]
-        public void SimpleCustomPropertyTest() {
+        public void SimpleCustomPropertyTest() 
+        {
             const int testId = 42;
             dynamic testValue = 1;
             const string expectedRendering = "1";

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -15,11 +15,17 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
     public class Registrar : IDisposable
     {
         private IUIAutomationRegistrar _uiaRegistrar;
-        private Action<int, ITypeConverter> _callback;
+        private Action<int, ITypeConverter> _converterRegistrationAction;
         private bool disposedValue;
 
         public Registrar()
             : this(new CUIAutomationRegistrar(), new Action<int, ITypeConverter>(A11yProperty.RegisterCustomProperty)) { }
+
+        internal Registrar(IUIAutomationRegistrar uiaRegistrar, Action<int, ITypeConverter> converterRegistrationAction)
+        {
+            _uiaRegistrar = uiaRegistrar;
+            _converterRegistrationAction = converterRegistrationAction;
+        }
 
         public void RegisterCustomProperty(CustomProperty prop)
         {
@@ -32,13 +38,7 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
             };
 
             _uiaRegistrar.RegisterProperty(ref info, out int dynamicId);
-            _callback(dynamicId, CreateTypeConverter(prop.Type));
-        }
-
-        internal Registrar(IUIAutomationRegistrar uiaRegistrar, Action<int, ITypeConverter> callback)
-        {
-            _uiaRegistrar = uiaRegistrar;
-            _callback = callback;
+            _converterRegistrationAction(dynamicId, CreateTypeConverter(prop.Type));
         }
 
         private static UIAutomationType GetUnderlyingUIAType(CustomUIAPropertyType type)

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -1,6 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Axe.Windows.Core;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.CustomObjects;
+using Axe.Windows.Core.CustomObjects.Converters;
+using Axe.Windows.Core.Enums;
 using Interop.UIAutomationCore;
 using System;
 using System.Runtime.InteropServices;
@@ -9,21 +14,59 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
 {
     public class Registrar : IDisposable
     {
-        CUIAutomationRegistrar _uiaRegistrar = new CUIAutomationRegistrar();
+        private CUIAutomationRegistrar _uiaRegistrar;
+        private Action<int, ITypeConverter> _callback;
         private bool disposedValue;
 
-        public int RegisterCustomProperty(Guid id, string name, UIAutomationType type)
+        public Registrar()
+            : this(new CUIAutomationRegistrar(), new Action<int, ITypeConverter>(A11yProperty.HandleCustomPropertyRegistration)) { }
+
+        public void RegisterCustomProperty(CustomProperty prop)
         {
+            if (prop == null) throw new ArgumentNullException(nameof(prop));
             UIAutomationPropertyInfo info = new UIAutomationPropertyInfo
             {
-                guid = id,
-                pProgrammaticName = name,
-                type = type,
+                guid = prop.Guid,
+                pProgrammaticName = prop.ProgrammaticName,
+                type = GetUnderlyingUIAType(prop.Type)
             };
 
             _uiaRegistrar.RegisterProperty(ref info, out int dynamicId);
+            _callback(dynamicId, CreateTypeConverter(prop.Type));
+        }
 
-            return dynamicId;
+        internal Registrar(IUIAutomationRegistrar uiaRegistrar, Action<int, ITypeConverter> callback)
+        {
+            _uiaRegistrar = uiaRegistrar;
+            _callback = callback;
+        }
+
+        private static UIAutomationType GetUnderlyingUIAType(CustomUIAPropertyType type)
+        {
+            switch (type)
+            {
+                case CustomUIAPropertyType.String: return UIAutomationType.UIAutomationType_OutString;
+                case CustomUIAPropertyType.Int: return UIAutomationType.UIAutomationType_Int;
+                case CustomUIAPropertyType.Bool: return UIAutomationType.UIAutomationType_Bool;
+                case CustomUIAPropertyType.Double: return UIAutomationType.UIAutomationType_Double;
+                case CustomUIAPropertyType.Point: return UIAutomationType.UIAutomationType_OutPoint;
+                case CustomUIAPropertyType.Element: return UIAutomationType.UIAutomationType_Element;
+                default: throw new ArgumentException("Unset or unknown type", nameof(type));
+            }
+        }
+
+        private static ITypeConverter CreateTypeConverter(CustomUIAPropertyType type)
+        {
+            switch (type)
+            {
+                case CustomUIAPropertyType.String: return new StringTypeConverter();
+                case CustomUIAPropertyType.Int: return new IntTypeConverter();
+                case CustomUIAPropertyType.Bool: return new BoolTypeConverter();
+                case CustomUIAPropertyType.Double: return new DoubleTypeConverter();
+                case CustomUIAPropertyType.Point: return new PointTypeConverter();
+                case CustomUIAPropertyType.Element: return new ElementTypeConverter();
+                default: throw new ArgumentException("Unset or unknown type", nameof(type));
+            }
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -55,7 +55,7 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
             }
         }
 
-        private static ITypeConverter CreateTypeConverter(CustomUIAPropertyType type)
+        internal static ITypeConverter CreateTypeConverter(CustomUIAPropertyType type)
         {
             switch (type)
             {

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -14,12 +14,12 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
 {
     public class Registrar : IDisposable
     {
-        private CUIAutomationRegistrar _uiaRegistrar;
+        private IUIAutomationRegistrar _uiaRegistrar;
         private Action<int, ITypeConverter> _callback;
         private bool disposedValue;
 
         public Registrar()
-            : this(new CUIAutomationRegistrar(), new Action<int, ITypeConverter>(A11yProperty.HandleCustomPropertyRegistration)) { }
+            : this(new CUIAutomationRegistrar(), new Action<int, ITypeConverter>(A11yProperty.RegisterCustomProperty)) { }
 
         public void RegisterCustomProperty(CustomProperty prop)
         {

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -1,22 +1,19 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Axe.Windows.Core;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.CustomObjects;
 using Axe.Windows.Core.CustomObjects.Converters;
 using Axe.Windows.Core.Enums;
 using Interop.UIAutomationCore;
 using System;
-using System.Runtime.InteropServices;
 
 namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
 {
-    public class Registrar : IDisposable
+    public class Registrar
     {
         private IUIAutomationRegistrar _uiaRegistrar;
         private Action<int, ITypeConverter> _converterRegistrationAction;
-        private bool disposedValue;
 
         public Registrar()
             : this(new CUIAutomationRegistrar(), new Action<int, ITypeConverter>(A11yProperty.RegisterCustomProperty)) { }
@@ -67,36 +64,6 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
                 case CustomUIAPropertyType.Element: return new ElementTypeConverter();
                 default: throw new ArgumentException("Unset or unknown type", nameof(type));
             }
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!disposedValue)
-            {
-                if (disposing)
-                {
-                    // TODO: dispose managed state (managed objects)
-                }
-
-                // Free unmanaged resources (unmanaged objects) and set large fields to null
-                Marshal.ReleaseComObject(_uiaRegistrar);
-                _uiaRegistrar = null;
-
-                disposedValue = true;
-            }
-        }
-
-        ~Registrar()
-        {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: false);
-        }
-
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
@@ -18,27 +18,27 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
         [TestMethod, Timeout(1000)]
         public void RegisterCustomProperty_CorrectDataFlow()
         {
-            Guid testGuid = new Guid("312F7536-259A-47C7-B192-AA16352522C4");
-            string testName = "CommentReplyCount";
-            CustomProperty testConfig = new CustomProperty { Guid = testGuid, ProgrammaticName = testName, ConfigType = "int" };
-            UIAutomationPropertyInfo testInfo = new UIAutomationPropertyInfo { guid = testGuid, pProgrammaticName = testName, type = UIAutomationType.UIAutomationType_Int };
-            int testId = 43;
-            Mock<IUIAutomationRegistrar> UIARegistrarMock = new Mock<IUIAutomationRegistrar>(MockBehavior.Strict);
-            UIARegistrarMock.Setup(x => x.RegisterProperty(ref testInfo, out testId));
+            Guid propertyGuid = new Guid("312F7536-259A-47C7-B192-AA16352522C4");
+            string propertyName = "CommentReplyCount";
+            CustomProperty propertyToRegister = new CustomProperty { Guid = propertyGuid, ProgrammaticName = propertyName, ConfigType = "int" };
+            UIAutomationPropertyInfo expectedPropertyInfo = new UIAutomationPropertyInfo { guid = propertyGuid, pProgrammaticName = propertyName, type = UIAutomationType.UIAutomationType_Int };
+            int propertyId = 43;
+            Mock<IUIAutomationRegistrar> uiaRegistrarMock = new Mock<IUIAutomationRegistrar>(MockBehavior.Strict);
+            uiaRegistrarMock.Setup(x => x.RegisterProperty(ref expectedPropertyInfo, out propertyId));
             int counter = 0;
             Action<int, ITypeConverter> testCallback = new Action<int, ITypeConverter>((id, converter) =>
             {
-                Assert.AreEqual(testId, id);
+                Assert.AreEqual(propertyId, id);
                 Assert.IsInstanceOfType(converter, typeof(IntTypeConverter));
                 counter++;
             });
 
-            Registrar r = new Registrar(UIARegistrarMock.Object, testCallback);
+            Registrar r = new Registrar(uiaRegistrarMock.Object, testCallback);
 
-            r.RegisterCustomProperty(testConfig);
+            r.RegisterCustomProperty(propertyToRegister);
 
             Assert.AreEqual(1, counter); // Callback should only be called once
-            UIARegistrarMock.VerifyAll();
+            uiaRegistrarMock.VerifyAll();
         }
 
         [TestMethod, Timeout(1000)]

--- a/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Axe.Windows.Core.CustomObjects;
+using Axe.Windows.Core.CustomObjects.Converters;
+using Axe.Windows.Core.Enums;
 using Axe.Windows.Desktop.UIAutomation.CustomObjects;
 using Interop.UIAutomationCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using System;
 
 namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
@@ -11,35 +15,72 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
     [TestClass]
     public class RegistrarTests
     {
-        // Note: We normally avoid Guid.NewGuid() to make tests more consistently reproducible. This class
-        // intentionally uses Guid.NewGuid to reduce the risk of the UIA state contamination between test runs.
-
-        [TestMethod]
-        [Timeout(1000)]
-        public void RegisterCustomProperty_ReturnsNonZeroValue()
+        [TestMethod, Timeout(1000)]
+        public void RegisterCustomProperty_CorrectDataFlow()
         {
-            using (Registrar r = new Registrar())
+            Guid testGuid = new Guid("312F7536-259A-47C7-B192-AA16352522C4");
+            string testName = "CommentReplyCount";
+            CustomProperty testConfig = new CustomProperty { Guid = testGuid, ProgrammaticName = testName, ConfigType = "int" };
+            UIAutomationPropertyInfo testInfo = new UIAutomationPropertyInfo { guid = testGuid, pProgrammaticName = testName, type = UIAutomationType.UIAutomationType_Int };
+            int testId = 43;
+            Mock<IUIAutomationRegistrar> UIARegistrarMock = new Mock<IUIAutomationRegistrar>(MockBehavior.Strict);
+            UIARegistrarMock.Setup(x => x.RegisterProperty(ref testInfo, out testId));
+            int counter = 0;
+            Action<int, ITypeConverter> testCallback = new Action<int, ITypeConverter>((id, converter) =>
             {
-                int dynamicId = r.RegisterCustomProperty(Guid.NewGuid(), "This is a name", UIAutomationType.UIAutomationType_Double);
-                Assert.AreNotEqual(0, dynamicId);
-            }
+                Assert.AreEqual(testId, id);
+                Assert.IsInstanceOfType(converter, typeof(IntTypeConverter));
+                counter++;
+            });
+
+            Registrar r = new Registrar(UIARegistrarMock.Object, testCallback);
+
+            r.RegisterCustomProperty(testConfig);
+
+            Assert.AreEqual(1, counter); // Callback should only be called once
+            UIARegistrarMock.VerifyAll();
         }
 
-        [TestMethod]
-        [Timeout(1000)]
-        public void RegisterCustomProperty_SamePropertyTwise_ReturnsSameNonZeroValue()
+        [TestMethod, Timeout(1000)]
+        public void CreateTypeConverterStringTest()
         {
-            using (Registrar r = new Registrar())
-            {
-                Guid id = Guid.NewGuid();
-                const string name = "My property name";
-                const UIAutomationType type = UIAutomationType.UIAutomationType_Bool;
+            Assert.IsInstanceOfType(Registrar.CreateTypeConverter(CustomUIAPropertyType.String), typeof(StringTypeConverter));
+        }
 
-                int dynamicId1 = r.RegisterCustomProperty(id, name, type);
-                int dynamicId2 = r.RegisterCustomProperty(id, name, type);
-                Assert.AreNotEqual(0, dynamicId1);
-                Assert.AreEqual(dynamicId1, dynamicId2);
-            }
+        [TestMethod, Timeout(1000)]
+        public void CreateTypeConverterIntTest()
+        {
+            Assert.IsInstanceOfType(Registrar.CreateTypeConverter(CustomUIAPropertyType.Int), typeof(IntTypeConverter));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void CreateTypeConverterBoolTest()
+        {
+            Assert.IsInstanceOfType(Registrar.CreateTypeConverter(CustomUIAPropertyType.Bool), typeof(BoolTypeConverter));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void CreateTypeConverterDoubleTest()
+        {
+            Assert.IsInstanceOfType(Registrar.CreateTypeConverter(CustomUIAPropertyType.Double), typeof(DoubleTypeConverter));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void CreateTypeConverterPointTest()
+        {
+            Assert.IsInstanceOfType(Registrar.CreateTypeConverter(CustomUIAPropertyType.Point), typeof(PointTypeConverter));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void CreateTypeConverterElementTest()
+        {
+            Assert.IsInstanceOfType(Registrar.CreateTypeConverter(CustomUIAPropertyType.Element), typeof(ElementTypeConverter));
+        }
+
+        [TestMethod, Timeout(1000)]
+        public void CreateTypeConverterUnsetTest()
+        {
+            Assert.ThrowsException<ArgumentException>(() => Registrar.CreateTypeConverter(CustomUIAPropertyType.Unset));
         }
     }
 }


### PR DESCRIPTION
#### Details
This PR integrates the `Desktop.UIAutomation.CustomObjects.Registrar` with `CustomProperty` and adds logic to `A11yProperty` to facilitate rendering.

##### Motivation
Part of custom UIA extensions feature (internal access required to view).

##### Context
`A11yProperty.ToString` uses a `switch` statement with hardcoded UIA property cases. Later refactoring might consider moving these to the newly added `TypeConverterMap` to make lookup more efficient/cleaner.

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000