### PR TITLE
[feat(scan-multiple-windows)] Add code to scan multiple root-level windows

### DIFF
--- a/src/Automation/DisplayStrings.resx
+++ b/src/Automation/DisplayStrings.resx
@@ -125,7 +125,7 @@
     <value>The directory "{0}" was invalid.</value>
   </data>
   <data name="ErrorFailToGetRootElementOfProcess" xml:space="preserve">
-    <value>ERROR Automation017: Fail to get the root element of a process({0}) : {1}</value>
+    <value>ERROR Automation017: Failed to get the root element(s) of the specified process({0}) : {1}</value>
   </data>
   <data name="ErrorIsNotFullPath" xml:space="preserve">
     <value>The given path was not an absolute path.</value>

--- a/src/Automation/DisplayStrings.resx
+++ b/src/Automation/DisplayStrings.resx
@@ -124,7 +124,7 @@
   <data name="ErrorDirectoryInvalid" xml:space="preserve">
     <value>The directory "{0}" was invalid.</value>
   </data>
-  <data name="ErrorFailToGetRootElementOfProcess" xml:space="preserve">
+  <data name="ErrorFailToGetRootElementsOfProcess" xml:space="preserve">
     <value>ERROR Automation017: Failed to get the root element(s) of the specified process({0}) : {1}</value>
   </data>
   <data name="ErrorIsNotFullPath" xml:space="preserve">

--- a/src/Automation/Interfaces/ITargetElementLocator.cs
+++ b/src/Automation/Interfaces/ITargetElementLocator.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
+using System.Collections.Generic;
 
 namespace Axe.Windows.Automation
 {
     internal interface ITargetElementLocator
     {
-        A11yElement LocateRootElement(int processId);
+        IEnumerable<A11yElement> LocateRootElements(int processId);
     } // interface
 } // namespace

