### PR TITLE
feat(custom-uia): save and load custom property registrations as part of the .a11ytest archive

### DIFF
--- a/src/Actions/Actions/CaptureAction.cs
+++ b/src/Actions/Actions/CaptureAction.cs
@@ -7,6 +7,7 @@ using Axe.Windows.Actions.Enums;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;
+using Axe.Windows.Desktop.UIAutomation.CustomObjects;
 using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using System;
 using System.Collections.Generic;
@@ -91,6 +92,8 @@ namespace Axe.Windows.Actions
             if (ec.DataContext != null && ec.DataContext.Mode == DataContextMode.Live)
             {
                 ec.DataContext = null;
+                // Re-register user-configured custom UIA data
+                Registrar.GetDefaultInstance().RestoreCustomPropertyRegistrations();
             }
 
             if (NeedNewDataContext(ec.DataContext, dm, tvm) || force)

--- a/src/Actions/Actions/LoadAction.cs
+++ b/src/Actions/Actions/LoadAction.cs
@@ -112,9 +112,9 @@ namespace Axe.Windows.Actions
             using (StreamReader reader = new StreamReader(stream))
             {
                 string jsonProps = reader.ReadToEnd();
-                Dictionary<int, CustomProperty> res = JsonConvert.DeserializeObject<Dictionary<int, CustomProperty>>(jsonProps);
-                Registrar.GetDefaultInstance().MergeCustomPropertyRegistrations(res);
-                return res;
+                Dictionary<int, CustomProperty> deserializedProperties = JsonConvert.DeserializeObject<Dictionary<int, CustomProperty>>(jsonProps);
+                Registrar.GetDefaultInstance().MergeCustomPropertyRegistrations(deserializedProperties);
+                return deserializedProperties;
             }
         }
     }

--- a/src/Actions/Actions/LoadAction.cs
+++ b/src/Actions/Actions/LoadAction.cs
@@ -64,15 +64,18 @@ namespace Axe.Windows.Actions
                     CustomProperties = LoadCustomProperties(customPropertiesPart);
                     customPropertiesPart.Close();
                 }
-                catch (InvalidOperationException e)  // Gets thrown if custom properties map doesn't exist in file
+#pragma warning disable CA1031 // Do not catch general exception types: specific handlers placed in conditional below
+                catch (Exception e)
+#pragma warning restore CA1031 // Do not catch general exception types: specific handlers placed in conditional below
                 {
-                    e.ReportException();
+                    if (!(e is InvalidOperationException))  // An expected exception thrown when file does not exist, such as in old a11ytest files
+                        e.ReportException();
                     CustomProperties = null;
                 }
 
                 var selectedElement = element.FindDescendant(k => k.UniqueId == meta.ScreenshotElementId);
 
-                return new LoadActionParts(element, bmp, selectedElement.SynthesizeBitmapFromElements(), meta, CustomProperties);
+                return new LoadActionParts(element, bmp, selectedElement.SynthesizeBitmapFromElements(), meta);
             }
         }
 

--- a/src/Actions/Actions/LoadActionParts.cs
+++ b/src/Actions/Actions/LoadActionParts.cs
@@ -35,24 +35,18 @@ namespace Axe.Windows.Actions
         public SnapshotMetaInfo MetaInfo { get; private set; }
 
         /// <summary>
-        /// Custom UIA registrations
-        /// </summary>
-        IReadOnlyDictionary<int, CustomProperty> CustomProperties { get; }
-
-        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="el">The element that was selected when the file was saved</param>
         /// <param name="bmp">Actual screenshot</param>
         /// <param name="synthesizedBmp">Synthesized ("yellow box") bitmap</param>
         /// <param name="settings">Metadata about the snapshot</param>
-        public LoadActionParts(A11yElement el, Bitmap bmp, Bitmap synthesizedBmp, SnapshotMetaInfo settings, IReadOnlyDictionary<int, CustomProperty> customProperties)
+        public LoadActionParts(A11yElement el, Bitmap bmp, Bitmap synthesizedBmp, SnapshotMetaInfo settings)
         {
             this.Element = el;
             this.Bmp = bmp;
             this.SynthesizedBmp = synthesizedBmp;
             this.MetaInfo = settings;
-            this.CustomProperties = customProperties;
         }
     }
 }

