### PR TITLE
chore: Run automatic cleanup tool

### DIFF
--- a/src/Actions/Actions/DataManager.cs
+++ b/src/Actions/Actions/DataManager.cs
@@ -178,7 +178,7 @@ namespace Axe.Windows.Actions
         public static DataManager GetDefaultInstance()
         {
             var dm = GetInstance(DefaultInstanceName);
-            if(dm == null)
+            if (dm == null)
             {
                 sDataManagers.Add(DefaultInstanceName, new DataManager());
             }

--- a/src/Actions/Actions/GetDataAction.cs
+++ b/src/Actions/Actions/GetDataAction.cs
@@ -90,7 +90,7 @@ namespace Axe.Windows.Actions
         /// </summary>
         /// <param name="ecId"></param>
         /// <returns></returns>
-        public static Tuple<string,string> GetProcessAndUIFrameworkOfElementContext(Guid ecId)
+        public static Tuple<string, string> GetProcessAndUIFrameworkOfElementContext(Guid ecId)
         {
             var ec = DataManager.GetDefaultInstance().GetElementContext(ecId);
 

--- a/src/Actions/Actions/LoadActionParts.cs
+++ b/src/Actions/Actions/LoadActionParts.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Core.Bases;
-using Axe.Windows.Core.CustomObjects;
 using Axe.Windows.Desktop.Settings;
-using System.Collections.Generic;
 using System.Drawing;
 
 namespace Axe.Windows.Actions

--- a/src/Actions/Actions/ScreenShotAction.cs
+++ b/src/Actions/Actions/ScreenShotAction.cs
@@ -50,7 +50,7 @@ namespace Axe.Windows.Actions
                 ec.DataContext.Screenshot = bmp;
                 ec.DataContext.ScreenshotElementId = el.UniqueId;
             }
-            catch(TypeInitializationException e)
+            catch (TypeInitializationException e)
             {
                 e.ReportException();
                 // silently ignore. since it happens only on WCOS.

--- a/src/Actions/Actions/SelectAction.cs
+++ b/src/Actions/Actions/SelectAction.cs
@@ -250,9 +250,9 @@ namespace Axe.Windows.Actions
         /// <returns>true when there is new selection</returns>
         public bool Select()
         {
-            lock(_elementContextLock)
+            lock (_elementContextLock)
             {
-                if(CandidateEC != null && ( POIElementContext == null || POIElementContext.Element.IsSameUIElement(CandidateEC.Element) == false))
+                if (CandidateEC != null && (POIElementContext == null || POIElementContext.Element.IsSameUIElement(CandidateEC.Element) == false))
                 {
                     POIElementContext = CandidateEC;
                     CandidateEC = null;
@@ -377,7 +377,7 @@ namespace Axe.Windows.Actions
         /// <returns></returns>
         public static SelectAction GetDefaultInstance()
         {
-            if(sDefaultInstance == null)
+            if (sDefaultInstance == null)
             {
                 sDefaultInstance = new SelectAction();
             }
@@ -391,7 +391,7 @@ namespace Axe.Windows.Actions
         /// </summary>
         public static void ClearDefaultInstance()
         {
-            if(sDefaultInstance != null)
+            if (sDefaultInstance != null)
             {
                 sDefaultInstance.Dispose();
                 sDefaultInstance = null;
@@ -423,7 +423,7 @@ namespace Axe.Windows.Actions
                         this.MouseTracker.Dispose();
                         this.MouseTracker = null;
                     }
-                    if(this.FocusTracker != null)
+                    if (this.FocusTracker != null)
                     {
                         this.FocusTracker.Stop();
                         this.FocusTracker.Dispose();

--- a/src/Actions/Contexts/ElementContext.cs
+++ b/src/Actions/Contexts/ElementContext.cs
@@ -37,7 +37,7 @@ namespace Axe.Windows.Actions.Contexts
         /// Constructor
         /// </summary>
         /// <param name="element"></param>
-        public ElementContext (A11yElement element)
+        public ElementContext(A11yElement element)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
 

--- a/src/Actions/Trackers/BaseTracker.cs
+++ b/src/Actions/Trackers/BaseTracker.cs
@@ -68,7 +68,7 @@ namespace Axe.Windows.Actions.Trackers
         /// <returns></returns>
         protected A11yElement GetElementBasedOnScope(A11yElement e)
         {
-            if(e != null && Scope == SelectionScope.App)
+            if (e != null && Scope == SelectionScope.App)
             {
                 var el = A11yAutomation.GetAppElement(e);
 

--- a/src/Automation/Data/Config.cs
+++ b/src/Automation/Data/Config.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-
 namespace Axe.Windows.Automation
 {
     /// <summary>
@@ -39,12 +37,12 @@ namespace Axe.Windows.Automation
         public OutputFileFormat OutputFileFormat { get; private set; }
 
         ///  <summary>The path to a file containing configuration instructing Axe Windows how to interpret custom UI Automation data.</summary>
-        public string CustomUIAConfigPath{ get; private set; }
+        public string CustomUIAConfigPath { get; private set; }
 
         private Config()
         { }
 
-        #pragma warning disable CA1034 // Do not nest type
+#pragma warning disable CA1034 // Do not nest type
         /// <summary>
         /// Builds an instance of the <see cref="Config"/> class
         /// </summary>
@@ -115,6 +113,6 @@ namespace Axe.Windows.Automation
                 };
             }
         } // Builder
-        #pragma warning restore CA1034
+#pragma warning restore CA1034
     } // class
 } // namespace

--- a/src/Automation/Data/ElementInfo.cs
+++ b/src/Automation/Data/ElementInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using System.Collections.Generic;
 
 namespace Axe.Windows.Automation
@@ -13,7 +12,7 @@ namespace Axe.Windows.Automation
         /// <summary>
         /// This element's parent element.
         /// </summary>
-        public ElementInfo Parent { get; internal set;  }
+        public ElementInfo Parent { get; internal set; }
 
         /// <summary>
         /// A string to string dictionary where the key is a UIAutomation property name

--- a/src/Automation/Data/ScanResult.cs
+++ b/src/Automation/Data/ScanResult.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Rules;
-using System;
 
 namespace Axe.Windows.Automation
 {

--- a/src/Automation/Factory.cs
+++ b/src/Automation/Factory.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.SystemAbstractions;
-using System;
 
 namespace Axe.Windows.Automation
 {

--- a/src/Automation/Interfaces/IFactory.cs
+++ b/src/Automation/Interfaces/IFactory.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.SystemAbstractions;
-using System;
 
 namespace Axe.Windows.Automation
 {

--- a/src/Automation/Interfaces/INativeMethods.cs
+++ b/src/Automation/Interfaces/INativeMethods.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 
 namespace Axe.Windows.Automation
 {

--- a/src/Automation/Interfaces/IOutputFileHelper.cs
+++ b/src/Automation/Interfaces/IOutputFileHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 
 namespace Axe.Windows.Automation
 {

--- a/src/Automation/Interfaces/IScanToolsBuilder.cs
+++ b/src/Automation/Interfaces/IScanToolsBuilder.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 
 namespace Axe.Windows.Automation
 {

--- a/src/Automation/NativeMethods.cs
+++ b/src/Automation/NativeMethods.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows;
-using System;
 
 namespace Axe.Windows.Automation
 {

--- a/src/Automation/OutputFileHelper.cs
+++ b/src/Automation/OutputFileHelper.cs
@@ -5,9 +5,8 @@ using Axe.Windows.Core.Exceptions;
 using Axe.Windows.SystemAbstractions;
 using System;
 using System.Globalization;
-using Path = System.IO.Path;
-
 using static System.FormattableString;
+using Path = System.IO.Path;
 
 namespace Axe.Windows.Automation
 {

--- a/src/Automation/ScanResultsAssembler.cs
+++ b/src/Automation/ScanResultsAssembler.cs
@@ -87,11 +87,11 @@ namespace Axe.Windows.Automation
 
         private static IEnumerable<RuleResult> GetFailedRuleResultsFromElement(A11yElement element)
         {
-           return from scanResult in element.ScanResults.Items
-                  where scanResult.Status == ScanStatus.Fail
-                  from ruleResult in scanResult.Items
-                  where ruleResult.Status == ScanStatus.Fail
-                  select ruleResult;
+            return from scanResult in element.ScanResults.Items
+                   where scanResult.Status == ScanStatus.Fail
+                   from ruleResult in scanResult.Items
+                   where ruleResult.Status == ScanStatus.Fail
+                   select ruleResult;
         }
     }
 }

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Axe.Windows.Actions;
 using Axe.Windows.Automation.Resources;
 using Axe.Windows.Core.Bases;
 using System;

--- a/src/AutomationTests/ExecutionWrapperUnitTests.cs
+++ b/src/AutomationTests/ExecutionWrapperUnitTests.cs
@@ -25,7 +25,7 @@ namespace Axe.Windows.AutomationTests
         const string TestString = "He's dead, Jim!";
 
         [TestMethod]
-        [Timeout (5000)]
+        [Timeout(5000)]
         public void ExecuteCommand_CommandIsNull_ThrowsInnerNullReferenceException_Automation003InMessage()
         {
             try
@@ -40,7 +40,7 @@ namespace Axe.Windows.AutomationTests
         }
 
         [TestMethod]
-        [Timeout (1000)]
+        [Timeout(1000)]
         public void ExecuteCommand_CommandThrowsNonAutomationException_WrapsInAutomationException_Automation003InMessage()
         {
             try
@@ -60,7 +60,7 @@ namespace Axe.Windows.AutomationTests
         }
 
         [TestMethod]
-        [Timeout (1000)]
+        [Timeout(1000)]
         public void ExecuteCommand_CommandThrowsAutomationException_TestStringInMessage()
         {
             try
@@ -78,7 +78,7 @@ namespace Axe.Windows.AutomationTests
         }
 
         [TestMethod]
-        [Timeout (1000)]
+        [Timeout(1000)]
         public void ExecuteCommand_CommandReturnsObject_SameObjectIsReturnedToCaller()
         {
             TestResult result = ExecutionWrapper.ExecuteCommand<TestResult>(

--- a/src/AutomationTests/OutputFileHelperUnitTests.cs
+++ b/src/AutomationTests/OutputFileHelperUnitTests.cs
@@ -112,7 +112,7 @@ namespace Axe.Windows.AutomationTests
             string testParam = @"c:\TestDir";
             mockEnvironment.Setup(x => x.CurrentDirectory).Returns(testParam);
 
-string expectedDirectory = Path.Combine(testParam, OutputFileHelper.DefaultOutputDirectoryName);
+            string expectedDirectory = Path.Combine(testParam, OutputFileHelper.DefaultOutputDirectoryName);
 
             var outputFileHelper = new OutputFileHelper(outputDirectory: null, system: mockSystem.Object);
             string result = outputFileHelper.GetNewA11yTestFilePath();

--- a/src/CLI/IBrowserAbstraction.cs
+++ b/src/CLI/IBrowserAbstraction.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-
 namespace AxeWindowsCLI
 {
     internal interface IBrowserAbstraction

--- a/src/CLI/ParameterException.cs
+++ b/src/CLI/ParameterException.cs
@@ -12,7 +12,7 @@ namespace AxeWindowsCLI
         { }
 
         public ParameterException(string message)
-            : this (message, null)
+            : this(message, null)
         { }
 
         public ParameterException()

--- a/src/CLI/ProcessHelper.cs
+++ b/src/CLI/ProcessHelper.cs
@@ -33,7 +33,7 @@ namespace AxeWindowsCLI
                 caughtException = e;
             }
 
-            if (caughtException != null ||  processes == null || processes.Length == 0)
+            if (caughtException != null || processes == null || processes.Length == 0)
             {
                 throw new ParameterException(
                     string.Format(CultureInfo.CurrentCulture, DisplayStrings.ErrorNoMatchingProcessNameFormat, processName),

--- a/src/CLITests/OptionsUnitTests.cs
+++ b/src/CLITests/OptionsUnitTests.cs
@@ -21,7 +21,7 @@ namespace AxeWindowsCLITests
         const string ScanIdKey = "--scanid";
         const string ShowThirdPartyNoticesKey = "--showthirdpartynotices";
         const string DelayInSecondsKey = "--delayinseconds";
-        const string CustomUiaKey= "--customuia";
+        const string CustomUiaKey = "--customuia";
 
         const string TestProcessName = "MyProcess";
         const int TestProcessId = 42;

--- a/src/CLITests/OutputGeneratorUnitTests.cs
+++ b/src/CLITests/OutputGeneratorUnitTests.cs
@@ -269,7 +269,7 @@ namespace AxeWindowsCLITests
         {
             List<ScanResult> errors = new List<ScanResult>(errorCount);
 
-            for(int loop = 0; loop < errorCount; loop++)
+            for (int loop = 0; loop < errorCount; loop++)
             {
                 errors.Add(new ScanResult
                 {

--- a/src/Core/AssemblyInfo.cs
+++ b/src/Core/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Axe.Windows.Core")]
 [assembly: AssemblyCopyright("Copyright © 2020")]
 
-[assembly:NeutralResourcesLanguage("en-US")]
+[assembly: NeutralResourcesLanguage("en-US")]
 
 #if ENABLE_SIGNING
 [assembly: InternalsVisibleTo("Axe.Windows.Actions,PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]

--- a/src/Core/Attributes/PatternEventAttribute.cs
+++ b/src/Core/Attributes/PatternEventAttribute.cs
@@ -8,7 +8,7 @@ namespace Axe.Windows.Core.Attributes
     /// PatternEventAttribute class
     /// indicate the expected events for the pattern
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class,AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public sealed class PatternEventAttribute : Attribute
     {
         /// <summary>

--- a/src/Core/Bases/A11yElement.cs
+++ b/src/Core/Bases/A11yElement.cs
@@ -360,7 +360,7 @@ namespace Axe.Windows.Core.Bases
             if (!(temp is T))
                 return false;
 
-            value = temp ;
+            value = temp;
 
             return true;
         }
@@ -541,7 +541,7 @@ namespace Axe.Windows.Core.Bases
                 return ScanStatus.NoResult;
             }
         }
-#endregion
+        #endregion
 
         /// <summary>
         /// Header of this element
@@ -684,7 +684,7 @@ namespace Axe.Windows.Core.Bases
         /// <returns></returns>
         private static A11yElement FromText(string json)
         {
-            var e =  JsonConvert.DeserializeObject<A11yElement>(json);
+            var e = JsonConvert.DeserializeObject<A11yElement>(json);
 
             UpdateParent(null, e);
 
@@ -702,14 +702,14 @@ namespace Axe.Windows.Core.Bases
         /// <param name="e"></param>
         private static void UpdateParent(A11yElement p, A11yElement e)
         {
-            if(e != null)
+            if (e != null)
             {
                 e.Parent = p;
             }
 
-            if(e.Children != null && e.Children.Count != 0)
+            if (e.Children != null && e.Children.Count != 0)
             {
-                foreach(var c in e.Children)
+                foreach (var c in e.Children)
                 {
                     UpdateParent(e, c);
                 }
@@ -785,6 +785,6 @@ namespace Axe.Windows.Core.Bases
             Dispose(true);
             GC.SuppressFinalize(this);
         }
-#endregion
+        #endregion
     }
 }

--- a/src/Core/Bases/A11yPattern.cs
+++ b/src/Core/Bases/A11yPattern.cs
@@ -56,7 +56,7 @@ namespace Axe.Windows.Core.Bases
         /// Constructor
         /// </summary>
         /// <param name="e"></param>
-        public A11yPattern(A11yElement e, int id): this(e,id, PatternType.GetInstance().GetNameById(id)) { }
+        public A11yPattern(A11yElement e, int id) : this(e, id, PatternType.GetInstance().GetNameById(id)) { }
 
         /// <summary>
         /// Base class constructor for unknown pattern type.
@@ -64,7 +64,7 @@ namespace Axe.Windows.Core.Bases
         /// <param name="e"></param>
         /// <param name="id"></param>
         /// <param name="name"></param>
-        public A11yPattern(A11yElement e, int id,string name)
+        public A11yPattern(A11yElement e, int id, string name)
         {
             this.Element = e;
             this.Id = id;

--- a/src/Core/Bases/A11yProperty.cs
+++ b/src/Core/Bases/A11yProperty.cs
@@ -54,7 +54,7 @@ namespace Axe.Windows.Core.Bases
         /// </summary>
         /// <param name="id"></param>
         /// <param name="element"></param>
-        public A11yProperty (int id, dynamic value,string name = null): this(id,name)
+        public A11yProperty(int id, dynamic value, string name = null) : this(id, name)
         {
             this.Value = value;
         }
@@ -112,7 +112,7 @@ namespace Axe.Windows.Core.Bases
                     case PropertyType.UIA_SizeOfSetPropertyId:
                         /// these properties are 1 based.
                         /// if value is smaller than 1, it should be ignored.
-                        if(this.Value != null && this.Value > 0)
+                        if (this.Value != null && this.Value > 0)
                         {
                             txt = this.Value?.ToString();
                         }
@@ -168,9 +168,9 @@ namespace Axe.Windows.Core.Bases
             return text;
         }
 
-        public static void RegisterCustomProperty(int dynamicId, ITypeConverter converter) 
+        public static void RegisterCustomProperty(int dynamicId, ITypeConverter converter)
         {
-            TypeConverterMap[dynamicId] = converter; 
+            TypeConverterMap[dynamicId] = converter;
         }
 
         #region IDisposable Support
@@ -185,7 +185,7 @@ namespace Axe.Windows.Core.Bases
                     this.Name = null;
                     if (this.Value != null)
                     {
-                        if(NativeMethods.VariantClear(ref this.Value) == Win32Constants.S_OK)
+                        if (NativeMethods.VariantClear(ref this.Value) == Win32Constants.S_OK)
                         {
                             this.Value = null;
                         }

--- a/src/Core/Bases/IA11yElement.cs
+++ b/src/Core/Bases/IA11yElement.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.Core.Bases
         string AutomationId { get; }
         Rectangle BoundingRectangle { get; }
         string ClassName { get; }
-        string HelpText{ get; }
+        string HelpText { get; }
         bool IsEnabled { get; }
         bool IsKeyboardFocusable { get; }
         bool IsContentElement { get; }
@@ -34,7 +34,7 @@ namespace Axe.Windows.Core.Bases
         int ProcessId { get; }
         string Framework { get; }
         bool TransformPatternCanResize { get; }
-        string ProcessName { get;  }
+        string ProcessName { get; }
 
         IA11yElement Parent { get; }
         IEnumerable<IA11yElement> Children { get; }

--- a/src/Core/CustomObjects/Config.cs
+++ b/src/Core/CustomObjects/Config.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Newtonsoft.Json;
-using System;
 using System.IO;
-using System.Linq;
 
 namespace Axe.Windows.Core.CustomObjects
 {

--- a/src/Core/CustomObjects/CustomProperty.cs
+++ b/src/Core/CustomObjects/CustomProperty.cs
@@ -80,9 +80,9 @@ namespace Axe.Windows.Core.CustomObjects
         ///<summary>Checks that a property is structurally well-formed. For instance, verifies that Values is unset on non-enum types.</summary>
         public void Validate()
         {
-            if (Values == null && Type == CustomUIAPropertyType.Enum) 
+            if (Values == null && Type == CustomUIAPropertyType.Enum)
                 throw new InvalidDataException("Values required for enumeration types.");
-            if (Values != null && Type != CustomUIAPropertyType.Enum) 
+            if (Values != null && Type != CustomUIAPropertyType.Enum)
                 throw new InvalidDataException("Values cannot be defined for non-enumeration types.");
         }
     }

--- a/src/Core/Enums/CustomUIAPropertyType.cs
+++ b/src/Core/Enums/CustomUIAPropertyType.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-
 namespace Axe.Windows.Core.Enums
 {
     public enum CustomUIAPropertyType

--- a/src/Core/Misc/ExtensionMethods.cs
+++ b/src/Core/Misc/ExtensionMethods.cs
@@ -231,7 +231,7 @@ namespace Axe.Windows.Core.Misc
                 {
                     return element1.RuntimeId == runtimeId;
                 }
-                else if(element1.Name == name)
+                else if (element1.Name == name)
                 {
                     if (element1.ControlTypeId == controltype)
                     {
@@ -392,7 +392,7 @@ namespace Axe.Windows.Core.Misc
 
             foreach (var status in scanStatuses)
             {
-                results[(int) status]++;
+                results[(int)status]++;
             }
             return results;
         }
@@ -406,7 +406,7 @@ namespace Axe.Windows.Core.Misc
         {
             if (tss.Any())
             {
-                if(HasTestResults(tss, ScanStatus.ScanNotSupported))
+                if (HasTestResults(tss, ScanStatus.ScanNotSupported))
                 {
                     return ScanStatus.ScanNotSupported;
                 }
@@ -684,7 +684,7 @@ namespace Axe.Windows.Core.Misc
                 ? value : default(T);
         }
 
-        public static bool HasAttribute<T>(this FieldInfo field) where T: Attribute
+        public static bool HasAttribute<T>(this FieldInfo field) where T : Attribute
         {
             if (field == null) throw new ArgumentNullException(nameof(field));
 

--- a/src/Core/Misc/PackageInfo.cs
+++ b/src/Core/Misc/PackageInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 
 namespace Axe.Windows.Core.Misc

--- a/src/Core/Results/ScanMetaInfo.cs
+++ b/src/Core/Results/ScanMetaInfo.cs
@@ -29,7 +29,7 @@ namespace Axe.Windows.Core.Results
         /// </summary>
         /// <param name="e"></param>
         /// <param name="propertyid"></param>
-        public ScanMetaInfo(IA11yElement e, int propertyid):this(e)
+        public ScanMetaInfo(IA11yElement e, int propertyid) : this(e)
         {
             this.PropertyId = propertyid;
         }

--- a/src/Core/Types/PatternType.cs
+++ b/src/Core/Types/PatternType.cs
@@ -84,5 +84,5 @@ namespace Axe.Windows.Core.Types
 
             return sb.ToString();
         }
-     }
+    }
 }

--- a/src/Core/Types/TypeBase.cs
+++ b/src/Core/Types/TypeBase.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Misc;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using static System.FormattableString;
 
@@ -34,9 +32,9 @@ namespace Axe.Windows.Core.Types
         /// </summary>
         private void PopulateDictionary()
         {
-            var fields =  this.GetType().GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.FlattenHierarchy );
+            var fields = this.GetType().GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.FlattenHierarchy);
 
-            foreach(var f in fields)
+            foreach (var f in fields)
             {
                 if (ShouldIncludeFieldInDictionary(f))
                     AddFieldToDictionary(f);
@@ -60,7 +58,7 @@ namespace Axe.Windows.Core.Types
         /// <param name="name"></param>
         /// <param name="id"></param>
         /// <returns></returns>
-        protected virtual string GetNameInProperFormat(string name,int id)
+        protected virtual string GetNameInProperFormat(string name, int id)
         {
             return name;
         }
@@ -84,7 +82,7 @@ namespace Axe.Windows.Core.Types
 
             foreach (var k in this.Dic.Keys)
             {
-                if(IsPartOfKeyValuePairList(k))
+                if (IsPartOfKeyValuePairList(k))
                 {
                     list.Add(new KeyValuePair<int, string>(k, this.Dic[k]));
                 }

--- a/src/CoreTests/Bases/A11yPropertyTests.cs
+++ b/src/CoreTests/Bases/A11yPropertyTests.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.CustomObjects.Converters;
 using Axe.Windows.Core.Types;
 using Axe.Windows.UnitTestSharedLibrary;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 
 namespace Axe.Windows.CoreTests.Bases
 {
@@ -46,7 +45,7 @@ namespace Axe.Windows.CoreTests.Bases
         }
 
         [TestMethod()]
-        public void SimpleCustomPropertyTest() 
+        public void SimpleCustomPropertyTest()
         {
             const int testId = 42;
             dynamic testValue = 1;

--- a/src/CoreTests/CustomObjects/Converters/PointConverterTests.cs
+++ b/src/CoreTests/CustomObjects/Converters/PointConverterTests.cs
@@ -14,7 +14,7 @@ namespace Axe.Windows.CoreTests.CustomObjects.Converters
         [TestMethod, Timeout(1000)]
         public void RenderTest()
         {
-            dynamic value=new double[2] { 42.0, 42.0 };
+            dynamic value = new double[2] { 42.0, 42.0 };
             Assert.AreEqual("[x=42,y=42]", new PointTypeConverter().Render(value));
         }
 

--- a/src/CoreTests/Misc/MiscTests.cs
+++ b/src/CoreTests/Misc/MiscTests.cs
@@ -3,7 +3,6 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Results;
-using Axe.Windows.UnitTestSharedLibrary;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 using Utility = Axe.Windows.UnitTestSharedLibrary.Utility;
@@ -36,12 +35,12 @@ namespace Axe.Windows.CoreTests.Misc
                 Utility.PopulateChildrenTests(c);
             };
             var statuses = (from child in ke.Children
-                           select child.TestStatus);
+                            select child.TestStatus);
             int[] statusCounts = statuses.GetStatusCounts();
-            Assert.AreEqual(3, statusCounts[(int) ScanStatus.Fail]);
-            Assert.AreEqual(2, statusCounts[(int) ScanStatus.Pass]);
-            Assert.AreEqual(0, statusCounts[(int) ScanStatus.Uncertain]);
-            Assert.AreEqual(0, statusCounts[(int) ScanStatus.NoResult]);
+            Assert.AreEqual(3, statusCounts[(int)ScanStatus.Fail]);
+            Assert.AreEqual(2, statusCounts[(int)ScanStatus.Pass]);
+            Assert.AreEqual(0, statusCounts[(int)ScanStatus.Uncertain]);
+            Assert.AreEqual(0, statusCounts[(int)ScanStatus.NoResult]);
         }
     }
 }

--- a/src/CoreTests/Misc/PackageInfoTests.cs
+++ b/src/CoreTests/Misc/PackageInfoTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Misc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using System.Reflection;
 
 namespace Axe.Windows.CoreTests.Misc

--- a/src/CoreTests/Misc/PreconditionsUnitTests.cs
+++ b/src/CoreTests/Misc/PreconditionsUnitTests.cs
@@ -11,7 +11,7 @@ namespace Axe.Windows.CoreTests.Misc
     {
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
-        [Timeout (2000)]
+        [Timeout(2000)]
         public void IsNotNull_ValueIsNull_ThrowsCorrectException()
         {
             object someVariable = null;
@@ -28,7 +28,7 @@ namespace Axe.Windows.CoreTests.Misc
         }
 
         [TestMethod]
-        [Timeout (2000)]
+        [Timeout(2000)]
         public void IsNotNull_ValueIsNotNoll_DoesNotThrow()
         {
             object someVariable = new object();
@@ -37,7 +37,7 @@ namespace Axe.Windows.CoreTests.Misc
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
-        [Timeout (2000)]
+        [Timeout(2000)]
         public void IsNotTrivialString_IsTrivial_ThrowsCorrectException()
         {
             string someString = "";
@@ -53,7 +53,7 @@ namespace Axe.Windows.CoreTests.Misc
         }
 
         [TestMethod]
-        [Timeout (2000)]
+        [Timeout(2000)]
         public void IsNotTrivialString_IsNotTrivial_DoesNotThrow()
         {
             string someString = "hello";

--- a/src/CurrentFileVersionCompatibilityTests/Program.cs
+++ b/src/CurrentFileVersionCompatibilityTests/Program.cs
@@ -1,6 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Axe.Windows.Actions;
+using Axe.Windows.Actions.Contexts;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Core.Results;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/CurrentFileVersionCompatibilityTests/Program.cs
+++ b/src/CurrentFileVersionCompatibilityTests/Program.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Axe.Windows.Actions;
-using Axe.Windows.Actions.Contexts;
-using Axe.Windows.Core.Bases;
-using Axe.Windows.Core.Enums;
-using Axe.Windows.Core.Results;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Desktop/ColorContrastAnalyzer/ColorContrastResult.cs
+++ b/src/Desktop/ColorContrastAnalyzer/ColorContrastResult.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Axe.Windows.Desktop.ColorContrastAnalyzer
 {
-    public class ColorContrastResult: IColorContrastResult
+    public class ColorContrastResult : IColorContrastResult
     {
         private List<ColorPair> alternatives = new List<ColorPair>();
 
@@ -50,7 +50,8 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
             else if (numDifferentBackgroundColors > 1 || numVisiblyDifferentTextColors > 1)
             {
                 confidence = Confidence.Mid;
-            } else
+            }
+            else
             {
                 this.confidence = Confidence.High;
             }

--- a/src/Desktop/Styles/StyleId.cs
+++ b/src/Desktop/Styles/StyleId.cs
@@ -20,21 +20,21 @@ namespace Axe.Windows.Desktop.Styles
         /// https://docs.microsoft.com/en-us/windows/win32/winauto/uiauto-style-identifiers
         /// </summary>
 #pragma warning disable CA1707 // Identifiers should not contain underscores
-        public const int StyleId_Custom       = 70000;
-        public const int StyleId_Heading1     = 70001;
-        public const int StyleId_Heading2     = 70002;
-        public const int StyleId_Heading3     = 70003;
-        public const int StyleId_Heading4     = 70004;
-        public const int StyleId_Heading5     = 70005;
-        public const int StyleId_Heading6     = 70006;
-        public const int StyleId_Heading7     = 70007;
-        public const int StyleId_Heading8     = 70008;
-        public const int StyleId_Heading9     = 70009;
-        public const int StyleId_Title        = 70010;
-        public const int StyleId_Subtitle     = 70011;
-        public const int StyleId_Normal       = 70012;
-        public const int StyleId_Emphasis     = 70013;
-        public const int StyleId_Quote        = 70014;
+        public const int StyleId_Custom = 70000;
+        public const int StyleId_Heading1 = 70001;
+        public const int StyleId_Heading2 = 70002;
+        public const int StyleId_Heading3 = 70003;
+        public const int StyleId_Heading4 = 70004;
+        public const int StyleId_Heading5 = 70005;
+        public const int StyleId_Heading6 = 70006;
+        public const int StyleId_Heading7 = 70007;
+        public const int StyleId_Heading8 = 70008;
+        public const int StyleId_Heading9 = 70009;
+        public const int StyleId_Title = 70010;
+        public const int StyleId_Subtitle = 70011;
+        public const int StyleId_Normal = 70012;
+        public const int StyleId_Emphasis = 70013;
+        public const int StyleId_Quote = 70014;
         public const int StyleId_BulletedList = 70015;
         public const int StyleId_NumberedList = 70016;
 #pragma warning restore CA1707 // Identifiers should not contain underscores

--- a/src/Desktop/Types/EventType.cs
+++ b/src/Desktop/Types/EventType.cs
@@ -98,7 +98,7 @@ namespace Axe.Windows.Desktop.Types
         /// <returns></returns>
         protected override bool IsPartOfKeyValuePairList(int id)
         {
-            switch(id)
+            switch (id)
             {
                 case UIA_AutomationFocusChangedEventId:
                 case UIA_AutomationPropertyChangedEventId:

--- a/src/Desktop/Types/TextAttributeTemplate.cs
+++ b/src/Desktop/Types/TextAttributeTemplate.cs
@@ -9,8 +9,8 @@ using System.Linq;
 
 namespace Axe.Windows.Desktop.Types
 {
-    using TemplateData = Tuple<int, string, dynamic, Type>;
     using static Axe.Windows.Desktop.Types.TextAttributeType;
+    using TemplateData = Tuple<int, string, dynamic, Type>;
 
     public static class TextAttributeTemplate
     {

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -5,6 +5,7 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.CustomObjects;
 using Axe.Windows.Core.CustomObjects.Converters;
 using Axe.Windows.Core.Enums;
+using Interop.UIAutomationCore;
 using System;
 using System.Collections.Generic;
 

--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -5,7 +5,6 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.CustomObjects;
 using Axe.Windows.Core.CustomObjects.Converters;
 using Axe.Windows.Core.Enums;
-using Interop.UIAutomationCore;
 using System;
 using System.Collections.Generic;
 
@@ -67,7 +66,7 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
         /// <remarks>This function assumes that when ConverterRegistrationAction is called multiple times, the last call wins.</remarks>
         public void MergeCustomPropertyRegistrations(IReadOnlyDictionary<int, CustomProperty> registrations)
         {
-            if (registrations== null) throw new ArgumentNullException(nameof(registrations));
+            if (registrations == null) throw new ArgumentNullException(nameof(registrations));
             foreach (KeyValuePair<int, CustomProperty> entry in registrations)
             {
                 _converterRegistrationAction(entry.Key, CreateTypeConverter(entry.Value));

--- a/src/Desktop/UIAutomation/DesktopElement.cs
+++ b/src/Desktop/UIAutomation/DesktopElement.cs
@@ -108,7 +108,7 @@ namespace Axe.Windows.Desktop.UIAutomation
             dynamic value = null;
             try
             {
-               value = element.GetCurrentPropertyValue(id);
+                value = element.GetCurrentPropertyValue(id);
                 if (id == PropertyType.UIA_LabeledByPropertyId && value != null)
                 {
                     value = GetHeaderOfLabelBy(value);

--- a/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
+++ b/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
@@ -3,7 +3,6 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;
-using Axe.Windows.Desktop.Utility;
 using Axe.Windows.Telemetry;
 using Axe.Windows.Win32;
 using System;
@@ -132,7 +131,7 @@ namespace Axe.Windows.Desktop.UIAutomation
             if (e == null) return null;
             if (e.PlatformObject == null) return null;
 
-                try
+            try
             {
                 var cache = DesktopElementHelper.BuildCacheRequest(MiniumProperties, null);
 
@@ -208,7 +207,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// <summary>
         /// Get windows extended style and add it into Platform Properties
         /// </summary>
-        private static void AddWindowsExtendedStyleIntoPlatformProperties(this A11yElement element,IntPtr handle)
+        private static void AddWindowsExtendedStyleIntoPlatformProperties(this A11yElement element, IntPtr handle)
         {
             var val = Win32.NativeMethods.GetWindowLong(handle, Win32.Win32Constants.GWL_EXSTYLE);
             if (val != 0)
@@ -256,7 +255,7 @@ namespace Axe.Windows.Desktop.UIAutomation
                 }
 
                 A11yAutomation.UIAutomationObject.PollForPotentialSupportedPatterns((IUIAutomationElement)element.PlatformObject, out int[] ptids, out string[] ptns);
-                var ptl = new List<Tuple<int,string>>();
+                var ptl = new List<Tuple<int, string>>();
 
                 for (int i = 0; i < ptids.Length; i++)
                 {
@@ -288,9 +287,9 @@ namespace Axe.Windows.Desktop.UIAutomation
 
                 // retrieve patterns from cache
                 var ptlst = from pt in ptl
-                          let pi = A11yPatternFactory.GetPatternInstance(element, uia, pt.Item1, pt.Item2)
-                          where pi != null
-                          select pi;
+                            let pi = A11yPatternFactory.GetPatternInstance(element, uia, pt.Item1, pt.Item2)
+                            where pi != null
+                            select pi;
 
                 element.Patterns = ptlst.ToList();
 
@@ -321,7 +320,7 @@ namespace Axe.Windows.Desktop.UIAutomation
 
             bool ret = false;
 
-            if(element.PlatformObject != null)
+            if (element.PlatformObject != null)
             {
                 try
                 {
@@ -439,7 +438,7 @@ namespace Axe.Windows.Desktop.UIAutomation
                     variant = GetGlimpsesOfUIAElements(variant);
                     NativeMethods.VariantClear(ref tmp);
                 }
-                else if(Marshal.IsComObject(variant))
+                else if (Marshal.IsComObject(variant))
                 {
                     /* When checked against the four common return types for
                      * IUIAutomation.GetPropertyValueEx: int, bool, string, and double[]

--- a/src/Desktop/UIAutomation/EventHandlers/ChangesEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/ChangesEventListener.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Desktop.Types;
 using System.Collections.Generic;
-using System.Linq;
 using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.EventHandlers

--- a/src/Desktop/UIAutomation/EventHandlers/EventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventListener.cs
@@ -12,7 +12,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         /// <summary>
         /// Create an event handler and register it.
         /// </summary>
-        public EventListener(CUIAutomation uia, IUIAutomationElement element,TreeScope scope, int eventId,HandleUIAutomationEventMessage peDelegate):base(uia, element,scope,eventId,peDelegate)
+        public EventListener(CUIAutomation uia, IUIAutomationElement element, TreeScope scope, int eventId, HandleUIAutomationEventMessage peDelegate) : base(uia, element, scope, eventId, peDelegate)
         {
             Init();
         }

--- a/src/Desktop/UIAutomation/EventHandlers/EventListenerBase.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventListenerBase.cs
@@ -40,7 +40,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         /// Ctor to create an event handler (with CUIAutomation) and register it.
         /// </summary>
         protected EventListenerBase(CUIAutomation uia, IUIAutomationElement element, TreeScope scope, int eventId, HandleUIAutomationEventMessage peDelegate)
-            : this (element, scope, eventId, peDelegate)
+            : this(element, scope, eventId, peDelegate)
         {
             this.UIAutomation = uia;
         }

--- a/src/Desktop/UIAutomation/EventHandlers/EventListenerFactory.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventListenerFactory.cs
@@ -25,7 +25,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         public NotificationEventListener EventListenerNotification { get; private set; }
         public TextEditTextChangedEventListener EventListenerTextEditTextChanged { get; private set; }
         public ActiveTextPositionChangedEventListener EventListenerActiveTextPositionChanged { get; private set; }
-        public Dictionary<int,EventListener> EventListeners { get; private set; }
+        public Dictionary<int, EventListener> EventListeners { get; private set; }
 
         public TreeScope Scope { get; private set; }
         public CUIAutomation UIAutomation { get; private set; }
@@ -107,7 +107,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     // Get a message from the queue of action-related messages.
                     lock (_msgQueue)
                     {
-                        if(_msgQueue.Count != 0)
+                        if (_msgQueue.Count != 0)
                         {
                             msgData = _msgQueue.Dequeue();
                         }
@@ -117,7 +117,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                         }
                     }
 
-                    switch(msgData.MessageType)
+                    switch (msgData.MessageType)
                     {
                         case EventListenerFactoryMessageType.FinishThread:
                             // The main UI thread is telling this background thread to close down.
@@ -208,7 +208,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                 e.ReportException();
 
 #pragma warning disable CA2000 // Call IDisposable.Dispose()
-                var m  = EventMessage.GetInstance(EventType.UIA_EventRecorderNotificationEventId, null);
+                var m = EventMessage.GetInstance(EventType.UIA_EventRecorderNotificationEventId, null);
 #pragma warning restore CA2000
 
                 m.Properties = new List<KeyValuePair<string, dynamic>> { new KeyValuePair<string, dynamic>("Message", $"Failed to unregister all listeners: {e.Message}") };
@@ -351,7 +351,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     case EventType.UIA_AutomationFocusChangedEventId:
                         if (this.EventListenerFocusChanged == null)
                         {
-                            var uia = (IUIAutomation) UIAutomation8 ?? UIAutomation;
+                            var uia = (IUIAutomation)UIAutomation8 ?? UIAutomation;
                             this.EventListenerFocusChanged = new FocusChangedEventListener(uia, msgData.Listener);
                         }
                         break;
@@ -364,7 +364,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     case EventType.UIA_AutomationPropertyChangedEventId:
                         if (this.EventListenerPropertyChanged == null)
                         {
-                            this.EventListenerPropertyChanged = new PropertyChangedEventListener(this.UIAutomation, this.RootElement.PlatformObject, this.Scope, msgData.Listener,msgData.Properties);
+                            this.EventListenerPropertyChanged = new PropertyChangedEventListener(this.UIAutomation, this.RootElement.PlatformObject, this.Scope, msgData.Listener, msgData.Properties);
                         }
                         break;
                     case EventType.UIA_TextEdit_TextChangedEventId:
@@ -446,7 +446,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     new KeyValuePair<string, dynamic>("Event Name", EventType.GetInstance().GetNameById(msgData.EventId)),
                 };
                 msgData.Listener(m);
-                if(msgData.EventId == EventType.UIA_AutomationFocusChangedEventId)
+                if (msgData.EventId == EventType.UIA_AutomationFocusChangedEventId)
                 {
                     this.EventListenerFocusChanged.ReadyToListen = true;
                 }
@@ -500,7 +500,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         private void AddMessageToQueue(EventListenerFactoryMessage msgData)
         {
             // Request the lock, and block until it is obtained.
-            lock(_msgQueue)
+            lock (_msgQueue)
             {
                 // When the lock is obtained, add an element.
                 _msgQueue.Enqueue(msgData);
@@ -559,14 +559,14 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                 Properties = properties
             });
 #pragma warning restore CA2000
-}
+        }
 
         /// <summary>
         /// Unregister a automation event listener
         /// </summary>
         /// <param name="eventId"></param>
         /// <param name="wait">wait to complete</param>
-        public void UnregisterAutomationEventListener(int eventId,bool wait = false)
+        public void UnregisterAutomationEventListener(int eventId, bool wait = false)
         {
 #pragma warning disable CA2000 // Call IDisposable.Dispose()
             var msg = new EventListenerFactoryMessage()

--- a/src/Desktop/UIAutomation/EventHandlers/EventMessage.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventMessage.cs
@@ -22,7 +22,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         public string TimeStamp { get; set; }
 
 #pragma warning disable CA2227 // Collection properties should be read only
-        public IList<KeyValuePair<string,dynamic>> Properties { get; set; }
+        public IList<KeyValuePair<string, dynamic>> Properties { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
 
         public A11yElement Element { get; set; }
@@ -79,7 +79,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         {
             if (sender == null || !DesktopElement.IsFromCurrentProcess(sender))
             {
-                    return new EventMessage(id, sender);
+                return new EventMessage(id, sender);
             }
 
             return null;

--- a/src/Desktop/UIAutomation/EventHandlers/FocusChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/FocusChangedEventListener.cs
@@ -29,7 +29,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
             this.UIAutomation = uia;
             this.ListenEventMessage = peDelegate;
-            this.UIAutomation.AddFocusChangedEventHandler(null,this);
+            this.UIAutomation.AddFocusChangedEventHandler(null, this);
             IsHooked = true;
         }
 
@@ -62,7 +62,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                         this.UIAutomation.RemoveFocusChangedEventHandler(this);
                         this.UIAutomation = null;
                     }
-                    catch(ThreadAbortException)
+                    catch (ThreadAbortException)
                     {
                         // silently ignore exception since a ThreadAbortException is thrown at the process exit.
                     }

--- a/src/Desktop/UIAutomation/EventHandlers/PropertyChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/PropertyChangedEventListener.cs
@@ -14,7 +14,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         /// <summary>
         /// Create an event handler and register it.
         /// </summary>
-        public PropertyChangedEventListener(CUIAutomation uia,IUIAutomationElement element, TreeScope scope, HandleUIAutomationEventMessage peDelegate, int[] properties) : base(uia,element, scope, EventType.UIA_AutomationPropertyChangedEventId, peDelegate)
+        public PropertyChangedEventListener(CUIAutomation uia, IUIAutomationElement element, TreeScope scope, HandleUIAutomationEventMessage peDelegate, int[] properties) : base(uia, element, scope, EventType.UIA_AutomationPropertyChangedEventId, peDelegate)
         {
             this.propertyArray = properties;
             Init();

--- a/src/Desktop/UIAutomation/EventHandlers/StructureChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/StructureChangedEventListener.cs
@@ -13,7 +13,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         /// <summary>
         /// Create an event handler and register it.
         /// </summary>
-        public StructureChangedEventListener(CUIAutomation uia, IUIAutomationElement element, TreeScope scope, HandleUIAutomationEventMessage peDelegate) : base(uia,element, scope, EventType.UIA_StructureChangedEventId, peDelegate)
+        public StructureChangedEventListener(CUIAutomation uia, IUIAutomationElement element, TreeScope scope, HandleUIAutomationEventMessage peDelegate) : base(uia, element, scope, EventType.UIA_StructureChangedEventId, peDelegate)
         {
             Init();
         }

--- a/src/Desktop/UIAutomation/Patterns/AnnotationPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/AnnotationPattern.cs
@@ -17,7 +17,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
     {
         IUIAutomationAnnotationPattern Pattern;
 
-        public AnnotationPattern(A11yElement e, IUIAutomationAnnotationPattern p) :base(e, PatternType.UIA_AnnotationPatternId)
+        public AnnotationPattern(A11yElement e, IUIAutomationAnnotationPattern p) : base(e, PatternType.UIA_AnnotationPatternId)
         {
             Pattern = p;
 
@@ -44,7 +44,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         protected override void Dispose(bool disposing)
         {
-            if(Pattern != null)
+            if (Pattern != null)
             {
                 Marshal.ReleaseComObject(Pattern);
                 this.Pattern = null;

--- a/src/Desktop/UIAutomation/Patterns/CustomNavigationPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/CustomNavigationPattern.cs
@@ -17,7 +17,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
     {
         IUIAutomationCustomNavigationPattern Pattern;
 
-        public CustomNavigationPattern(A11yElement e, IUIAutomationCustomNavigationPattern p) :base(e, PatternType.UIA_CustomNavigationPatternId)
+        public CustomNavigationPattern(A11yElement e, IUIAutomationCustomNavigationPattern p) : base(e, PatternType.UIA_CustomNavigationPatternId)
         {
             this.Pattern = p;
         }

--- a/src/Desktop/UIAutomation/Patterns/DropTargetPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/DropTargetPattern.cs
@@ -38,7 +38,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             {
                 for (int i = 0; i < array.Length; i++)
                 {
-                    this.Properties.Add(new A11yPatternProperty() { Name = Invariant($"DropTargetEffects[{i}]"), Value = array.GetValue(i)?.ToString()});
+                    this.Properties.Add(new A11yPatternProperty() { Name = Invariant($"DropTargetEffects[{i}]"), Value = array.GetValue(i)?.ToString() });
                 }
             }
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()

--- a/src/Desktop/UIAutomation/Patterns/MultipleViewPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/MultipleViewPattern.cs
@@ -33,8 +33,8 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             {
                 for (int i = 0; i < array.Length; i++)
                 {
-                    var view = (int) array.GetValue(i);
-                    Properties.Add(new A11yPatternProperty() { Name = Invariant($"SupportedViews[{i}]"), Value = Invariant($"{view}: {Pattern.GetViewName(view)}")});
+                    var view = (int)array.GetValue(i);
+                    Properties.Add(new A11yPatternProperty() { Name = Invariant($"SupportedViews[{i}]"), Value = Invariant($"{view}: {Pattern.GetViewName(view)}") });
                 }
             }
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()

--- a/src/Desktop/UIAutomation/Patterns/SpreadsheetItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SpreadsheetItemPattern.cs
@@ -44,7 +44,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             var array = this.Pattern.GetCurrentAnnotationTypes();
             List<string> list = new List<string>();
 
-            if(array.Length > 0)
+            if (array.Length > 0)
             {
                 for (int i = 0; i < array.Length; i++)
                 {

--- a/src/Desktop/UIAutomation/Patterns/TextEditPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextEditPattern.cs
@@ -27,7 +27,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         public TextRange GetActiveComposition()
         {
             var tr = this.Pattern.GetActiveComposition();
-            return tr != null ? new TextRange(tr, null) : null ;
+            return tr != null ? new TextRange(tr, null) : null;
         }
 
         [PatternMethod]

--- a/src/Desktop/UIAutomation/Patterns/TextPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextPattern.cs
@@ -66,13 +66,13 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         {
             if (child == null) throw new ArgumentNullException(nameof(child));
 
-            return new TextRange(this.Pattern.RangeFromChild(child.PlatformObject),this);
+            return new TextRange(this.Pattern.RangeFromChild(child.PlatformObject), this);
         }
 
         [PatternMethod]
         public TextRange RangeFromPoint(tagPOINT pt)
         {
-            return new TextRange(this.Pattern.RangeFromPoint(pt),this);
+            return new TextRange(this.Pattern.RangeFromPoint(pt), this);
         }
 
         List<TextRange> ToListOfTextRanges(IUIAutomationTextRangeArray array)

--- a/src/Desktop/UIAutomation/Patterns/TextRange.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextRange.cs
@@ -181,7 +181,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         {
             if (!disposedValue)
             {
-                if(this.UIATextRange != null)
+                if (this.UIATextRange != null)
                 {
                     Marshal.ReleaseComObject(UIATextRange);
                     UIATextRange = null;

--- a/src/Desktop/UIAutomation/Patterns/ValuePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ValuePattern.cs
@@ -31,7 +31,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             {
                 this.Properties.Add(new A11yPatternProperty() { Name = "Value", Value = this.Pattern.CurrentValue });
             }
-            catch(InvalidOperationException e)
+            catch (InvalidOperationException e)
             {
                 e.ReportException();
                 // there is a known case that CurrentValue is not ready.

--- a/src/Desktop/UIAutomation/Support/TextRangeFinder.cs
+++ b/src/Desktop/UIAutomation/Support/TextRangeFinder.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Desktop.Types;
 using Axe.Windows.Desktop.UIAutomation.Patterns;
 
 namespace Axe.Windows.Desktop.UIAutomation.Support
@@ -48,9 +47,9 @@ namespace Axe.Windows.Desktop.UIAutomation.Support
         {
             var range = this.OriginalRange.Clone();
 
-            if(this.FoundRange != null)
+            if (this.FoundRange != null)
             {
-                if(backward == true)
+                if (backward == true)
                 {
                     range.MoveEndpointByRange(UIAutomationClient.TextPatternRangeEndpoint.TextPatternRangeEndpoint_End, this.FoundRange, UIAutomationClient.TextPatternRangeEndpoint.TextPatternRangeEndpoint_Start);
                 }

--- a/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
@@ -59,7 +59,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             this.TreeWalkerMode = mode;
             this.Items = new List<A11yElement>();
             this.SetMembers = setMem;
-            SetParent(e,-1);
+            SetParent(e, -1);
 
             if (Items.Count != 0)
             {

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -146,7 +146,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
                     rootNode.Children.Add(childNode);
                     childNode.Parent = rootNode;
                     childNode.UniqueId = startChildId++;
-                    startChildId = PopulateChildrenTreeNode(childNode, rootNode,startChildId);
+                    startChildId = PopulateChildrenTreeNode(childNode, rootNode, startChildId);
                     try
                     {
                         child = walker.GetNextSiblingElement(child);

--- a/src/Desktop/Utility/ExtensionMethods.cs
+++ b/src/Desktop/Utility/ExtensionMethods.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
-using System.Linq;
 using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.Utility

--- a/src/Desktop/Utility/SupportedEvents.cs
+++ b/src/Desktop/Utility/SupportedEvents.cs
@@ -199,7 +199,7 @@ namespace Axe.Windows.Desktop.Utility
         public static IEnumerable<int> GetEventsForControl(int controlId, IEnumerable<A11yPattern> patterns)
         {
             return (from map in EventTypeMappings
-                    where map.ControlId == controlId && (map.PatternId == null || patterns.Select(p=>p.Id).Contains(map.PatternId.Value))
+                    where map.ControlId == controlId && (map.PatternId == null || patterns.Select(p => p.Id).Contains(map.PatternId.Value))
                     select map.EventId).ToList();
         }
     }

--- a/src/DesktopTests/ColorContrastAnalyzer/ImageTests.cs
+++ b/src/DesktopTests/ColorContrastAnalyzer/ImageTests.cs
@@ -7,8 +7,8 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using CCColor = Axe.Windows.Desktop.ColorContrastAnalyzer.Color;
 using System.Reflection;
+using CCColor = Axe.Windows.Desktop.ColorContrastAnalyzer.Color;
 
 namespace Axe.Windows.DesktopTests.ColorContrastAnalyzer
 {

--- a/src/DesktopTests/ColorContrastAnalyzer/ImageTestsV2.cs
+++ b/src/DesktopTests/ColorContrastAnalyzer/ImageTestsV2.cs
@@ -6,8 +6,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Drawing;
 using System.IO;
-using CCColor = Axe.Windows.Desktop.ColorContrastAnalyzer.Color;
 using System.Reflection;
+using CCColor = Axe.Windows.Desktop.ColorContrastAnalyzer.Color;
 
 namespace Axe.Windows.DesktopTests.ColorContrastAnalyzer
 {
@@ -51,7 +51,7 @@ namespace Axe.Windows.DesktopTests.ColorContrastAnalyzer
                 result.MostLikelyColorPair);
         }
 
-        [TestMethod] 
+        [TestMethod]
         [Timeout(2000)]
         public void SimplePurpleAndWhiteButton()
         {

--- a/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
@@ -4,6 +4,7 @@
 using Axe.Windows.Core.CustomObjects;
 using Axe.Windows.Core.CustomObjects.Converters;
 using Axe.Windows.Desktop.UIAutomation.CustomObjects;
+using Interop.UIAutomationCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;

--- a/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
@@ -4,7 +4,6 @@
 using Axe.Windows.Core.CustomObjects;
 using Axe.Windows.Core.CustomObjects.Converters;
 using Axe.Windows.Desktop.UIAutomation.CustomObjects;
-using Interop.UIAutomationCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
@@ -20,7 +19,7 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
         {
             Guid propertyGuid = new Guid("312F7536-259A-47C7-B192-AA16352522C4");
             string propertyName = "CommentReplyCount";
-            CustomProperty propertyToRegister = new CustomProperty { Guid = propertyGuid, ProgrammaticName = propertyName, ConfigType = CustomProperty.IntConfigType};
+            CustomProperty propertyToRegister = new CustomProperty { Guid = propertyGuid, ProgrammaticName = propertyName, ConfigType = CustomProperty.IntConfigType };
             UIAutomationPropertyInfo expectedPropertyInfo = new UIAutomationPropertyInfo { guid = propertyGuid, pProgrammaticName = propertyName, type = UIAutomationType.UIAutomationType_Int };
             int propertyId = 43;
             Mock<IUIAutomationRegistrar> uiaRegistrarMock = new Mock<IUIAutomationRegistrar>(MockBehavior.Strict);
@@ -104,14 +103,14 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
 
             Guid intPropertyGuid = new Guid("312F7536-259A-47C7-B192-AA16352522C4");
             string intPropertyName = "CommentReplyCount";
-            CustomProperty intProperty = new CustomProperty { Guid = intPropertyGuid, ProgrammaticName = intPropertyName, ConfigType = CustomProperty.IntConfigType};
+            CustomProperty intProperty = new CustomProperty { Guid = intPropertyGuid, ProgrammaticName = intPropertyName, ConfigType = CustomProperty.IntConfigType };
             UIAutomationPropertyInfo expectedIntPropertyInfo = new UIAutomationPropertyInfo { guid = intPropertyGuid, pProgrammaticName = intPropertyName, type = UIAutomationType.UIAutomationType_Int };
             int propertyId = 42;
             uiaRegistrarMock.Setup(x => x.RegisterProperty(ref expectedIntPropertyInfo, out propertyId));
 
             Guid boolPropertyGuid = new Guid("4BB56516-F354-44CF-A5AA-96B52E968CFD");
             string boolPropertyName = "AreGridlinesVisible";
-            CustomProperty boolProperty = new CustomProperty { Guid = boolPropertyGuid, ProgrammaticName = boolPropertyName, ConfigType = CustomProperty.BoolConfigType};
+            CustomProperty boolProperty = new CustomProperty { Guid = boolPropertyGuid, ProgrammaticName = boolPropertyName, ConfigType = CustomProperty.BoolConfigType };
 
             int counter = 0;
             Action<int, ITypeConverter> testCallback = new Action<int, ITypeConverter>((id, converter) =>
@@ -128,7 +127,7 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
             r.RegisterCustomProperty(intProperty);
             r.MergeCustomPropertyRegistrations(
                 new Dictionary<int, CustomProperty> { [42] = boolProperty }
-            ); 
+            );
             r.RestoreCustomPropertyRegistrations();
 
             Assert.AreEqual(3, counter); // Callback should be called three times: register int, merge bool, restore int.

--- a/src/RuleSelection/ReferenceLinks.cs
+++ b/src/RuleSelection/ReferenceLinks.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Extensions;
 using Axe.Windows.Extensions.Interfaces.ReferenceLinks;
 using Axe.Windows.Rules;
 
@@ -26,7 +25,7 @@ namespace Axe.Windows.RuleSelection
             if (link == null) return (string.Empty, string.Empty);
 
             return (link.ShortDescription ?? string.Empty,
-                    TryGetValidUrl(link.Uri, out string url) ? url: string.Empty);
+                    TryGetValidUrl(link.Uri, out string url) ? url : string.Empty);
         }
 
         private static IReferenceLink GetReferenceLink(string lookupToken) => DefaultLinks.GetReferenceLink(lookupToken);

--- a/src/Rules/Conditions/ValueCondition.cs
+++ b/src/Rules/Conditions/ValueCondition.cs
@@ -16,7 +16,7 @@ namespace Axe.Windows.Rules
     class ValueCondition<T> : Condition where T : IComparable, IEquatable<T>
     {
         public delegate T GetterDelegate(IA11yElement e);
-        private readonly string Description ;
+        private readonly string Description;
         public readonly GetterDelegate GetValue;
 
         public ValueCondition(GetterDelegate getter, string description)

--- a/src/Rules/Library/BoundingRectangleContainedInParent.cs
+++ b/src/Rules/Library/BoundingRectangleContainedInParent.cs
@@ -11,7 +11,6 @@ using System.Text.RegularExpressions;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
-using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.Rules.Library
 {

--- a/src/Rules/Library/ControlShouldSupportSetInfoXAML.cs
+++ b/src/Rules/Library/ControlShouldSupportSetInfoXAML.cs
@@ -26,7 +26,7 @@ namespace Axe.Windows.Rules.Library
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             return PositionInSet.Exists.Matches(e) & SizeOfSet.Exists.Matches(e);
-}
+        }
 
         protected override Condition CreateCondition()
         {

--- a/src/Rules/Library/FrameworkDoesNotSupportUIAutomation.cs
+++ b/src/Rules/Library/FrameworkDoesNotSupportUIAutomation.cs
@@ -17,7 +17,7 @@ namespace Axe.Windows.Rules.Library
             @"^\s*SunAwt.*$",
         };
 
-        public FrameworkDoesNotSupportUIAutomation ()
+        public FrameworkDoesNotSupportUIAutomation()
         {
             this.Info.Description = Descriptions.FrameworkDoesNotSupportUIAutomation;
             this.Info.HowToFix = HowToFix.FrameworkDoesNotSupportUIAutomation;

--- a/src/Rules/Library/IsContentElementTrueOptional.cs
+++ b/src/Rules/Library/IsContentElementTrueOptional.cs
@@ -30,7 +30,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            var controls =  (Button & NotParent(ComboBox | ScrollBar | TitleBar))
+            var controls = (Button & NotParent(ComboBox | ScrollBar | TitleBar))
                 | Calendar | CheckBox | ComboBox | DataGrid | DataItem
                 | Document | Edit | Group
                 | Hyperlink | List | ListItem | MenuItem

--- a/src/Rules/Library/IsKeyboardFocusableForListItemShouldBeTrue.cs
+++ b/src/Rules/Library/IsKeyboardFocusableForListItemShouldBeTrue.cs
@@ -6,8 +6,8 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
+using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/LandmarkNoDuplicateBanner.cs
+++ b/src/Rules/Library/LandmarkNoDuplicateBanner.cs
@@ -29,7 +29,7 @@ namespace Axe.Windows.Rules.Library
 
             var landmark = Landmarks.Banner & (Edge | IsNotOffScreen);
             var condition = DescendantCount(landmark) <= 1;
-            return  condition.Matches(e);
+            return condition.Matches(e);
         }
 
         protected override Condition CreateCondition()

--- a/src/Rules/Library/LocalizedControlTypeIsNotEmpty.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotEmpty.cs
@@ -5,8 +5,8 @@ using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.Resources;
 using System;
-using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
+using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.Rules.Library
 {

--- a/src/Rules/Library/LocalizedControlTypeIsReasonable.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsReasonable.cs
@@ -42,7 +42,7 @@ namespace Axe.Windows.Rules.Library
         {
             string names = null;
 
-            switch(controlTypeId)
+            switch (controlTypeId)
             {
                 case Axe.Windows.Core.Types.ControlType.UIA_AppBarControlTypeId:
                     names = LocalizedControlTypeNames.AppBar;

--- a/src/Rules/Library/NameIsEmptyButElementIsNotKeyboardFocusable.cs
+++ b/src/Rules/Library/NameIsEmptyButElementIsNotKeyboardFocusable.cs
@@ -7,8 +7,8 @@ using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
-using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.Rules.Library
 {

--- a/src/Rules/Library/NameIsInformative.cs
+++ b/src/Rules/Library/NameIsInformative.cs
@@ -44,7 +44,7 @@ namespace Axe.Windows.Rules.Library
         {
             return Name.NotNullOrEmpty & Name.NotWhiteSpace & BoundingRectangle.Valid
                 & ~Win32Framework
-                & ( ElementGroups.NameRequired | ElementGroups.NameOptional);
+                & (ElementGroups.NameRequired | ElementGroups.NameOptional);
         }
     } // class
 } // namespace

--- a/src/Rules/Library/NameIsNotEmpty.cs
+++ b/src/Rules/Library/NameIsNotEmpty.cs
@@ -6,8 +6,8 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
-using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.Rules.Library
 {

--- a/src/Rules/PropertyConditions/Patterns.cs
+++ b/src/Rules/PropertyConditions/Patterns.cs
@@ -61,7 +61,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         {
             return CustomNavigation | Drag | Dock | ExpandCollapse
                 | Invoke | RangeValue | SelectionItem | Transform
-                | Transform2 | Text | Toggle ;
+                | Transform2 | Text | Toggle;
         }
 
         private static bool IsTextSelectionSupported(IA11yElement e)

--- a/src/Rules/PropertyConditions/Relationships.cs
+++ b/src/Rules/PropertyConditions/Relationships.cs
@@ -31,7 +31,7 @@ namespace Axe.Windows.Rules.PropertyConditions
 
         private static Condition CreateSecondChildCondition()
         {
-            return Condition.Create(e => MatchOrderInSiblings(e,2));
+            return Condition.Create(e => MatchOrderInSiblings(e, 2));
         }
 
         private static bool MatchOrderInSiblings(IA11yElement e, int index)
@@ -40,7 +40,7 @@ namespace Axe.Windows.Rules.PropertyConditions
             if (e.Parent == null || e.Parent.Children == null) return false;
             if (index < 1 || index > e.Parent.Children.Count()) return false;
 
-            return e.Parent.Children.ElementAt(index -1).RuntimeId == e.RuntimeId;
+            return e.Parent.Children.ElementAt(index - 1).RuntimeId == e.RuntimeId;
         }
 
         private static bool HasSiblingsOfSameType(IA11yElement e)
@@ -170,12 +170,12 @@ namespace Axe.Windows.Rules.PropertyConditions
         {
             if (c == null) throw new ArgumentNullException(nameof(c));
 
-            var description= string.Format(CultureInfo.InvariantCulture, ConditionDescriptions.AnyChild, c);
+            var description = string.Format(CultureInfo.InvariantCulture, ConditionDescriptions.AnyChild, c);
 
             return AnyChildInternal(c)[description];
         }
 
-            private static Condition AnyChildInternal(Condition c)
+        private static Condition AnyChildInternal(Condition c)
         {
             if (c == null) throw new ArgumentNullException(nameof(c));
 

--- a/src/Rules/PropertyConditions/StringProperty.cs
+++ b/src/Rules/PropertyConditions/StringProperty.cs
@@ -179,7 +179,7 @@ namespace Axe.Windows.Rules.PropertyConditions
 
                 Regex r = new Regex(s, options);
                 return r.IsMatch(propertyValue);
-                },
+            },
                 string.Format(CultureInfo.InvariantCulture, ConditionDescriptions.MatchesRegExWithOptions, PropertyDescription, s, options.ToString()));
         }
     } // class

--- a/src/Rules/Rule.cs
+++ b/src/Rules/Rule.cs
@@ -7,7 +7,7 @@ namespace Axe.Windows.Rules
 {
     interface IRule
     {
-        RuleInfo Info { get;  }
+        RuleInfo Info { get; }
         Condition Condition { get; }
         bool PassesTest(IA11yElement element);
     }

--- a/src/Rules/RunResult.cs
+++ b/src/Rules/RunResult.cs
@@ -29,6 +29,6 @@ namespace Axe.Windows.Rules
         /// this property may contain a description of the error.
         /// Otherwise, it should be null.
         /// </summary>
-        public string ErrorMessage{ get; set; }
+        public string ErrorMessage { get; set; }
     } // class
 } // namespace

--- a/src/RulesMD/CLIOptions.cs
+++ b/src/RulesMD/CLIOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using CommandLine;
+
 namespace RulesMD
 {
     class CLIOptions

--- a/src/RulesMD/CLIOptions.cs
+++ b/src/RulesMD/CLIOptions.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using CommandLine;
-using System;
 
 namespace RulesMD
 {

--- a/src/RulesMD/Helpers.cs
+++ b/src/RulesMD/Helpers.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Rules;
 using Axe.Windows.RuleSelection.Resources;
-using System;
 
 namespace RulesMD
 {

--- a/src/RulesMD/Program.cs
+++ b/src/RulesMD/Program.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using CommandLine;
 using System;
-using System.Collections.Generic;
 using System.IO;
 
 namespace RulesMD
@@ -24,7 +22,7 @@ namespace RulesMD
 
         static void DoWork(string[] args)
         {
-            Parser.Default.ParseArguments < CLIOptions>(args)
+            Parser.Default.ParseArguments<CLIOptions>(args)
                 .WithParsed<CLIOptions>(Run);
         }
 

--- a/src/RulesMD/Program.cs
+++ b/src/RulesMD/Program.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using CommandLine;
 using System;
 using System.IO;
 

--- a/src/RulesMD/Properties/AssemblyInfo.cs
+++ b/src/RulesMD/Properties/AssemblyInfo.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Reflection;
 using System.Resources;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/src/RulesTest/Library/BoundingRectangleCompletelyObscuresContainerTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleCompletelyObscuresContainerTest.cs
@@ -227,7 +227,7 @@ namespace Axe.Windows.RulesTests.Library
             Assert.IsTrue(Rule.Condition.Matches(e));
 
             e = CreateLightDismissButton();
-            e.ControlTypeId = 0 ;
+            e.ControlTypeId = 0;
             Assert.IsTrue(Rule.Condition.Matches(e));
         }
 

--- a/src/RulesTest/Library/BoundingRectangleDataFormatCorrectTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleDataFormatCorrectTest.cs
@@ -16,7 +16,7 @@ namespace Axe.Windows.RulesTests.Library
         {
             using (var e = new MockA11yElement())
             {
-                var p = new A11yProperty(PropertyType.UIA_BoundingRectanglePropertyId, new double[] {  1, 2, 3, 4 });
+                var p = new A11yProperty(PropertyType.UIA_BoundingRectanglePropertyId, new double[] { 1, 2, 3, 4 });
                 e.Properties.Add(PropertyType.UIA_BoundingRectanglePropertyId, p);
                 Assert.IsTrue(Rule.PassesTest(e));
             } // using

--- a/src/RulesTest/Library/ControlShouldNotSupportScrollPatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldNotSupportScrollPatternTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;

--- a/src/RulesTest/Library/ControlShouldSupportExpandCollapsePattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportExpandCollapsePattern.cs
@@ -65,7 +65,7 @@ namespace Axe.Windows.RulesTests.Library
             Assert.IsTrue(this.Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
-        
+
         /// <summary>
         /// Condition should match since SplitButton has a child text item
         /// and ExpandCollapse is supported. so scan succeeds
@@ -86,7 +86,7 @@ namespace Axe.Windows.RulesTests.Library
             Assert.IsTrue(this.Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
-        
+
         /// <summary>
         /// Condition should not match since SplitButton has a child SplitButton
         /// and ExpandCollapse is supported. so scan succeeds

--- a/src/RulesTest/Library/ControlShouldSupportGridPattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportGridPattern.cs
@@ -4,8 +4,6 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Diagnostics;
-using UIAutomationClient;
 
 namespace Axe.Windows.RulesTests.Library
 {

--- a/src/RulesTest/Library/ControlShouldSupportSetInfoWPFTest.cs
+++ b/src/RulesTest/Library/ControlShouldSupportSetInfoWPFTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Enums;
-using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 

--- a/src/RulesTest/Library/ControlShouldSupportSetInfoXAMLTest.cs
+++ b/src/RulesTest/Library/ControlShouldSupportSetInfoXAMLTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Enums;
-using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 

--- a/src/RulesTest/Library/ControlShouldSupportTablePattern.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTablePattern.cs
@@ -3,7 +3,6 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
-using Axe.Windows.RulesTests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 

--- a/src/RulesTest/Library/ControlShouldSupportTablePatternInEdge.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTablePatternInEdge.cs
@@ -3,7 +3,6 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
-using Axe.Windows.RulesTests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 

--- a/src/RulesTest/Library/FrameworkDoesNotSupportUIAutomationTests.cs
+++ b/src/RulesTest/Library/FrameworkDoesNotSupportUIAutomationTests.cs
@@ -5,7 +5,6 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using System.Reflection;
 
 namespace Axe.Windows.RulesTests.Library
 {

--- a/src/RulesTest/Library/HelpTextExcludesPrivateUnicodeCharactersUnitTests.cs
+++ b/src/RulesTest/Library/HelpTextExcludesPrivateUnicodeCharactersUnitTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using static Axe.Windows.RulesTests.ControlType;
 
 namespace Axe.Windows.RulesTests.Library
 {

--- a/src/RulesTest/Library/LandmarkIsTopLevel.cs
+++ b/src/RulesTest/Library/LandmarkIsTopLevel.cs
@@ -10,7 +10,7 @@ namespace Axe.Windows.RulesTests.Library
     public class LandmarkIsTopLevel
     {
         private readonly Axe.Windows.Rules.IRule Rule = null;
-        private readonly  int LandmarkType = 0;
+        private readonly int LandmarkType = 0;
         private readonly string LocalizedLandmarkType = null;
 
         protected LandmarkIsTopLevel(object rule, int landmarkType, string localizedLandmarkType)

--- a/src/RulesTest/Library/LocalizedControlTypeExcludesPrivateUnicodeCharactersUnitTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeExcludesPrivateUnicodeCharactersUnitTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using static Axe.Windows.RulesTests.ControlType;
 
 namespace Axe.Windows.RulesTests.Library
 {

--- a/src/RulesTest/Library/NameIsInformative.cs
+++ b/src/RulesTest/Library/NameIsInformative.cs
@@ -33,7 +33,7 @@ namespace Axe.Windows.RulesTests.Library
                 };
 
                 foreach (var s in stringsToTry)
-                    {
+                {
                     e.Name = s;
                     Assert.IsFalse(Rule.PassesTest(e));
                 }

--- a/src/RulesTest/Library/NameIsNotEmpty.cs
+++ b/src/RulesTest/Library/NameIsNotEmpty.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using static Axe.Windows.RulesTests.ControlType;
 using System.Drawing;
+using static Axe.Windows.RulesTests.ControlType;
 
 namespace Axe.Windows.RulesTests.Library
 {

--- a/src/RulesTest/Library/NameIsReasonableLength.cs
+++ b/src/RulesTest/Library/NameIsReasonableLength.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Text;

--- a/src/RulesTest/Library/SiblingUniqueAndFocusableTest.cs
+++ b/src/RulesTest/Library/SiblingUniqueAndFocusableTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
-using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 

--- a/src/RulesTest/Library/Structure/ContentView/SpinnerTests.cs
+++ b/src/RulesTest/Library/Structure/ContentView/SpinnerTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 
 namespace Axe.Windows.RulesTests.Library.Structure.ContentView
 {

--- a/src/RulesTest/Library/Structure/ControlView/SpinnerTests.cs
+++ b/src/RulesTest/Library/Structure/ControlView/SpinnerTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 
 namespace Axe.Windows.RulesTests.Library.Structure.ControlView
 {

--- a/src/RulesTest/MockA11yElement.cs
+++ b/src/RulesTest/MockA11yElement.cs
@@ -26,7 +26,7 @@ namespace Axe.Windows.RulesTests
                 return;
             }
 
-            var property = new A11yProperty {  Id = id, Value = value };
+            var property = new A11yProperty { Id = id, Value = value };
             this.Properties[id] = property;
         }
 
@@ -216,7 +216,7 @@ namespace Axe.Windows.RulesTests
 
             set
             {
-                SetProperty(PropertyType.UIA_OrientationPropertyId, (int) value);
+                SetProperty(PropertyType.UIA_OrientationPropertyId, (int)value);
             }
         }
 

--- a/src/RulesTest/PropertyConditions/BoundingRectangleTest.cs
+++ b/src/RulesTest/PropertyConditions/BoundingRectangleTest.cs
@@ -3,8 +3,8 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using BoundingRectangle = Axe.Windows.Rules.PropertyConditions.BoundingRectangle;
 using System.Drawing;
+using BoundingRectangle = Axe.Windows.Rules.PropertyConditions.BoundingRectangle;
 
 namespace Axe.Windows.RulesTests.PropertyConditions
 {

--- a/src/RulesTest/PropertyConditions/PatternsTest.cs
+++ b/src/RulesTest/PropertyConditions/PatternsTest.cs
@@ -15,11 +15,12 @@ namespace Axe.Windows.RulesTests.PropertyConditions
             using (var e = new MockA11yElement())
             {
                 var pattern = new A11yPattern(e, PatternIDs.Text);
-                var property = new A11yPatternProperty {  Name = "SupportedTextSelection", Value = UIAutomationClient.SupportedTextSelection.SupportedTextSelection_Single};
+                var property = new A11yPatternProperty { Name = "SupportedTextSelection", Value = UIAutomationClient.SupportedTextSelection.SupportedTextSelection_Single };
                 pattern.Properties.Add(property);
                 e.Patterns.Add(pattern);
                 Assert.IsTrue(Patterns.TextSelectionSupported.Matches(e));
-;            } // using
+                ;
+            } // using
         }
 
         [TestMethod]

--- a/src/RulesTest/PropertyConditions/PatternsTest.cs
+++ b/src/RulesTest/PropertyConditions/PatternsTest.cs
@@ -19,7 +19,6 @@ namespace Axe.Windows.RulesTests.PropertyConditions
                 pattern.Properties.Add(property);
                 e.Patterns.Add(pattern);
                 Assert.IsTrue(Patterns.TextSelectionSupported.Matches(e));
-                ;
             } // using
         }
 

--- a/src/RulesTest/PropertyConditions/ScrollPatternTest.cs
+++ b/src/RulesTest/PropertyConditions/ScrollPatternTest.cs
@@ -84,7 +84,7 @@ namespace Axe.Windows.RulesTests.PropertyConditions
                 var scrollPattern = new A11yPattern(e, PatternType.UIA_ScrollPatternId);
                 e.Patterns.Add(scrollPattern);
                 scrollPattern.Properties.Add(new A11yPatternProperty() { Name = ScrollPattern.HorizontallyScrollableProperty, Value = true });
-                scrollPattern.Properties.Add(new A11yPatternProperty() { Name = ScrollPattern.HorizontalScrollPercentProperty, Value = (double)0/0 });
+                scrollPattern.Properties.Add(new A11yPatternProperty() { Name = ScrollPattern.HorizontalScrollPercentProperty, Value = (double)0 / 0 });
                 Assert.IsFalse(ScrollPattern.HorizontallyScrollable.Matches(e));
             } // using
         }

--- a/src/RulesTest/RuleRunnerTests.cs
+++ b/src/RulesTest/RuleRunnerTests.cs
@@ -281,7 +281,8 @@ namespace Axe.Windows.RulesTests
 
         private static Mock<IRule> CreateRuleMock(Condition condition, EvaluationCode code, A11yElement e)
         {
-            var infoStub = new RuleInfo {
+            var infoStub = new RuleInfo
+            {
                 ErrorCode = code
             };
 

--- a/src/SystemAbstractions/Abstractions/ISystemEnvironment.cs
+++ b/src/SystemAbstractions/Abstractions/ISystemEnvironment.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 
 namespace Axe.Windows.SystemAbstractions
 {

--- a/src/SystemAbstractions/Abstractions/ISystemIO.cs
+++ b/src/SystemAbstractions/Abstractions/ISystemIO.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 
 namespace Axe.Windows.SystemAbstractions
 {

--- a/src/SystemAbstractions/Concretions/Microsoft.cs
+++ b/src/SystemAbstractions/Concretions/Microsoft.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
-using System.Collections.Generic;
 
 namespace Axe.Windows.SystemAbstractions
 {

--- a/src/SystemAbstractions/Concretions/MicrosoftFactory.cs
+++ b/src/SystemAbstractions/Concretions/MicrosoftFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 
 namespace Axe.Windows.SystemAbstractions
 {

--- a/src/SystemAbstractions/Concretions/MicrosoftWin32.cs
+++ b/src/SystemAbstractions/Concretions/MicrosoftWin32.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
-using System.Collections.Generic;
 
 namespace Axe.Windows.SystemAbstractions
 {

--- a/src/SystemAbstractions/Concretions/MicrosoftWin32Registry.cs
+++ b/src/SystemAbstractions/Concretions/MicrosoftWin32Registry.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.Win32;
-using System;
 
 namespace Axe.Windows.SystemAbstractions
 {

--- a/src/SystemAbstractions/Concretions/System.cs
+++ b/src/SystemAbstractions/Concretions/System.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
-using System.Collections.Generic;
 
 namespace Axe.Windows.SystemAbstractions
 {

--- a/src/SystemAbstractions/Concretions/SystemIODirectory.cs
+++ b/src/SystemAbstractions/Concretions/SystemIODirectory.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using System.IO;
 
 namespace Axe.Windows.SystemAbstractions

--- a/src/SystemAbstractionsTests/MicrosoftUnitTests.cs
+++ b/src/SystemAbstractionsTests/MicrosoftUnitTests.cs
@@ -3,7 +3,6 @@
 using Axe.Windows.SystemAbstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Win32;
-using Moq;
 
 namespace Axe.Windows.SystemAbstractionsTests
 {

--- a/src/SystemAbstractionsTests/SystemUnitTests.cs
+++ b/src/SystemAbstractionsTests/SystemUnitTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.SystemAbstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 
 namespace Axe.Windows.SystemAbstractionsTests
 {

--- a/src/Telemetry/ExcludedException.cs
+++ b/src/Telemetry/ExcludedException.cs
@@ -20,7 +20,7 @@ namespace Axe.Windows.Telemetry
         public Type ExcludedType => InnerException.GetType();
 
         public ExcludedException(Exception innerException)
-            : base (innerException?.Message, innerException)
+            : base(innerException?.Message, innerException)
         {
             if (innerException == null) throw new ArgumentNullException(nameof(innerException));
         }

--- a/src/Telemetry/IAxeWindowsTelemetry.cs
+++ b/src/Telemetry/IAxeWindowsTelemetry.cs
@@ -24,6 +24,6 @@ namespace Axe.Windows.Telemetry
         /// Whether or not telemetry is enabled. Exposed to allow callers who do lots of
         /// work to short-circuit their processing when telemetry is disabled
         /// </summary>
-        bool IsEnabled { get;  }
+        bool IsEnabled { get; }
     } // interface
 } // namespace

--- a/src/Win32Tests/Win32ApisTests.cs
+++ b/src/Win32Tests/Win32ApisTests.cs
@@ -4,8 +4,6 @@ using Axe.Windows.SystemAbstractions;
 using Axe.Windows.Win32;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using System;
-using System.Collections.Generic;
 
 namespace Axe.Windows.Win32Tests
 {


### PR DESCRIPTION
#### Details

Microsoft publishes a Visual Studio extension called [Power Commands for Visual Studio](https://marketplace.visualstudio.com/items?itemName=VisualStudioPlatformTeam.PowerCommandsforVisualStudio) that can apply normalizations across an entire project from a single command. After creating [AIWin PR 1303](https://github.com/microsoft/accessibility-insights-windows/pull/1303), I ran the same tool on Axe.Windows. I ran the extension using the default set of fixers, which are:

- Format document (includes things like consistent spacing, braces, etc.)
- Remove unnecessary usings
- Sort usings
- Apply file header preferences

The last fixer did nothing to our code, since we have no configured file header preferences. The first 3 fixers, though, found and fixed issues across the entire solution.

This PR is fairly large (nearly 20% of our files), but the individual changes are trivial--the vast majority of them are tiny whitespace tweaks that just got missed in previous changes. I've reviewed them, but it would be good to get a second reviewer

##### Motivation

Code consistency

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
The first commit here is straight from running the tool. Upon reviewing, I found an extra line that provided no value, so I went ahead and removed it manually--that's the second commit.

Newer versions of VS (which we get in the PR builds) support [EditorConfig files](https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options?view=vs-2019), which can provide enforcement and even (I think) format on save support. Let's try to add EditorConfig in a future PR

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
