### PR TITLE
feat(custom-uia): Expose registered custom properties in the actions and automation layers

### DIFF
--- a/src/Actions/Actions/CaptureAction.cs
+++ b/src/Actions/Actions/CaptureAction.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Actions.Attributes;
 using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Actions.Enums;

--- a/src/Actions/Actions/CustomUIAAction.cs
+++ b/src/Actions/Actions/CustomUIAAction.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Core.CustomObjects;
+using Axe.Windows.Desktop.UIAutomation.CustomObjects;
+using System;
+using System.Collections.Generic;
+
+namespace Axe.Windows.Actions.Actions
+{
+    public static class CustomUIAAction
+    {
+        public static Config ReadConfigFromFile(string path) { return Config.ReadFromFile(path); }
+
+        public static void RegisterCustomProperties(IEnumerable<CustomProperty> properties)
+        {
+            if (properties == null) throw new ArgumentNullException(nameof(properties));
+            foreach (CustomProperty p in properties)
+            {
+                Registrar.GetDefaultInstance().RegisterCustomProperty(p);
+            }
+        }
+    }
+}

--- a/src/Automation/AxeWindowsActions.cs
+++ b/src/Automation/AxeWindowsActions.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Actions;
 using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Actions.Enums;
 using Axe.Windows.Actions.Misc;
 using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.CustomObjects;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Desktop.Settings;
 using System;
@@ -57,6 +59,13 @@ namespace Axe.Windows.Automation
         public void SaveA11yTestFile(string path, A11yElement element, Guid elementId)
         {
             SaveAction.SaveSnapshotZip(path, elementId, element.UniqueId, A11yFileMode.Test);
+        }
+
+
+        void RegisterCustomUIAPropertiesFromConfig(string path)
+        {
+            Config conf = CustomUIAAction.ReadConfigFromFile(config.CustomUIAConfigPath);
+            CustomUIAAction.RegisterCustomProperties(conf.Properties);
         }
     } // class
 } // namespace

--- a/src/Automation/AxeWindowsActions.cs
+++ b/src/Automation/AxeWindowsActions.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Actions;
+using Axe.Windows.Actions.Actions;
 using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Actions.Enums;
 using Axe.Windows.Actions.Misc;
 using Axe.Windows.Core.Bases;
-using Axe.Windows.Core.CustomObjects;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Desktop.Settings;
 using System;
@@ -61,10 +61,9 @@ namespace Axe.Windows.Automation
             SaveAction.SaveSnapshotZip(path, elementId, element.UniqueId, A11yFileMode.Test);
         }
 
-
-        void RegisterCustomUIAPropertiesFromConfig(string path)
+        public void RegisterCustomUIAPropertiesFromConfig(string path)
         {
-            Config conf = CustomUIAAction.ReadConfigFromFile(config.CustomUIAConfigPath);
+            Core.CustomObjects.Config conf = CustomUIAAction.ReadConfigFromFile(path);
             CustomUIAAction.RegisterCustomProperties(conf.Properties);
         }
     } // class

--- a/src/Automation/Data/Config.cs
+++ b/src/Automation/Data/Config.cs
@@ -95,7 +95,8 @@ namespace Axe.Windows.Automation
             /// </summary>
             public Builder WithCustomUIAConfig(string path)
             {
-                _config.CustomUIAConfigPath= path;
+
+                _config.CustomUIAConfigPath = path;
                 return this;
             }
 

--- a/src/Automation/Data/Config.cs
+++ b/src/Automation/Data/Config.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.Automation
@@ -36,6 +37,9 @@ namespace Axe.Windows.Automation
         /// No output files will be written if no errors were found during the automation session.
         /// </remarks>
         public OutputFileFormat OutputFileFormat { get; private set; }
+
+        ///  <summary>The path to a file containing configuration instructing Axe Windows how to interpret custom UI Automation data.</summary>
+        public string CustomUIAConfigPath{ get; private set; }
 
         private Config()
         { }
