### PR TITLE
feat(custom-uia): make namespacing for CustomUIAAction more consistent with other actions

### DIFF
--- a/src/Actions/Actions/CustomUIAAction.cs
+++ b/src/Actions/Actions/CustomUIAAction.cs
@@ -6,7 +6,7 @@ using Axe.Windows.Desktop.UIAutomation.CustomObjects;
 using System;
 using System.Collections.Generic;
 
-namespace Axe.Windows.Actions.Actions
+namespace Axe.Windows.Actions
 {
     public static class CustomUIAAction
     {

--- a/src/Automation/AxeWindowsActions.cs
+++ b/src/Automation/AxeWindowsActions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Actions;
-using Axe.Windows.Actions.Actions;
 using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Actions.Enums;
 using Axe.Windows.Actions.Misc;

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Axe.Windows.Actions.Actions;
+using Axe.Windows.Actions;
 using Axe.Windows.Automation.Resources;
 using Axe.Windows.Core.Bases;
 using System;


### PR DESCRIPTION
#### Details
This PR moves `CustomUIAAction` from `Axe.Windows.Actions.Actions` to `Axe.Windows.Actions`.

##### Motivation
Consistency.

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
