### PR TITLE
chore: Corrections to #668

### DIFF
--- a/src/DesktopTests/ColorContrastAnalyzer/ImageTests.cs
+++ b/src/DesktopTests/ColorContrastAnalyzer/ImageTests.cs
@@ -229,6 +229,9 @@ namespace Axe.Windows.DesktopTests.ColorContrastAnalyzer
             IColorContrastResult result = image.RunColorContrastCalculation();
 
             Assert.AreEqual(Confidence.Mid, result.Confidence);
+
+            Assert.AreEqual(new ColorPair(new CCColor(255, 255, 255), new CCColor(0, 0, 0)),
+                result.MostLikelyColorPair);
         }
 
         [TestMethod]

--- a/src/DesktopTests/DesktopTests.csproj
+++ b/src/DesktopTests/DesktopTests.csproj
@@ -17,15 +17,15 @@
     <None Remove="TestImages\simple_white_and_black_text.bmp" />
     <None Remove="TestImages\visual_studio_tab.bmp" />
     <None Remove="TestImages\weird_text_arrangement.bmp" />
-    <None Remove="wildlife_manager_listbox_beetle.bmp" />
-    <None Remove="wildlife_manager_listbox_mouse.bmp" />
-    <None Remove="wildlife_manager_listbox_owl.bmp" />
-    <None Remove="wildlife_manager_listbox_owl_cropped.bmp" />
-    <None Remove="wildlife_manager_species_label.bmp" />
-    <None Remove="button_icon_antialiased.bmp" />
-    <None Remove="outlook_translate.bmp" />
-    <None Remove="outlook_share_to_teams.bmp" />
-    <None Remove="outlook_get_add_ins.bmp" />
+    <None Remove="TestImages\wildlife_manager_listbox_beetle.bmp" />
+    <None Remove="TestImages\wildlife_manager_listbox_mouse.bmp" />
+    <None Remove="TestImages\wildlife_manager_listbox_owl.bmp" />
+    <None Remove="TestImages\wildlife_manager_listbox_owl_cropped.bmp" />
+    <None Remove="TestImages\wildlife_manager_species_label.bmp" />
+    <None Remove="TestImages\button_icon_antialiased.bmp" />
+    <None Remove="TestImages\outlook_translate.bmp" />
+    <None Remove="TestImages\outlook_share_to_teams.bmp" />
+    <None Remove="TestImages\outlook_get_add_ins.bmp" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#### Details

#668 had a couple of errors:
1. The resource paths for cleanup omitted the `TestImages\` prefix
2. One test ddn't include the colors for validation

This PR fixes both oversights.

##### Motivation

Complete and accurate tests

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
