### PR TITLE
feat(compliance-fall-21): Exclude non-localizable fields from CLI help output

### DIFF
--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -3,6 +3,7 @@
 
 using Axe.Windows.Automation;
 using CommandLine;
+using CommandLine.Text;
 using System;
 using System.IO;
 using System.Threading;
@@ -59,8 +60,18 @@ namespace AxeWindowsCLI
             {
                 using (var parser = CaseInsensitiveParser())
                 {
-                    parser.ParseArguments<Options>(_args)
-                        .WithParsed<Options>(RunWithParsedInputs);
+                    ParserResult<Options> parserResult = parser.ParseArguments<Options>(_args);
+                    parserResult.WithParsed(RunWithParsedInputs)
+                        .WithNotParsed(_ =>
+                        {
+                            HelpText helpText = HelpText.AutoBuild(parserResult, h =>
+                            {
+                                h.AutoHelp = false;     // hides --help
+                                h.AutoVersion = false;  // hides --version
+                                return HelpText.DefaultParsingErrorsHandler(parserResult, h);
+                            }, e => e);
+                            Console.WriteLine(helpText);
+                        });
                 }
             }
 #pragma warning disable CA1031

--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -70,7 +70,7 @@ namespace AxeWindowsCLI
                                 h.AutoVersion = false;  // hides --version
                                 return HelpText.DefaultParsingErrorsHandler(parserResult, h);
                             }, e => e);
-                            Console.WriteLine(helpText);
+                            _writer.WriteLine(helpText);
                         });
                 }
             }

--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -36,10 +36,6 @@ Copyright c 2020
                              a default of 0.
 
   --customuia                The path to a configuration file specifying custom UI Automation attributes
-
-  --help                     Display this help screen.
-
-  --version                  Display version information.
 ```
 
   To scan an application, you need to specify the application's process via either the `--processId` or `--processName` parameters


### PR DESCRIPTION
#### Details

When running the CLI, we use localized text for the fields that we control, but the fields for `--help` and `--version` are hardcoded:

```
AxeWindowsCLI 1.0.10
Copyright c 2020
  --processid                Process Id
  --processname              Process Name
  --outputdirectory          Output directory
  --scanid                   Scan ID
  --verbosity                Verbosity level (Quiet/Default/Verbose)
  --showthirdpartynotices    Display Third Party Notices (opens file in browser
                             without executing scan). If specified, all other
                             options will be ignored.
  --delayinseconds           How many seconds to delay before triggering the
                             scan. Valid range is 0 to 60 seconds, with a
                             default of 0.
  --customuia                The path to a configuration file specifying custom
                             UI Automation attributes
  --help                     Display this help screen.
  --version                  Display version information.
```

The --help and --version fields are hardcoded in `ComandLineParser` and frankly aren't very interesting for our purposes, so we'll just exclude then from the output. Here's the output with this change (same as before, but without the --help or --version options):

```
AxeWindowsCLI 1.1.10
Copyright c 2020
  --processid                Process Id
  --processname              Process Name
  --outputdirectory          Output directory
  --scanid                   Scan ID
  --verbosity                Verbosity level (Quiet/Default/Verbose)
  --showthirdpartynotices    Display Third Party Notices (opens file in browser
                             without executing scan). If specified, all other
                             options will be ignored.
  --delayinseconds           How many seconds to delay before triggering the
                             scan. Valid range is 0 to 60 seconds, with a
                             default of 0.
  --customuia                The path to a configuration file specifying custom
                             UI Automation attributes
```


##### Motivation

Part of global readiness compliance work. Make it simpler to localize the CLI if/when that ever happens.

##### Context

The code changes are based on the documented way to handle this at https://github.com/commandlineparser/commandline/wiki/How-To#q1

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