--- a/src/Automation/Resources/ErrorMessages.Designer.cs
+++ b/src/Automation/Resources/ErrorMessages.Designer.cs
@@ -61,6 +61,15 @@ namespace Axe.Windows.Automation.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The argument must be a non-empty IEnumerable.
+        /// </summary>
+        internal static string NoDesktopElements {
+            get {
+                return ResourceManager.GetString("NoDesktopElements", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The Actions property of the given ScanTools object should not be null.
         /// </summary>
         internal static string ScanToolsActionsNull {

--- a/src/Automation/Resources/ErrorMessages.resx
+++ b/src/Automation/Resources/ErrorMessages.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="NoDesktopElements" xml:space="preserve">
+    <value>The argument must be a non-empty IEnumerable</value>
+  </data>
   <data name="ScanToolsActionsNull" xml:space="preserve">
     <value>The Actions property of the given ScanTools object should not be null</value>
   </data>

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -6,6 +6,7 @@ using Axe.Windows.Automation.Resources;
 using Axe.Windows.Core.Bases;
 using System;
 using System.Globalization;
+using System.Linq;
 
 namespace Axe.Windows.Automation
 {
@@ -35,9 +36,9 @@ namespace Axe.Windows.Automation
             if (config.CustomUIAConfigPath != null)
                 scanTools.Actions.RegisterCustomUIAPropertiesFromConfig(config.CustomUIAConfigPath);
 
-            var rootElement = scanTools.TargetElementLocator.LocateRootElement(config.ProcessId);
+            var rootElements = scanTools.TargetElementLocator.LocateRootElements(config.ProcessId);
 
-            return scanTools.Actions.Scan(rootElement, (element, elementId) =>
+            return scanTools.Actions.Scan(rootElements?.First(), (element, elementId) =>
             {
                 return ProcessResults(element, elementId, config, scanTools);
             });

--- a/src/Automation/TargetElementLocator.cs
+++ b/src/Automation/TargetElementLocator.cs
@@ -1,28 +1,40 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Actions.Contexts;
+using Axe.Windows.Automation.Resources;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Desktop.UIAutomation;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 
 namespace Axe.Windows.Automation
 {
     class TargetElementLocator : ITargetElementLocator
     {
-        public A11yElement LocateRootElement(int processId)
+        public IEnumerable<A11yElement> LocateRootElements(int processId)
         {
             try
             {
-                var element = A11yAutomation.ElementFromProcessId(processId);
-
-#pragma warning disable CA2000 // Call IDisposable.Dispose()
-                return new ElementContext(element).Element;
-#pragma warning restore CA2000
+                var desktopElements = A11yAutomation.ElementsFromProcessId(processId);
+                return GetA11YElementsFromDesktopElements(desktopElements);
             }
             catch (Exception ex)
             {
                 throw new AxeWindowsAutomationException(string.Format(CultureInfo.InvariantCulture, DisplayStrings.ErrorFailToGetRootElementOfProcess, processId, ex), ex);
+            }
+        }
+
+        private static IEnumerable<A11yElement> GetA11YElementsFromDesktopElements(IEnumerable<DesktopElement> desktopElements)
+            {
+            if (!desktopElements.Any()) throw new ArgumentException(ErrorMessages.NoDesktopElements, nameof(desktopElements));
+
+            foreach (var e in desktopElements)
+            {
+#pragma warning disable CA2000 // Call IDisposable.Dispose()
+                yield return new ElementContext(e).Element;
+#pragma warning restore CA2000
             }
         }
     }

--- a/src/AutomationTests/SnapshotCommandUnitTests.cs
+++ b/src/AutomationTests/SnapshotCommandUnitTests.cs
@@ -5,6 +5,8 @@ using Axe.Windows.Core.Bases;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Axe.Windows.AutomationTests
 {
@@ -48,6 +50,16 @@ namespace Axe.Windows.AutomationTests
             _actionsMock.Setup(x => x.Scan(It.IsAny<A11yElement>(), It.IsAny<ScanActionCallback<ScanResults>>()))
                 .Callback<A11yElement, ScanActionCallback<ScanResults>>((e, cb) => tempResults = cb(e, Guid.Empty))
                 .Returns(() => tempResults);
+        }
+
+        private IEnumerable<A11yElement> CreateMockElementArray()
+        {
+            var elements = new List<A11yElement>();
+
+            for (int i = 0; i < 3; ++i)
+                elements.Add(new A11yElement());
+
+            return elements;
         }
 
         [TestMethod]
@@ -114,7 +126,7 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
             _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
 
-            _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns<A11yElement>(null);
+            _targetElementLocatorMock.Setup(x => x.LocateRootElements(It.IsAny<int>())).Returns<IEnumerable<A11yElement>>(null);
             _actionsMock.Setup(x => x.Scan(null, It.IsNotNull<ScanActionCallback<ScanResults>>())).Returns<ScanResults>(null);
 
             SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object);
@@ -135,7 +147,7 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
             _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
 
-            _targetElementLocatorMock.Setup(x => x.LocateRootElement(expectedProcessId)).Returns<A11yElement>(null);
+            _targetElementLocatorMock.Setup(x => x.LocateRootElements(expectedProcessId)).Returns<IEnumerable<A11yElement>>(null);
             _actionsMock.Setup(x => x.Scan(null, It.IsNotNull<ScanActionCallback<ScanResults>>())).Returns<ScanResults>(null);
 
             var config = Config.Builder.ForProcessId(expectedProcessId).Build();
@@ -156,10 +168,12 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
             _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
 
-            var element = new A11yElement();
-            _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns(element);
 
-            _actionsMock.Setup(x => x.Scan(element, It.IsAny<ScanActionCallback<ScanResults>>())).Returns<ScanResults>(null);
+            var elements = CreateMockElementArray();            
+            _targetElementLocatorMock.Setup(x => x.LocateRootElements(It.IsAny<int>())).Returns(elements);
+
+            _actionsMock.Setup(x => x.Scan(
+                elements.First(), It.IsAny<ScanActionCallback<ScanResults>>())).Returns<ScanResults>(null);
 
             SnapshotCommand.Execute(_minimalConfig, _scanToolsMock.Object);
 
@@ -178,7 +192,7 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
             _scanToolsMock.Setup(x => x.ResultsAssembler).Returns(_resultsAssemblerMock.Object);
 
-            _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns(new A11yElement());
+            _targetElementLocatorMock.Setup(x => x.LocateRootElements(It.IsAny<int>())).Returns(CreateMockElementArray());
 
             var expectedResults = new ScanResults();
             InitResultsCallback(expectedResults);
@@ -202,7 +216,7 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
             _scanToolsMock.Setup(x => x.ResultsAssembler).Returns<IScanResultsAssembler>(null);
 
-            _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns(new A11yElement());
+            _targetElementLocatorMock.Setup(x => x.LocateRootElements(It.IsAny<int>())).Returns(CreateMockElementArray());
 
             ScanResults tempResults = null;
             _actionsMock.Setup(x => x.Scan(It.IsAny<A11yElement>(), It.IsAny<ScanActionCallback<ScanResults>>()))
@@ -228,7 +242,7 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
             _scanToolsMock.Setup(x => x.ResultsAssembler).Returns(_resultsAssemblerMock.Object);
 
-            _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns(new A11yElement());
+            _targetElementLocatorMock.Setup(x => x.LocateRootElements(It.IsAny<int>())).Returns(CreateMockElementArray());
 
             var expectedResults = new ScanResults();
             expectedResults.ErrorCount = 0;
@@ -261,7 +275,7 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
             _scanToolsMock.Setup(x => x.ResultsAssembler).Returns(_resultsAssemblerMock.Object);
             _scanToolsMock.Setup(x => x.OutputFileHelper).Returns<IOutputFileHelper>(null);
-            _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns(new A11yElement());
+            _targetElementLocatorMock.Setup(x => x.LocateRootElements(It.IsAny<int>())).Returns(CreateMockElementArray());
             var expectedResults = new ScanResults();
             expectedResults.ErrorCount = 1;
             InitResultsCallback(expectedResults);
@@ -285,7 +299,7 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.ResultsAssembler).Returns(_resultsAssemblerMock.Object);
             _scanToolsMock.Setup(x => x.OutputFileHelper).Returns(_outputFileHelperMock.Object);
 
-            _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns(new A11yElement());
+            _targetElementLocatorMock.Setup(x => x.LocateRootElements(It.IsAny<int>())).Returns(CreateMockElementArray());
 
             var expectedResults = new ScanResults();
             expectedResults.ErrorCount = 1;
@@ -323,7 +337,7 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.ResultsAssembler).Returns(_resultsAssemblerMock.Object);
             _scanToolsMock.Setup(x => x.OutputFileHelper).Returns(_outputFileHelperMock.Object);
 
-            _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns(new A11yElement());
+            _targetElementLocatorMock.Setup(x => x.LocateRootElements(It.IsAny<int>())).Returns(CreateMockElementArray());
 
             var expectedResults = new ScanResults();
             expectedResults.ErrorCount = 75;
@@ -364,7 +378,7 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.NativeMethods).Returns(_nativeMethodsMock.Object);
             _scanToolsMock.Setup(x => x.ResultsAssembler).Returns(_resultsAssemblerMock.Object);
 
-            _targetElementLocatorMock.Setup(x => x.LocateRootElement(It.IsAny<int>())).Returns(new A11yElement());
+            _targetElementLocatorMock.Setup(x => x.LocateRootElements(It.IsAny<int>())).Returns(CreateMockElementArray());
             var expectedResults = new ScanResults();
             InitResultsCallback(expectedResults);
             _outputFileHelperMock.Setup(m => m.EnsureOutputDirectoryExists());

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -153,9 +153,8 @@ namespace Axe.Windows.Desktop.UIAutomation
             for (int i = 0; i < elementArray.Length; ++i)
             {
                 var uiaElement = elementArray.GetElement(i);
-                if (DesktopElement.IsFromCurrentProcess(uiaElement)) continue;
-
-                var e = new DesktopElement(uiaElement, true, false);
+                var e = ElementFromUIAElement(uiaElement);
+                if (e == null) continue;
 
                 e.PopulateMinimumPropertiesForSelection();
 

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -87,6 +87,7 @@ namespace Axe.Windows.Desktop.UIAutomation
                 {
                     Marshal.ReleaseComObject(condition);
                 }
+
                 if (elementArray != null)
                 {
                     Marshal.ReleaseComObject(elementArray);
@@ -150,16 +151,27 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// <returns>An IEnumerable of <see cref="DesktopElement"/></returns>
         private static IEnumerable<DesktopElement> ElementsFromUIAElements(IUIAutomationElementArray elementArray)
         {
-            for (int i = 0; i < elementArray.Length; ++i)
+            if (elementArray == null) throw new ArgumentNullException(nameof(elementArray));
+
+            var count = elementArray.Length;
+            if (count <= 0) return null;
+
+            // This function was originally an iterator
+            // Meaning it used the yield keyword to yield return each element
+            // But that caused a com exception IRL
+            // So now we use a list
+            List<DesktopElement> elements = new List<DesktopElement>();
+
+            for (int i = 0; i < count; ++i)
             {
                 var uiaElement = elementArray.GetElement(i);
                 var e = ElementFromUIAElement(uiaElement);
                 if (e == null) continue;
 
-                e.PopulateMinimumPropertiesForSelection();
-
-                yield return e;
+                elements.Add(e);
             } // for each element
+
+            return elements;
         }
 
         /// <summary>

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -153,8 +153,9 @@ namespace Axe.Windows.Desktop.UIAutomation
         {
             if (elementArray == null) throw new ArgumentNullException(nameof(elementArray));
 
+            // Return an empty IEnumerable<DesktopElement> instead of null from ElementsFromUIAElements so that downstream calls to Linq extensions on the IEnumerable don't throw null reference exceptions.
             var count = elementArray.Length;
-            if (count <= 0) return null;
+            if (count <= 0) return Enumerable.Empty<DesktopElement>();
 
             // This function was originally an iterator
             // Meaning it used the yield keyword to yield return each element


### PR DESCRIPTION
#### Details

This change refactors TargetElementLocator so that it returns all root-level window elements for a given process id. The scanner itself still only scans the first window returned, which is the same as the existing behavior. 

##### Motivation

This commit partially addresses  #665.

##### Context

This change was kept as small as possible. But it should pave the way for a change where the user can specify that all root-level windows are scanned.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
