### PR TITLE
fix: Update misleading split button pattern error message

### DIFF
--- a/docs/RulesDescription.md
+++ b/docs/RulesDescription.md
@@ -13,7 +13,7 @@ BoundingRectangleOnUWPMenuBar | Open | The BoundingRectangle property of a menub
 BoundingRectangleOnUWPMenuItem | Open | The BoundingRectangle property of a menu item in UWP may have a null or empty value. | Section 508 502.3.1 ObjectInformation
 BoundingRectangleOnWPFTextParent | Open | The BoundingRectangle property of a given element in the WPF framework whose parent is of type text may have a null or empty value. | Section 508 502.3.1 ObjectInformation
 BoundingRectangleSizeReasonable | Error | The BoundingRectangle property must represent an area of at least 25 pixels. | Section 508 502.3.1 ObjectInformation
-SplitButtonInvokeAndTogglePatterns | Error | A split button must not support both the Invoke and Toggle patterns. | WCAG 4.1.2 NameRoleValue
+SplitButtonInvokeAndTogglePatterns | Error | A split button must support exactly one of the Invoke or Toggle patterns. | WCAG 4.1.2 NameRoleValue
 ButtonShouldHavePatterns | Error | A button must support one of these patterns: Invoke, Toggle, or ExpandCollapse. | WCAG 4.1.2 NameRoleValue
 ButtonInvokeAndTogglePatterns | Error | A button must not support both the Invoke and Toggle patterns. | WCAG 4.1.2 NameRoleValue
 ButtonInvokeAndExpandCollapsePatterns | Warning | A button may have the Invoke and ExpandCollapse patterns together, but it is not recommended. If possible, please have only one of them.  | WCAG 1.3.1 InfoAndRelationships

--- a/src/Rules/Resources/Descriptions.Designer.cs
+++ b/src/Rules/Resources/Descriptions.Designer.cs
@@ -970,7 +970,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A split button must not support both the Invoke and Toggle patterns..
+        ///   Looks up a localized string similar to A split button must support exactly one of the Invoke or Toggle patterns..
         /// </summary>
         internal static string SplitButtonInvokeAndTogglePatterns {
             get {

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -235,7 +235,7 @@
     <value>The RangeValue pattern of an edit control must have a null LargeChange property.</value>
   </data>
   <data name="SplitButtonInvokeAndTogglePatterns" xml:space="preserve">
-    <value>A split button must not support both the Invoke and Toggle patterns.</value>
+    <value>A split button must support exactly one of the Invoke or Toggle patterns.</value>
   </data>
   <data name="ControlShouldNotSupportInvokePattern" xml:space="preserve">
     <value>An element of the given ControlType must not support the Invoke pattern.</value>


### PR DESCRIPTION
#### Details

Updates the error message as discussed in #653 

##### Motivation

Addresses #653

##### Context

N/A
#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #653
