### PR TITLE
feat(custom-uia): Add a command-line option to enable scanning with custom UIA extensions

### DIFF
--- a/src/CLI/IOptions.cs
+++ b/src/CLI/IOptions.cs
@@ -11,5 +11,6 @@ namespace AxeWindowsCLI
         string ProcessName { get; }
         VerbosityLevel VerbosityLevel { get; }
         int DelayInSeconds { get; }
+        string CustomUia { get; }
     }
 }

--- a/src/CLI/Options.cs
+++ b/src/CLI/Options.cs
@@ -32,7 +32,7 @@ namespace AxeWindowsCLI
         // CommandLineParser will never set this value!
         public VerbosityLevel VerbosityLevel { get; set; } = VerbosityLevel.Default;
 
-        [Option("customUIA", Required = false, HelpText = "CustomUia", ResourceType = typeof(Resources.OptionsHelpText))]
+        [Option("CustomUIA", Required = false, HelpText = "CustomUia", ResourceType = typeof(Resources.OptionsHelpText))]
         public string CustomUia{ get; set; }
     }
 }

--- a/src/CLI/Options.cs
+++ b/src/CLI/Options.cs
@@ -31,5 +31,8 @@ namespace AxeWindowsCLI
 
         // CommandLineParser will never set this value!
         public VerbosityLevel VerbosityLevel { get; set; } = VerbosityLevel.Default;
+
+        [Option("custom-uia", Required = false, HelpText = "CustomUia", ResourceType = typeof(Resources.OptionsHelpText))]
+        public string CustomUia{ get; set; }
     }
 }

--- a/src/CLI/Options.cs
+++ b/src/CLI/Options.cs
@@ -32,7 +32,7 @@ namespace AxeWindowsCLI
         // CommandLineParser will never set this value!
         public VerbosityLevel VerbosityLevel { get; set; } = VerbosityLevel.Default;
 
-        [Option("custom-uia", Required = false, HelpText = "CustomUia", ResourceType = typeof(Resources.OptionsHelpText))]
+        [Option("customUIA", Required = false, HelpText = "CustomUia", ResourceType = typeof(Resources.OptionsHelpText))]
         public string CustomUia{ get; set; }
     }
 }

--- a/src/CLI/Options.cs
+++ b/src/CLI/Options.cs
@@ -29,10 +29,10 @@ namespace AxeWindowsCLI
         [Option(Required = false, HelpText = "DelayInSeconds", ResourceType = typeof(Resources.OptionsHelpText))]
         public int DelayInSeconds { get; set; }
 
+        [Option("CustomUIA", Required = false, HelpText = "CustomUia", ResourceType = typeof(Resources.OptionsHelpText))]
+        public string CustomUia { get; set; }
+
         // CommandLineParser will never set this value!
         public VerbosityLevel VerbosityLevel { get; set; } = VerbosityLevel.Default;
-
-        [Option("CustomUIA", Required = false, HelpText = "CustomUia", ResourceType = typeof(Resources.OptionsHelpText))]
-        public string CustomUia{ get; set; }
     }
 }

--- a/src/CLI/Options.cs
+++ b/src/CLI/Options.cs
@@ -29,7 +29,7 @@ namespace AxeWindowsCLI
         [Option(Required = false, HelpText = "DelayInSeconds", ResourceType = typeof(Resources.OptionsHelpText))]
         public int DelayInSeconds { get; set; }
 
-        [Option("CustomUIA", Required = false, HelpText = "CustomUia", ResourceType = typeof(Resources.OptionsHelpText))]
+        [Option(Required = false, HelpText = "CustomUia", ResourceType = typeof(Resources.OptionsHelpText))]
         public string CustomUia { get; set; }
 
         // CommandLineParser will never set this value!

--- a/src/CLI/OptionsEvaluator.cs
+++ b/src/CLI/OptionsEvaluator.cs
@@ -63,6 +63,7 @@ namespace AxeWindowsCLI
                 ScanId = rawInputs.ScanId,
                 VerbosityLevel = verbosityLevel,
                 DelayInSeconds = delayInSeconds,
+                CustomUia = rawInputs.CustomUia,
             };
         }
 

