### PR TITLE
chore: Revert #603

### DIFF
--- a/src/CLI/CLI.csproj
+++ b/src/CLI/CLI.csproj
@@ -79,8 +79,4 @@
     </None>
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="del $(OutDir)Interop.UIAutomationCore.dll" />
-  </Target>
-
 </Project>

--- a/src/CLI_Full/CLI_Full.csproj
+++ b/src/CLI_Full/CLI_Full.csproj
@@ -55,8 +55,4 @@
     <ProjectReference Include="..\Automation\Automation.csproj" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="del $(OutDir)Interop.UIAutomationCore.dll" />
-  </Target>
-
 </Project>


### PR DESCRIPTION
#### Details

#603 didn't work, but we didn't learn that until after it had gone through the signed pipeline. We're reverting the change and taking a different approach that will keep the interop from breaking the MSI install.

##### Motivation

This will not be needed with the new approach.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