@@ -87,6 +91,15 @@ namespace Axe.Windows.Automation
             }
 
             /// <summary>
+            /// Specify the path to a custom configuration file instructing Axe Windows how to interpret custom UIA data.
+            /// </summary>
+            public Builder WithCustomUIAConfig(string path)
+            {
+                _config.CustomUIAConfigPath= path;
+                return this;
+            }
+
+            /// <summary>
             /// Build an instance of <see cref="Config"/>
             /// </summary>
             /// <returns></returns>
@@ -97,6 +110,7 @@ namespace Axe.Windows.Automation
                     ProcessId = _config.ProcessId,
                     OutputFileFormat = _config.OutputFileFormat,
                     OutputDirectory = _config.OutputDirectory,
+                    CustomUIAConfigPath = _config.CustomUIAConfigPath,
                 };
             }
         } // Builder

--- a/src/Automation/Interfaces/IAxeWindowsActions.cs
+++ b/src/Automation/Interfaces/IAxeWindowsActions.cs
@@ -38,5 +38,11 @@ namespace Axe.Windows.Automation
         /// <param name="element"></param>
         /// <param name="elementId"></param>
         void SaveA11yTestFile(string path, A11yElement element, Guid elementId);
+
+        /// <summary>
+        /// Registers the custom UI Automation properties defined in the configuration file at path
+        /// </summary>
+        /// <param name="path"></param>
+        void RegisterCustomUIAPropertiesFromConfig(string path);
     } // interface
 } // namespace

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -33,7 +33,7 @@ namespace Axe.Windows.Automation
             scanTools.NativeMethods.SetProcessDPIAware();
 
             if (config.CustomUIAConfigPath != null)
-                scanTools.Actions.RegisterCustomUIAPropertiesFromConfig(path);
+                scanTools.Actions.RegisterCustomUIAPropertiesFromConfig(config.CustomUIAConfigPath);
 
             var rootElement = scanTools.TargetElementLocator.LocateRootElement(config.ProcessId);
 

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -33,10 +33,7 @@ namespace Axe.Windows.Automation
             scanTools.NativeMethods.SetProcessDPIAware();
 
             if (config.CustomUIAConfigPath != null)
-            {
-                Core.CustomObjects.Config conf = CustomUIAAction.ReadConfigFromFile(config.CustomUIAConfigPath);
-                CustomUIAAction.RegisterCustomProperties(conf.Properties);
-            }
+                scanTools.Actions.RegisterCustomUIAPropertiesFromConfig(path);
 
             var rootElement = scanTools.TargetElementLocator.LocateRootElement(config.ProcessId);
 

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Actions.Actions;
 using Axe.Windows.Automation.Resources;
 using Axe.Windows.Core.Bases;
 using System;
@@ -29,6 +31,12 @@ namespace Axe.Windows.Automation
 
             // We must turn on DPI awareness so we get physical, not logical, UIA element bounding rectangles
             scanTools.NativeMethods.SetProcessDPIAware();
+
+            if (config.CustomUIAConfigPath != null)
+            {
+                Core.CustomObjects.Config conf = CustomUIAAction.ReadConfigFromFile(config.CustomUIAConfigPath);
+                CustomUIAAction.RegisterCustomProperties(conf.Properties);
+            }
 
             var rootElement = scanTools.TargetElementLocator.LocateRootElement(config.ProcessId);
 

--- a/src/AutomationTests/SnapshotCommandUnitTests.cs
+++ b/src/AutomationTests/SnapshotCommandUnitTests.cs
@@ -353,5 +353,32 @@ namespace Axe.Windows.AutomationTests
             _resultsAssemblerMock.VerifyAll();
             _outputFileHelperMock.VerifyAll();
         }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void Execute_CustomUIAPropertyConfig_RegisterCustomUIAPropertiesCalled()
