### PR TITLE
chore: Remove legacy constructor for BitmapCollection

### DIFF
--- a/src/Desktop/ColorContrastAnalyzer/BitmapCollection.cs
+++ b/src/Desktop/ColorContrastAnalyzer/BitmapCollection.cs
@@ -7,12 +7,6 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
     {
         private readonly System.Drawing.Bitmap bitmap;
 
-        // Temporary legacy constructor, will be removed after the new ctor is wired up in AIWin
-        public BitmapCollection(System.Drawing.Bitmap bitmap)
-            : this(bitmap, new DefaultColorContrastConfig())
-        {
-        }
-
         public BitmapCollection(System.Drawing.Bitmap bitmap, IColorContrastConfig colorContrastConfig)
             : base(colorContrastConfig)
         {


### PR DESCRIPTION
#### Details

Finish the change that was started with #469, then forgotten. This will merge only after https://github.com/microsoft/accessibility-insights-windows/pull/1245, which adds the corresponding change in AIWin, merges. There are no other supported callers of the `BitmapCollection` class.

##### Motivation

We want to allow AIWin to experiment with different parameters to the color auto-detection algorithm, without requiring a re-release of Axe.Windows.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
