### PR TITLE
fix: Delete Interop.UIAutomationCore.dll from CLI projects

### DIFF
--- a/src/CLI/CLI.csproj
+++ b/src/CLI/CLI.csproj
@@ -79,4 +79,8 @@
     </None>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="del $(OutDir)Interop.UIAutomationCore.dll" />
+  </Target>
+
 </Project>

--- a/src/CLI_Full/CLI_Full.csproj
+++ b/src/CLI_Full/CLI_Full.csproj
@@ -55,4 +55,8 @@
     <ProjectReference Include="..\Automation\Automation.csproj" />
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="del $(OutDir)Interop.UIAutomationCore.dll" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
#### Details

The signed binary check is unhappy about Interop.UIAutomationCore.dll. We _could_ sign it with our 3rd party cert and ship it with our binaries, but since we embed the assembly in the [Desktop assembly](https://github.com/microsoft/axe-windows/blob/main/src/Desktop/Desktop.csproj#L48), there's no need to ship it.

##### Motivation

Don't ship unsigned files

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
