### PR TITLE
feat(custom-uia): Add interop project to facilitate embedding in release

### DIFF
--- a/src/AxeWindows.sln
+++ b/src/AxeWindows.sln
@@ -19,6 +19,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreTests", "CoreTests\CoreTests.csproj", "{BD29FE9B-6FB1-4141-92A5-34C4CAED8274}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Desktop", "Desktop\Desktop.csproj", "{0B9855FD-7B04-415C-A813-DA9697693FDA}"
+	ProjectSection(ProjectDependencies) = postProject
+		{D8127637-0DF7-44EA-96AB-C460B90B342A} = {D8127637-0DF7-44EA-96AB-C460B90B342A}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DesktopTests", "DesktopTests\DesktopTests.csproj", "{AB9E59B6-54CE-4F5D-8055-8AD6745F3B84}"
 EndProject
@@ -63,6 +66,8 @@ Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "CLI_Installer", "CLI_Instal
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CLI_Full", "CLI_Full\CLI_Full.csproj", "{EA268022-DB48-4958-BF9E-A29BF90F51D2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Interop", "Interop\Interop.csproj", "{D8127637-0DF7-44EA-96AB-C460B90B342A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -394,6 +399,18 @@ Global
 		{EA268022-DB48-4958-BF9E-A29BF90F51D2}.Release|x64.Build.0 = Release|Any CPU
 		{EA268022-DB48-4958-BF9E-A29BF90F51D2}.Release|x86.ActiveCfg = Release|Any CPU
 		{EA268022-DB48-4958-BF9E-A29BF90F51D2}.Release|x86.Build.0 = Release|Any CPU
+		{D8127637-0DF7-44EA-96AB-C460B90B342A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8127637-0DF7-44EA-96AB-C460B90B342A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8127637-0DF7-44EA-96AB-C460B90B342A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D8127637-0DF7-44EA-96AB-C460B90B342A}.Debug|x64.Build.0 = Debug|Any CPU
+		{D8127637-0DF7-44EA-96AB-C460B90B342A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D8127637-0DF7-44EA-96AB-C460B90B342A}.Debug|x86.Build.0 = Debug|Any CPU
+		{D8127637-0DF7-44EA-96AB-C460B90B342A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8127637-0DF7-44EA-96AB-C460B90B342A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8127637-0DF7-44EA-96AB-C460B90B342A}.Release|x64.ActiveCfg = Release|Any CPU
+		{D8127637-0DF7-44EA-96AB-C460B90B342A}.Release|x64.Build.0 = Release|Any CPU
+		{D8127637-0DF7-44EA-96AB-C460B90B342A}.Release|x86.ActiveCfg = Release|Any CPU
+		{D8127637-0DF7-44EA-96AB-C460B90B342A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Desktop/Desktop.csproj
+++ b/src/Desktop/Desktop.csproj
@@ -9,7 +9,6 @@
   <Import Project="..\..\build\NetStandardRelease.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Interop.UIAutomationCore.Signed" Version="10.19041.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -44,7 +43,7 @@
 
   <ItemGroup>
     <Reference Include="Interop.UIAutomationCore">
-      <HintPath>Interop.UIAutomationCore.dll</HintPath>
+      <HintPath>..\Interop\bin\$(Configuration)\netcoreapp3.1\Interop.UIAutomationCore.dll</HintPath>
       <EmbedInteropTypes>true</EmbedInteropTypes>
     </Reference>
   </ItemGroup>

--- a/src/DesktopTests/DesktopTests.csproj
+++ b/src/DesktopTests/DesktopTests.csproj
@@ -83,6 +83,13 @@
     <EmbeddedResource Include="TestImages\weird_text_arrangement.bmp" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="Interop.UIAutomationCore">
+      <HintPath>..\Interop\bin\$(Configuration)\netcoreapp3.1\Interop.UIAutomationCore.dll</HintPath>
+      <EmbedInteropTypes>true</EmbedInteropTypes>
+    </Reference>
+  </ItemGroup>
+
   <Import Project="..\..\build\NetStandardTest.targets" />
 
 </Project>

--- a/src/Interop/ForceInclusion.cs
+++ b/src/Interop/ForceInclusion.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Interop.UIAutomationCore;
+using System;
+
+namespace Axe.Windows.Interop
+{
+    static class ForceInclusion
+    {
+        public static Type DummyGetType()
+        {
+            return new CUIAutomationRegistrar().GetType();
+        }
+
+        public static void Main() =>
+#pragma warning disable CA1303 // Do not pass literals as localized parameters
+            Console.WriteLine("This project exists to help us consume Interop.UIAutomationCore.dll.");
+#pragma warning restore CA1303 // Do not pass literals as localized parameters
+
+    }
+}

--- a/src/Interop/Interop.csproj
+++ b/src/Interop/Interop.csproj
@@ -1,4 +1,4 @@
-﻿	<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Interop/Interop.csproj
+++ b/src/Interop/Interop.csproj
@@ -1,0 +1,34 @@
+﻿	<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AssemblyName>Axe.Windows.Interop</AssemblyName>
+    <RootNamespace>Axe.Windows.Interop</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Interop.UIAutomationCore.Signed" Version="10.19041.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.3.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
+    <PackageReference Include="Text.Analyzers" Version="2.6.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <Import Project="..\..\build\NetStandardRelease.targets" />
+  
+</Project>


### PR DESCRIPTION
#### Details
This PR adds an interop dummy project containing the `Interop.UIAutomationcore.signed` package to facilitate embedding Interop.UIAutomationCore.dll (which we get through a NuGet package) into Axe.Windows.Desktop.dlll, instead of shipping it as a standalone assembly.

##### Motivation
Part of custom UIA extensions (internal access required to view).

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