--- a/src/Actions/Actions/LoadActionParts.cs
+++ b/src/Actions/Actions/LoadActionParts.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.CustomObjects;
 using Axe.Windows.Desktop.Settings;
+using System.Collections.Generic;
 using System.Drawing;
 
 namespace Axe.Windows.Actions
@@ -32,18 +35,24 @@ namespace Axe.Windows.Actions
         public SnapshotMetaInfo MetaInfo { get; private set; }
 
         /// <summary>
+        /// Custom UIA registrations
+        /// </summary>
+        IReadOnlyDictionary<int, CustomProperty> CustomProperties { get; }
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="el">The element that was selected when the file was saved</param>
         /// <param name="bmp">Actual screenshot</param>
         /// <param name="synthesizedBmp">Synthesized ("yellow box") bitmap</param>
         /// <param name="settings">Metadata about the snapshot</param>
-        public LoadActionParts(A11yElement el, Bitmap bmp, Bitmap synthesizedBmp, SnapshotMetaInfo settings)
+        public LoadActionParts(A11yElement el, Bitmap bmp, Bitmap synthesizedBmp, SnapshotMetaInfo settings, IReadOnlyDictionary<int, CustomProperty> customProperties)
         {
             this.Element = el;
             this.Bmp = bmp;
             this.SynthesizedBmp = synthesizedBmp;
             this.MetaInfo = settings;
+            this.CustomProperties = customProperties;
         }
     }
 }

--- a/src/Actions/Actions/SaveAction.cs
+++ b/src/Actions/Actions/SaveAction.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Actions.Attributes;
 using Axe.Windows.Actions.Enums;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Desktop.Settings;
+using Axe.Windows.Desktop.UIAutomation.CustomObjects;
 using Axe.Windows.RuleSelection;
 using Newtonsoft.Json;
 using System;
@@ -25,6 +27,7 @@ namespace Axe.Windows.Actions
         public const string elementFileName = "el.snapshot";
         public const string screenshotFileName = "scshot.png";
         public const string metadataFileName = "metadata.json";
+        public const string customPropsFileName = "CustomProperties.json";
 
         /// <summary>
         /// Buffer size for stream copying
@@ -76,6 +79,13 @@ namespace Axe.Windows.Actions
             using (MemoryStream mStrm = new MemoryStream(Encoding.UTF8.GetBytes(jsonMeta)))
             {
                 AddStream(package, mStrm, metadataFileName);
+            }
+
+            var customProps = Registrar.GetDefaultInstance().GetCustomPropertyRegistrations();
+            var jsonCustomProps = JsonConvert.SerializeObject(customProps, Formatting.Indented);
+            using (MemoryStream mStrm = new MemoryStream(Encoding.UTF8.GetBytes(jsonCustomProps)))
+            {
+                AddStream(package, mStrm, customPropsFileName);
             }
         }
 

--- a/src/Core/CustomObjects/CustomProperty.cs
+++ b/src/Core/CustomObjects/CustomProperty.cs
@@ -22,6 +22,7 @@ namespace Axe.Windows.Core.CustomObjects
         public string ProgrammaticName { get; set; }
 
         ///  <summary>An internal representation of this property's type. For performance reasons, calling code should always use this property in place of the config representation.s</summary>
+        [JsonIgnore]
         public CustomUIAPropertyType Type { get; private set; }
 
         public const string StringConfigType = "string";

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -59,8 +59,12 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
         public Dictionary<int, CustomProperty> GetCustomPropertyRegistrations() { return new Dictionary<int, CustomProperty>(_idToCustomPropertyMap); }
 #pragma warning restore CA1024 // Use properties where appropriate: this is a copy of the object, not the object itself
 
