### PR TITLE
fix: Exclude WinForms edit control from ControlShouldSupportTextPattern rule

### DIFF
--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.AutomationTests
         // These values should change only in response to intentional rule modifications
         const int WildlifeManagerKnownErrorCount = 12;
         const int Win32ControlSamplerKnownErrorCount = 0;
-        const int WindowsFormsControlSamplerKnownErrorCount = 6;
+        const int WindowsFormsControlSamplerKnownErrorCount = 4;
         const int WpfControlSamplerKnownErrorCount = 5;
 
         readonly string WildlifeManagerAppPath = Path.GetFullPath("../../../../../tools/WildlifeManager/WildlifeManager.exe");

--- a/src/Rules/Library/ControlShouldSupportTextPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTextPattern.cs
@@ -31,12 +31,14 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
+            var winFormsEdit = Edit & WinForms;
             var win32Edit = Edit & Win32Framework;
             var nonfocusableDirectUIEdit = Edit & ~IsKeyboardFocusable & DirectUI;
 
             return Document
                 | (Edit
                 & ~win32Edit
+                & ~winFormsEdit
                 & ~nonfocusableDirectUIEdit);
         }
     } // class

--- a/src/RulesTest/Library/ControlShouldSupportTextPatternUnitTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTextPatternUnitTests.cs
@@ -59,6 +59,16 @@ namespace Axe.Windows.RulesTests.Library
         }
 
         [TestMethod]
+        public void WinFormsEdit_NotApplicable()
+        {
+            var e = new MockA11yElement();
+            e.ControlTypeId = ControlType.Edit;
+            e.Framework = FrameworkId.WinForm;
+
+            Assert.IsFalse(Rule.Condition.Matches(e));
+        }
+
+        [TestMethod]
         public void DirectUIEdit_NotApplicable()
         {
             var e = new MockA11yElement();


### PR DESCRIPTION
#### Details

As reported in #636, WinForms Edit controls don't support TextPattern. It's a known framework issue that we don't really expect app developers to try to fix. It's possible that a future .NET WinForms version might support this pattern, but there's no guarantee of _if_ or _when_ this might occur. To minimize noise, we've decided to exclude WinForms edit controls from this rule until a less noisy solution becomes available. 

##### Motivation

Remove noise, address #636

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #636 