--- a/src/CLI/Resources/OptionsHelpText.Designer.cs
+++ b/src/CLI/Resources/OptionsHelpText.Designer.cs
@@ -61,6 +61,15 @@ namespace AxeWindowsCLI.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The path to a configuration file specifying custom UI Automation attributes.
+        /// </summary>
+        public static string CustomUia {
+            get {
+                return ResourceManager.GetString("CustomUia", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to How many seconds to delay before triggering the scan. Valid range is 0 to 60 seconds, with a default of 0..
         /// </summary>
         public static string DelayInSeconds {

--- a/src/CLI/Resources/OptionsHelpText.resx
+++ b/src/CLI/Resources/OptionsHelpText.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CustomUia" xml:space="preserve">
+    <value>The path to a configuration file specifying custom UI Automation attributes</value>
+  </data>
   <data name="DelayInSeconds" xml:space="preserve">
     <value>How many seconds to delay before triggering the scan. Valid range is 0 to 60 seconds, with a default of 0.</value>
   </data>

--- a/src/CLI/ScanRunner.cs
+++ b/src/CLI/ScanRunner.cs
@@ -17,7 +17,8 @@ namespace AxeWindowsCLI
         {
             Config.Builder builder = Config.Builder
                 .ForProcessId(options.ProcessId)
-                .WithOutputFileFormat(OutputFileFormat.A11yTest);
+                .WithOutputFileFormat(OutputFileFormat.A11yTest)
+                .WithCustomUIAConfig(options.CustomUia);
 
             if (!string.IsNullOrEmpty(options.OutputDirectory))
                 builder = builder.WithOutputDirectory(options.OutputDirectory);

--- a/src/CLITests/OptionsUnitTests.cs
+++ b/src/CLITests/OptionsUnitTests.cs
@@ -21,6 +21,7 @@ namespace AxeWindowsCLITests
         const string ScanIdKey = "--scanid";
         const string ShowThirdPartyNoticesKey = "--showthirdpartynotices";
         const string DelayInSecondsKey = "--delayinseconds";
+        const string CustomUiaKey= "--custom-uia";
 
         const string TestProcessName = "MyProcess";
         const int TestProcessId = 42;
@@ -34,7 +35,7 @@ namespace AxeWindowsCLITests
         private int ValidateOptions(Options options, string processName = null,
             int processId = 0, string outputDirectory = null, string scanId = null,
             string verbosity = null, bool showThirdPartyNotices = false,
-            int delayInSeconds = 0)
+            int delayInSeconds = 0, string customUia=null)
         {
             Assert.AreEqual(processName, options.ProcessName);
             Assert.AreEqual(processId, options.ProcessId);
@@ -44,6 +45,7 @@ namespace AxeWindowsCLITests
             Assert.AreEqual(VerbosityLevel.Default, options.VerbosityLevel);
             Assert.AreEqual(showThirdPartyNotices, options.ShowThirdPartyNotices);
             Assert.AreEqual(delayInSeconds, options.DelayInSeconds);
+            Assert.AreEqual(customUia, options.CustomUia);
             return ExpectedParseSuccess;
         }
 
@@ -133,6 +135,22 @@ namespace AxeWindowsCLITests
             int parseResult = Parser.Default.ParseArguments<Options>(args)
                 .MapResult(
                     (o) => ValidateOptions(o, delayInSeconds: delayInt),
+                    FailIfCalled);
+
+            Assert.AreEqual(ExpectedParseSuccess, parseResult);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ParseArguments_CustomUiaIsSet_SucceedsWithCustomUia()
+        {
+            const string expectedCustomUia = "test.json";
+
+            string[] args = { CustomUiaKey, expectedCustomUia };
+
+            int parseResult = Parser.Default.ParseArguments<Options>(args)
+                .MapResult(
+                    (o) => ValidateOptions(o, customUia: expectedCustomUia),
                     FailIfCalled);
 
             Assert.AreEqual(ExpectedParseSuccess, parseResult);

--- a/src/CLITests/OptionsUnitTests.cs
+++ b/src/CLITests/OptionsUnitTests.cs
@@ -21,7 +21,7 @@ namespace AxeWindowsCLITests
         const string ScanIdKey = "--scanid";
         const string ShowThirdPartyNoticesKey = "--showthirdpartynotices";
         const string DelayInSecondsKey = "--delayinseconds";
-        const string CustomUiaKey= "--custom-uia";
+        const string CustomUiaKey= "--customuia";
 
         const string TestProcessName = "MyProcess";
         const int TestProcessId = 42;

--- a/src/CLITests/OptionsUnitTests.cs
+++ b/src/CLITests/OptionsUnitTests.cs
@@ -35,7 +35,7 @@ namespace AxeWindowsCLITests
         private int ValidateOptions(Options options, string processName = null,
             int processId = 0, string outputDirectory = null, string scanId = null,
             string verbosity = null, bool showThirdPartyNotices = false,
-            int delayInSeconds = 0, string customUia=null)
+            int delayInSeconds = 0, string customUia = null)
         {
             Assert.AreEqual(processName, options.ProcessName);
             Assert.AreEqual(processId, options.ProcessId);


### PR DESCRIPTION
#### Details
This PR adds an option to the CLI allowing users to scan a process with custom UIA configuration.

##### Motivation
Part of custom UIA extensions (internal access required to view).

##### Context
Connection with Accessibility Insights to follow in a subsequent PR.

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000