-        ///  <summary>Notifies ConverterRegistrationAction about all of the custom property registrations in the passed-in dictionary. This is used, for instance, when switching between file and live mode in Accessibility Insights for Windows.</summary>
-        ///  <remarks>This function assumes that when ConverterRegistrationAction is called multiple times, the last call wins.</remarks>
+        /// <summary>
+        /// Notifies ConverterRegistrationAction about all of the custom property registrations in
+        // the passed-in dictionary. This is used, for instance, when switching between file and
+        // live mode in Accessibility Insights for Windows.
+        /// </summary>
+        /// <remarks>This function assumes that when ConverterRegistrationAction is called multiple times, the last call wins.</remarks>
         public void MergeCustomPropertyRegistrations(IReadOnlyDictionary<int, CustomProperty> registrations)
         {
             if (registrations== null) throw new ArgumentNullException(nameof(registrations));
@@ -70,8 +74,12 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
             }
         }
 
-        /// <summary>Re-notifies converterRegistrationAction of the custom properties registered with UIA, in effect restoring IDs registered in live mode to the state before any calls to MergeCustomPropertyRegistrations.</summary>
-        ///  <remarks>This function assumes that when ConverterRegistrationAction is called multiple times, the last call wins.</remarks>
+        /// <summary>
+        // Re-notifies converterRegistrationAction of the custom properties registered with UIA, in
+        // effect restoring IDs registered in live mode to the state before any calls to
+        // MergeCustomPropertyRegistrations.
+        // </summary>
+        /// <remarks>This function assumes that when ConverterRegistrationAction is called multiple times, the last call wins.</remarks>
         public void RestoreCustomPropertyRegistrations() { MergeCustomPropertyRegistrations(_idToCustomPropertyMap); }
 
         private static UIAutomationType GetUnderlyingUIAType(CustomUIAPropertyType type)

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -59,6 +59,21 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
         public Dictionary<int, CustomProperty> GetCustomPropertyRegistrations() { return new Dictionary<int, CustomProperty>(_idToCustomPropertyMap); }
 #pragma warning restore CA1024 // Use properties where appropriate: this is a copy of the object, not the object itself
 
+        ///  <summary>Notifies ConverterRegistrationAction about all of the custom property registrations in the passed-in dictionary. This is used, for instance, when switching between file and live mode in Accessibility Insights for Windows.</summary>
+        ///  <remarks>This function assumes that when ConverterRegistrationAction is called multiple times, the last call wins.</remarks>
+        public void MergeCustomPropertyRegistrations(IReadOnlyDictionary<int, CustomProperty> registrations)
+        {
+            if (registrations== null) throw new ArgumentNullException(nameof(registrations));
+            foreach (KeyValuePair<int, CustomProperty> entry in registrations)
+            {
+                _converterRegistrationAction(entry.Key, CreateTypeConverter(entry.Value));
+            }
+        }
+
+        /// <summary>Re-notifies converterRegistrationAction of the custom properties registered with UIA, in effect restoring IDs registered in live mode to the state before any calls to MergeCustomPropertyRegistrations.</summary>
+        ///  <remarks>This function assumes that when ConverterRegistrationAction is called multiple times, the last call wins.</remarks>
+        public void RestoreCustomPropertyRegistrations() { MergeCustomPropertyRegistrations(_idToCustomPropertyMap); }
+
         private static UIAutomationType GetUnderlyingUIAType(CustomUIAPropertyType type)
         {
             switch (type)

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -61,8 +61,8 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
 
         /// <summary>
         /// Notifies ConverterRegistrationAction about all of the custom property registrations in
-        // the passed-in dictionary. This is used, for instance, when switching between file and
-        // live mode in Accessibility Insights for Windows.
+        /// the passed-in dictionary. This is used, for instance, when switching between file and
+        /// live mode in Accessibility Insights for Windows.
         /// </summary>
         /// <remarks>This function assumes that when ConverterRegistrationAction is called multiple times, the last call wins.</remarks>
         public void MergeCustomPropertyRegistrations(IReadOnlyDictionary<int, CustomProperty> registrations)

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -75,10 +75,10 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
         }
 
         /// <summary>
