### PR TITLE
feat(custom-uia): Fix type handling for String and Point

### DIFF
--- a/src/CLI/ScanRunner.cs
+++ b/src/CLI/ScanRunner.cs
@@ -17,7 +17,6 @@ namespace AxeWindowsCLI
         {
             Config.Builder builder = Config.Builder
                 .ForProcessId(options.ProcessId)
-                .WithCustomUIAConfig(@"c:\excel.json")
                 .WithOutputFileFormat(OutputFileFormat.A11yTest);
             if (!string.IsNullOrEmpty(options.OutputDirectory))
                 builder = builder.WithOutputDirectory(options.OutputDirectory);

--- a/src/CLI/ScanRunner.cs
+++ b/src/CLI/ScanRunner.cs
@@ -18,6 +18,7 @@ namespace AxeWindowsCLI
             Config.Builder builder = Config.Builder
                 .ForProcessId(options.ProcessId)
                 .WithOutputFileFormat(OutputFileFormat.A11yTest);
+
             if (!string.IsNullOrEmpty(options.OutputDirectory))
                 builder = builder.WithOutputDirectory(options.OutputDirectory);
 

--- a/src/CLI/ScanRunner.cs
+++ b/src/CLI/ScanRunner.cs
@@ -17,8 +17,8 @@ namespace AxeWindowsCLI
         {
             Config.Builder builder = Config.Builder
                 .ForProcessId(options.ProcessId)
+                .WithCustomUIAConfig(@"c:\excel.json")
                 .WithOutputFileFormat(OutputFileFormat.A11yTest);
-
             if (!string.IsNullOrEmpty(options.OutputDirectory))
                 builder = builder.WithOutputDirectory(options.OutputDirectory);
 

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -62,11 +62,11 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
         {
             switch (type)
             {
-                case CustomUIAPropertyType.String: return UIAutomationType.UIAutomationType_OutString;
+                case CustomUIAPropertyType.String: return UIAutomationType.UIAutomationType_String;
                 case CustomUIAPropertyType.Int: return UIAutomationType.UIAutomationType_Int;
                 case CustomUIAPropertyType.Bool: return UIAutomationType.UIAutomationType_Bool;
                 case CustomUIAPropertyType.Double: return UIAutomationType.UIAutomationType_Double;
-                case CustomUIAPropertyType.Point: return UIAutomationType.UIAutomationType_OutPoint;
+                case CustomUIAPropertyType.Point: return UIAutomationType.UIAutomationType_Point;
                 case CustomUIAPropertyType.Element: return UIAutomationType.UIAutomationType_Element;
                 default: throw new ArgumentException("Unset or unknown type", nameof(type));
             }


### PR DESCRIPTION
#### Details
This PR fixes handling of the string and bool UIA types in `Registrar.GetUnderlyingUIAType` by providing the correct underlying types.

##### Motivation
Part of custom UIA extensions (internal access required to view).

##### Context
N/A

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
