### PR TITLE
fix: Fix win32 SplitButton nesting leading to faulty expand collapse pattern rule errors

### DIFF
--- a/src/Rules/Library/ControlShouldSupportExpandCollapsePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportExpandCollapsePattern.cs
@@ -30,8 +30,9 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
+            var elligbleSplitButton = SplitButton & ~Parent(SplitButton);
             var complexComboBox = ComboBox & ~PlatformProperties.SimpleStyle;
-            return AppBar | complexComboBox | SplitButton | (TreeItem & TreeItemChildrenExist);
+            return AppBar | complexComboBox | elligbleSplitButton | (TreeItem & TreeItemChildrenExist);
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/ControlShouldSupportExpandCollapsePattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportExpandCollapsePattern.cs
@@ -65,5 +65,71 @@ namespace Axe.Windows.RulesTests.Library
             Assert.IsTrue(this.Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
+        
+        /// <summary>
+        /// Condition should match since SplitButton has a child text item
+        /// and ExpandCollapse is supported. so scan succeeds
+        /// </summary>
+        [TestMethod]
+        public void TestSplitButtonWithChildItem()
+        {
+            var e = new MockA11yElement();
+            var ec = new MockA11yElement();
+
+            e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_SplitButtonControlTypeId;
+            ec.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_TextControlTypeId;
+
+            e.Children.Add(ec);
+            e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
+            ec.Parent = e;
+
+            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.PassesTest(e));
+        }
+        
+        /// <summary>
+        /// Condition should not match since SplitButton has a child SplitButton
+        /// and ExpandCollapse is supported. so scan succeeds
+        /// </summary>
+        [TestMethod]
+        public void TestSplitButtonWithChildSplitButton()
+        {
+            var e = new MockA11yElement();
+            var ec = new MockA11yElement();
+
+            e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_SplitButtonControlTypeId;
+            ec.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_SplitButtonControlTypeId;
+
+            e.Children.Add(ec);
+            e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
+            ec.Parent = e;
+
+            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(this.Rule.Condition.Matches(ec));
+            Assert.IsTrue(Rule.PassesTest(e));
+        }
+
+
+        /// <summary>
+        /// Condition should match since SplitButton is child of a Pane
+        /// and ExpandCollapse is supported. so scan succeeds
+        /// </summary>
+        [TestMethod]
+        public void TestPaneWithSplitButtonChild()
+        {
+            var e = new MockA11yElement();
+            var ec = new MockA11yElement();
+
+            e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_PaneControlTypeId;
+            ec.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_SplitButtonControlTypeId;
+
+            e.Children.Add(ec);
+            ec.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
+            ec.Parent = e;
+
+            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(this.Rule.Condition.Matches(ec));
+            Assert.IsTrue(Rule.PassesTest(ec));
+        }
     }
 }


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->

In win32 app, the SplitButton is implented using nested SplitButtons. Only the parent one implements the expand collapse pattern which is fine, however the child does not. This PR updates the rule to exclude direct SplitButton childrens of SplitButtons from the ExpandCollapsePatternRule.

##### Motivation

Addresses #659 

##### Context

N/A

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #659