-        // Re-notifies converterRegistrationAction of the custom properties registered with UIA, in
-        // effect restoring IDs registered in live mode to the state before any calls to
-        // MergeCustomPropertyRegistrations.
-        // </summary>
+        /// Re-notifies converterRegistrationAction of the custom properties registered with UIA, in
+        /// effect restoring IDs registered in live mode to the state before any calls to
+        /// MergeCustomPropertyRegistrations.
+        /// </summary>
         /// <remarks>This function assumes that when ConverterRegistrationAction is called multiple times, the last call wins.</remarks>
         public void RestoreCustomPropertyRegistrations() { MergeCustomPropertyRegistrations(_idToCustomPropertyMap); }
 

--- a/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
@@ -20,7 +20,7 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
         {
             Guid propertyGuid = new Guid("312F7536-259A-47C7-B192-AA16352522C4");
             string propertyName = "CommentReplyCount";
-            CustomProperty propertyToRegister = new CustomProperty { Guid = propertyGuid, ProgrammaticName = propertyName, ConfigType = "int" };
+            CustomProperty propertyToRegister = new CustomProperty { Guid = propertyGuid, ProgrammaticName = propertyName, ConfigType = CustomProperty.IntConfigType};
             UIAutomationPropertyInfo expectedPropertyInfo = new UIAutomationPropertyInfo { guid = propertyGuid, pProgrammaticName = propertyName, type = UIAutomationType.UIAutomationType_Int };
             int propertyId = 43;
             Mock<IUIAutomationRegistrar> uiaRegistrarMock = new Mock<IUIAutomationRegistrar>(MockBehavior.Strict);
@@ -104,14 +104,14 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
 
             Guid intPropertyGuid = new Guid("312F7536-259A-47C7-B192-AA16352522C4");
             string intPropertyName = "CommentReplyCount";
-            CustomProperty intProperty = new CustomProperty { Guid = intPropertyGuid, ProgrammaticName = intPropertyName, ConfigType = "int" };
+            CustomProperty intProperty = new CustomProperty { Guid = intPropertyGuid, ProgrammaticName = intPropertyName, ConfigType = CustomProperty.IntConfigType};
             UIAutomationPropertyInfo expectedIntPropertyInfo = new UIAutomationPropertyInfo { guid = intPropertyGuid, pProgrammaticName = intPropertyName, type = UIAutomationType.UIAutomationType_Int };
             int propertyId = 42;
             uiaRegistrarMock.Setup(x => x.RegisterProperty(ref expectedIntPropertyInfo, out propertyId));
 
             Guid boolPropertyGuid = new Guid("4BB56516-F354-44CF-A5AA-96B52E968CFD");
             string boolPropertyName = "AreGridlinesVisible";
-            CustomProperty boolProperty = new CustomProperty { Guid = boolPropertyGuid, ProgrammaticName = boolPropertyName, ConfigType = "bool" };
+            CustomProperty boolProperty = new CustomProperty { Guid = boolPropertyGuid, ProgrammaticName = boolPropertyName, ConfigType = CustomProperty.BoolConfigType};
 
             int counter = 0;
             Action<int, ITypeConverter> testCallback = new Action<int, ITypeConverter>((id, converter) =>

--- a/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
@@ -117,9 +117,9 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
             Action<int, ITypeConverter> testCallback = new Action<int, ITypeConverter>((id, converter) =>
             {
                 counter++;
-                if (counter % 2 == 1)
+                if (counter % 2 == 1) // first and third calls (register and restore)
                     Assert.IsInstanceOfType(converter, typeof(IntTypeConverter));
-                else
+                else // second call (merge)
                     Assert.IsInstanceOfType(converter, typeof(BoolTypeConverter));
             });
 


### PR DESCRIPTION
#### Details
This PR allows for the display of enums and handling of ID clashes in .a11ytest files by saving and loading UIA custom property registrations as part of the data.

##### Motivation
Part of custom UIA extensions (internal access required to view).

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