+        {
+            string configPath = "test.json";
+            _scanToolsMock.Setup(x => x.TargetElementLocator).Returns(_targetElementLocatorMock.Object);
+            _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
+            _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
+            _scanToolsMock.Setup(x => x.ResultsAssembler).Returns(_resultsAssemblerMock.Object);
+
+            _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns(new A11yElement());
+            var expectedResults = new ScanResults();
+            InitResultsCallback(expectedResults);
+            _outputFileHelperMock.Setup(m => m.EnsureOutputDirectoryExists());
+
+            _actionsMock.Setup(x => x.RegisterCustomUIAPropertiesFromConfig(configPath));
+
+            var config = Config.Builder
+                .ForProcessId(-1)
+                .WithCustomUIAConfig(configPath)
+                .Build();
+
+            var actualResults = SnapshotCommand.Execute(config, _scanToolsMock.Object);
+
+            _actionsMock.VerifyAll();
+        }
     } // class
 } // namespace

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -7,6 +7,7 @@ using Axe.Windows.Core.CustomObjects.Converters;
 using Axe.Windows.Core.Enums;
 using Interop.UIAutomationCore;
 using System;
+using System.Collections.Generic;
 
 namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
 {
@@ -14,6 +15,7 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
     {
         private IUIAutomationRegistrar _uiaRegistrar;
         private Action<int, ITypeConverter> _converterRegistrationAction;
+        public Dictionary<int, CustomProperty> IdsToCustomProperties { get; private set; }
 
         public Registrar()
             : this(new CUIAutomationRegistrar(), new Action<int, ITypeConverter>(A11yProperty.RegisterCustomProperty)) { }
@@ -22,6 +24,19 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
         {
             _uiaRegistrar = uiaRegistrar;
             _converterRegistrationAction = converterRegistrationAction;
+            IdsToCustomProperties = new Dictionary<int, CustomProperty>();
+        }
+
+        static Registrar sDefaultInstance;
+
+#pragma warning disable CA1024 // Use properties where appropriate: backing field
+        public static Registrar GetDefaultInstance()
+#pragma warning restore CA1024 // Use properties where appropriate: backing field
+        {
+            // This code is currently not thread safe.
+            if (sDefaultInstance == null)
+                sDefaultInstance = new Registrar();
+            return sDefaultInstance;
         }
 
         public void RegisterCustomProperty(CustomProperty prop)
@@ -36,6 +51,7 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
 
             _uiaRegistrar.RegisterProperty(ref info, out int dynamicId);
             _converterRegistrationAction(dynamicId, CreateTypeConverter(prop.Type));
+            IdsToCustomProperties[dynamicId] = prop;
         }
 
         private static UIAutomationType GetUnderlyingUIAType(CustomUIAPropertyType type)

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -15,7 +15,7 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
     {
         private IUIAutomationRegistrar _uiaRegistrar;
         private Action<int, ITypeConverter> _converterRegistrationAction;
-        private Dictionary<int, CustomProperty> IdsToCustomProperties { get;}
+        private Dictionary<int, CustomProperty> _idToCustomPropertyMap { get;}
 
         internal Registrar()
             : this(new CUIAutomationRegistrar(), new Action<int, ITypeConverter>(A11yProperty.RegisterCustomProperty)) { }
@@ -24,7 +24,7 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
         {
             _uiaRegistrar = uiaRegistrar;
             _converterRegistrationAction = converterRegistrationAction;
-            IdsToCustomProperties = new Dictionary<int, CustomProperty>();
+            _idToCustomPropertyMap = new Dictionary<int, CustomProperty>();
         }
 
         static Registrar sDefaultInstance;
@@ -51,11 +51,11 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
 
             _uiaRegistrar.RegisterProperty(ref info, out int dynamicId);
             _converterRegistrationAction(dynamicId, CreateTypeConverter(prop.Type));
-            IdsToCustomProperties[dynamicId] = prop;
+            _idToCustomPropertyMap[dynamicId] = prop;
         }
 
 #pragma warning disable CA1024 // Use properties where appropriate: this is a copy of the object, not the object itself
-        public Dictionary<int, CustomProperty> GetCustomPropertyRegistrations() { return new Dictionary<int, CustomProperty>(IdsToCustomProperties);  }
+        public Dictionary<int, CustomProperty> GetCustomPropertyRegistrations() { return new Dictionary<int, CustomProperty>(_idToCustomPropertyMap);  }
 #pragma warning restore CA1024 // Use properties where appropriate: this is a copy of the object, not the object itself
 
         private static UIAutomationType GetUnderlyingUIAType(CustomUIAPropertyType type)

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -15,9 +15,9 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
     {
         private IUIAutomationRegistrar _uiaRegistrar;
         private Action<int, ITypeConverter> _converterRegistrationAction;
-        public Dictionary<int, CustomProperty> IdsToCustomProperties { get; private set; }
+        private Dictionary<int, CustomProperty> IdsToCustomProperties { get;}
 
-        public Registrar()
+        internal Registrar()
             : this(new CUIAutomationRegistrar(), new Action<int, ITypeConverter>(A11yProperty.RegisterCustomProperty)) { }
 
         internal Registrar(IUIAutomationRegistrar uiaRegistrar, Action<int, ITypeConverter> converterRegistrationAction)
@@ -53,6 +53,10 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
             _converterRegistrationAction(dynamicId, CreateTypeConverter(prop.Type));
             IdsToCustomProperties[dynamicId] = prop;
         }
+
+#pragma warning disable CA1024 // Use properties where appropriate: this is a copy of the object, not the object itself
+        public Dictionary<int, CustomProperty> GetCustomPropertyRegistrations() { return new Dictionary<int, CustomProperty>(IdsToCustomProperties);  }
+#pragma warning restore CA1024 // Use properties where appropriate: this is a copy of the object, not the object itself
 
         private static UIAutomationType GetUnderlyingUIAType(CustomUIAPropertyType type)
         {

--- a/src/Desktop/UIAutomation/DesktopElementHelper.cs
+++ b/src/Desktop/UIAutomation/DesktopElementHelper.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Desktop.UIAutomation.CustomObjects;
 using System;
 using System.Collections.Generic;
 using UIAutomationClient;
@@ -40,6 +42,12 @@ namespace Axe.Windows.Desktop.UIAutomation
                 {
                     cr.AddProperty(pp);
                 }
+            }
+
+            IEnumerable<int> cps = Registrar.GetDefaultInstance().GetCustomPropertyRegistrations().Keys;
+            foreach (var cp in cps)
+            {
+                cr.AddProperty(cp);
             }
 
             if (pts != null)

--- a/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
@@ -38,7 +38,7 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
             r.RegisterCustomProperty(propertyToRegister);
 
             Assert.AreEqual(1, counter); // Callback should only be called once
-            Assert.AreEqual(propertyToRegister, r.IdsToCustomProperties[propertyId]);
+            Assert.AreEqual(propertyToRegister, r.GetCustomPropertyRegistrations()[propertyId]);
             uiaRegistrarMock.VerifyAll();
         }
 

--- a/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
@@ -38,6 +38,7 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
             r.RegisterCustomProperty(propertyToRegister);
 
             Assert.AreEqual(1, counter); // Callback should only be called once
+            Assert.AreEqual(propertyToRegister, r.IdsToCustomProperties[propertyId]);
             uiaRegistrarMock.VerifyAll();
         }
 


### PR DESCRIPTION
#### Details
This PR adds methods to the actions and automation layers to facilitate registration of custom UIA properties, and initial support for the output of custom properties in element snapshots.

##### Motivation
Part of custom UIA extensions (internal access required to view).

##### Context
Future PR to include the programmatic names in the output.

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
