### PR TITLE
fix: Solve resource problem with CLI_Full project

### DIFF
--- a/src/AxeWindows.sln
+++ b/src/AxeWindows.sln
@@ -66,6 +66,9 @@ Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "CLI_Installer", "CLI_Instal
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CLI_Full", "CLI_Full\CLI_Full.csproj", "{EA268022-DB48-4958-BF9E-A29BF90F51D2}"
+	ProjectSection(ProjectDependencies) = postProject
+		{EE543183-CD9C-4AED-A5F8-12CBCBDBB3C4} = {EE543183-CD9C-4AED-A5F8-12CBCBDBB3C4}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Interop", "Interop\Interop.csproj", "{D8127637-0DF7-44EA-96AB-C460B90B342A}"
 EndProject

--- a/src/CLI_Full/BuildNotes.md
+++ b/src/CLI_Full/BuildNotes.md
@@ -1,5 +1,5 @@
 # Build notes for CLI_Full project
 
-The `CLI_Full` project exists to gather the CLI into a self-contained format (.zip) where all necessary .NET Core runtime files are gathered by the compiler. We compile the code from the `CLI` project is used, but specify extra flags to create the self-contained version. We end up with two versions of `AxeWindowsCLI.exe`, which are not interchangeable due to compiler-generated differences inside the binaries.
+The `CLI_Full` project exists to gather the CLI into a self-contained format (.zip) where all necessary .NET Core runtime files are gathered by the compiler. We compile the code from the `CLI` project is used, but specify extra flags to create the self-contained version. We end up with two versions of `AxeWindowsCLI.exe`, which are not interchangeable due to compiler-generated differences inside the binaries. The csproj file that builds CLI_Full actually _copies_ AxeWindowsCLI.dll as part of the build. This was added to ensure that resources are identical between the 2 flavors.
 
-Changes that impact _common functionality_ need to be made in the `CLI` project. changes that impact the generation of the self-contained version need to be made in the `CLI_Full` project.
+The _only_ changes to be made in the `CLI_Full` project are those change that impact the packaging of the zip file.

--- a/src/CLI_Full/CLI_Full.csproj
+++ b/src/CLI_Full/CLI_Full.csproj
@@ -55,4 +55,8 @@
     <ProjectReference Include="..\Automation\Automation.csproj" />
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="copy /y $(ProjectDir)\..\CLI\bin\$(Configuration)\netcoreapp3.1\AxeWindowsCLI.dll $(TargetDir)" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
#### Details

Fix resource binding issue in `CLI_Full` project. This fixes a bug introduced in #577, when hardcoded strings in CLI were replaced by resource strings, and CLI_Full got enough of the strings to compile but not enough to embed the resources into the compiled binary. Since there is no intended difference between the `AxeWindowsCLI.dll` files that get generated by `CLI` and `CLI_Full`, this change ensures that `CLI` builds before `CLI_Full`, then adds a post-build step to copy `AxeWindowsCLI.dll` from `CLI` to `CLI_Full`. Not necessarily the prettiest fix, but surprisingly effective. I also updated `BuildNotes.md` with this information and strengthened its warning about making changes in the `CLI_Full` project.

##### Motivation

The `CLI_Full` package should work

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
I considered trying to modify `CLI_Full.csproj` in a way that would force the resources to get properly loaded into the binary built by the `CLI_Full` project, but that would have required duplicating a lot of VS-managed dependency tracking and it quickly got messy. Simply copying the binary over was quick and painless. It _might_ mean that this assembly gets signed twice in a signed build, but that seems like a very minor downside.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
