### PR TITLE
fix: Ignore names on WPF Text inside a CheckBox

### DIFF
--- a/src/Rules/PropertyConditions/ElementGroups.cs
+++ b/src/Rules/PropertyConditions/ElementGroups.cs
@@ -141,7 +141,7 @@ namespace Axe.Windows.Rules.PropertyConditions
                 | ToolTip | Tree | TreeItem | Window
                 | trueWhenElementHasSiblingsOfSameType)
                 & ~IsWPFCheckBoxText
-                &~isWPFPopupOrContextMenu;
+                & ~isWPFPopupOrContextMenu;
         }
 
         private static Condition CreateNameOptionalCondition()

--- a/src/Rules/PropertyConditions/ElementGroups.cs
+++ b/src/Rules/PropertyConditions/ElementGroups.cs
@@ -31,6 +31,8 @@ namespace Axe.Windows.Rules.PropertyConditions
         public static Condition ParentWPFDataItem = CreateParentWPFDataItemCondition();
         public static Condition WPFScrollBarPageButtons = CreateWPFScrollBarPageButtons();
         public static Condition NonFocusableSliderButtons = CreateNonFocusableSliderButtonsCondition();
+        public static Condition IsCheckBoxText = Text & AnyAncestor(CheckBox);
+        public static Condition IsWPFCheckBoxText = WPF & IsCheckBoxText;
         public static Condition NameRequired = CreateNameRequiredCondition();
         public static Condition NameOptional = CreateNameOptionalCondition();
         public static Condition IsControlElementTrueRequired = CreateIsControlRequiredCondition();
@@ -138,7 +140,8 @@ namespace Axe.Windows.Rules.PropertyConditions
                 | Table | allowedText | ToolBar
                 | ToolTip | Tree | TreeItem | Window
                 | trueWhenElementHasSiblingsOfSameType)
-                & ~isWPFPopupOrContextMenu;
+                & ~IsWPFCheckBoxText
+                &~isWPFPopupOrContextMenu;
         }
 
         private static Condition CreateNameOptionalCondition()

--- a/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
+++ b/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
@@ -287,8 +287,6 @@ namespace Axe.Windows.RulesTests.PropertyConditions
             using (var e = new MockA11yElement())
             using (var parent = new MockA11yElement())
             {
-                Assert.IsFalse(ElementGroups.IsCheckBoxText.Matches(e));
-
                 e.ControlTypeId = Button;
                 Assert.IsFalse(ElementGroups.IsCheckBoxText.Matches(e));
 
@@ -298,9 +296,6 @@ namespace Axe.Windows.RulesTests.PropertyConditions
                 e.Parent = parent;
                 parent.ControlTypeId = CheckBox;
                 Assert.IsTrue(ElementGroups.IsCheckBoxText.Matches(e));
-
-                parent.ControlTypeId = Window;
-                Assert.IsFalse(ElementGroups.IsCheckBoxText.Matches(e));
 
                 e.ControlTypeId = Button;
                 Assert.IsFalse(ElementGroups.IsCheckBoxText.Matches(e));

--- a/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
+++ b/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
@@ -280,5 +280,54 @@ namespace Axe.Windows.RulesTests.PropertyConditions
                 Assert.IsFalse(ElementGroups.IsButtonText.Matches(e));
             } // using
         }
+
+        [TestMethod]
+        public void IsCheckBoxText_MatchExpected()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                Assert.IsFalse(ElementGroups.IsCheckBoxText.Matches(e));
+
+                e.ControlTypeId = Button;
+                Assert.IsFalse(ElementGroups.IsCheckBoxText.Matches(e));
+
+                e.ControlTypeId = Text;
+                Assert.IsFalse(ElementGroups.IsCheckBoxText.Matches(e));
+
+                e.Parent = parent;
+                parent.ControlTypeId = CheckBox;
+                Assert.IsTrue(ElementGroups.IsCheckBoxText.Matches(e));
+
+                parent.ControlTypeId = Window;
+                Assert.IsFalse(ElementGroups.IsCheckBoxText.Matches(e));
+
+                e.ControlTypeId = Button;
+                Assert.IsFalse(ElementGroups.IsCheckBoxText.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void IsWPFCheckBoxText_MatchExpected()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                Assert.IsFalse(ElementGroups.IsWPFCheckBoxText.Matches(e));
+
+                // Exhaustive checks for IsCheckBoxText is handled in
+                // IsCheckBoxText_MatchExpected, so just need 1 true case
+                parent.ControlTypeId = CheckBox;
+                e.Parent = parent;
+                e.ControlTypeId = Text;
+                Assert.IsFalse(ElementGroups.IsWPFCheckBoxText.Matches(e));
+
+                e.Framework = "WPF";
+                Assert.IsTrue(ElementGroups.IsWPFCheckBoxText.Matches(e));
+
+                e.Parent = null;
+                Assert.IsFalse(ElementGroups.IsWPFCheckBoxText.Matches(e));
+            } // using
+        }
     } // class
 } // namespace


### PR DESCRIPTION
#### Details

As called out in #648, we should skip name checking of items inside a WPF CheckBox, since AT's will simply read the Name property of the CheckBox, which will be set either by the framework or overridden by the app developer.

##### Motivation

Handle case identified in #648.

##### Context

This is similar to #572, but handled differently. #572 changed the condition on a single rule, but this effectively causes us to ignore _all_ name-related rules within the scope of the fix. Happy to discuss pros & cons of the options, if desired.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #648 
