### PR TITLE
fix: Update rule desriptions to be easier to understand

### DIFF
--- a/src/RuleSelection/RuleRunner.cs
+++ b/src/RuleSelection/RuleRunner.cs
@@ -95,7 +95,6 @@ namespace Axe.Windows.RuleSelection
                     return ScanStatus.ScanNotSupported;
                 case EvaluationCode.Error:
                     return ScanStatus.Fail;
-                case EvaluationCode.Note:
                 case EvaluationCode.NeedsReview:
                 case EvaluationCode.Warning:
                     return ScanStatus.Uncertain;

--- a/src/RuleSelection/RuleRunner.cs
+++ b/src/RuleSelection/RuleRunner.cs
@@ -96,7 +96,7 @@ namespace Axe.Windows.RuleSelection
                 case EvaluationCode.Error:
                     return ScanStatus.Fail;
                 case EvaluationCode.Note:
-                case EvaluationCode.Open:
+                case EvaluationCode.NeedsReview:
                 case EvaluationCode.Warning:
                     return ScanStatus.Uncertain;
                 case EvaluationCode.NotApplicable:

--- a/src/Rules/EvaluationCode.cs
+++ b/src/Rules/EvaluationCode.cs
@@ -30,7 +30,7 @@ namespace Axe.Windows.Rules
         Error,
 
         /// <summary>
-        /// The rule requires human review to decide if it is satisfied
+        /// The rule highlights possible accessibility issues that need to be reviewed and verified by a human.
         /// </summary>
         NeedsReview,
 

--- a/src/Rules/EvaluationCode.cs
+++ b/src/Rules/EvaluationCode.cs
@@ -30,9 +30,9 @@ namespace Axe.Windows.Rules
         Error,
 
         /// <summary>
-        /// The rule is unable to make a determination, and the element should be investigated.
+        /// The rule requires human review to decide if it is satisfied
         /// </summary>
-        Open,
+        NeedsReview,
 
         /// <summary>
         /// The rule's description is informational and does not indicate success or failure.

--- a/src/Rules/EvaluationCode.cs
+++ b/src/Rules/EvaluationCode.cs
@@ -35,11 +35,6 @@ namespace Axe.Windows.Rules
         NeedsReview,
 
         /// <summary>
-        /// The rule's description is informational and does not indicate success or failure.
-        /// </summary>
-        Note,
-
-        /// <summary>
         /// The given element did not meet the success criteria of the rule evaluation,
         /// but the cause is known to be difficult for developers to fix
         /// (as in issues caused by the platform itself)

--- a/src/Rules/Library/BoundingRectangleNotValidButOffScreen.cs
+++ b/src/Rules/Library/BoundingRectangleNotValidButOffScreen.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.BoundingRectangleNotValidButOffScreen;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/BoundingRectangleOnUWPMenuBar.cs
+++ b/src/Rules/Library/BoundingRectangleOnUWPMenuBar.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.BoundingRectangleOnUWPMenuBar;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Open;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/BoundingRectangleOnUWPMenuItem.cs
+++ b/src/Rules/Library/BoundingRectangleOnUWPMenuItem.cs
@@ -20,7 +20,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.BoundingRectangleOnUWPMenuItem;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Open;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/BoundingRectangleOnWPFTextParent.cs
+++ b/src/Rules/Library/BoundingRectangleOnWPFTextParent.cs
@@ -20,7 +20,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.BoundingRectangleOnWPFTextParent;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Open;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsContentElementFalseOptional.cs
+++ b/src/Rules/Library/IsContentElementFalseOptional.cs
@@ -20,7 +20,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsContentElementFalseOptional;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_IsContentElementPropertyId;
-            this.Info.ErrorCode = EvaluationCode.Open;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsContentElementTrueOptional.cs
+++ b/src/Rules/Library/IsContentElementTrueOptional.cs
@@ -20,7 +20,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsContentElementTrueOptional;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_IsContentElementPropertyId;
-            this.Info.ErrorCode = EvaluationCode.Open;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsControlElementTrueOptional.cs
+++ b/src/Rules/Library/IsControlElementTrueOptional.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsControlElementTrueOptional;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_IsControlElementPropertyId;
-            this.Info.ErrorCode = EvaluationCode.Open;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsKeyboardFocusableDescendantTextPattern.cs
+++ b/src/Rules/Library/IsKeyboardFocusableDescendantTextPattern.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsKeyboardFocusableDescendantTextPattern;
             this.Info.Standard = A11yCriteriaId.Keyboard;
             this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsKeyboardFocusableFalseButDisabled.cs
+++ b/src/Rules/Library/IsKeyboardFocusableFalseButDisabled.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsKeyboardFocusableFalseButDisabled;
             this.Info.Standard = A11yCriteriaId.Keyboard;
             this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsKeyboardFocusableFalseButOffscreen.cs
+++ b/src/Rules/Library/IsKeyboardFocusableFalseButOffscreen.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsKeyboardFocusableFalseButOffscreen;
             this.Info.Standard = A11yCriteriaId.Keyboard;
             this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsKeyboardFocusableOnEmptyContainer.cs
+++ b/src/Rules/Library/IsKeyboardFocusableOnEmptyContainer.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.IsKeyboardFocusableOnEmptyContainer;
             this.Info.Standard = A11yCriteriaId.Keyboard;
             this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Open;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ItemStatusExists.cs
+++ b/src/Rules/Library/ItemStatusExists.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.ItemStatusExists;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_ItemStatusPropertyId;
-            this.Info.ErrorCode = EvaluationCode.Open;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ItemTypeRecommended.cs
+++ b/src/Rules/Library/ItemTypeRecommended.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.ItemTypeRecommended;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_ItemTypePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Open;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameIsEmptyButElementIsNotKeyboardFocusable.cs
+++ b/src/Rules/Library/NameIsEmptyButElementIsNotKeyboardFocusable.cs
@@ -21,7 +21,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameEmptyButElementNotKeyboardFocusable;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Open;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameIsNullButElementIsNotKeyboardFocusable.cs
+++ b/src/Rules/Library/NameIsNullButElementIsNotKeyboardFocusable.cs
@@ -20,7 +20,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameNullButElementNotKeyboardFocusable;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Open;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameNoSiblingsOfSameType.cs
+++ b/src/Rules/Library/NameNoSiblingsOfSameType.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameNoSiblingsOfSameType;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameOnCustomWithParentWPFDataItem.cs
+++ b/src/Rules/Library/NameOnCustomWithParentWPFDataItem.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameOnCustomWithParentWPFDataItem;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameOnOptionalType.cs
+++ b/src/Rules/Library/NameOnOptionalType.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.NameOnOptionalType;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Open;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
@@ -38,7 +38,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.SiblingUniqueAndNotFocusable;
             this.Info.HowToFix = HowToFix.SiblingUniqueAndNotFocusable;
             this.Info.Standard = A11yCriteriaId.NameRoleValue;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Button.cs
+++ b/src/Rules/Library/Structure/ContentView/Button.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.ButtonStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.ButtonStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Calendar.cs
+++ b/src/Rules/Library/Structure/ContentView/Calendar.cs
@@ -17,7 +17,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.CalendarStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.CalendarStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/CheckBox.cs
+++ b/src/Rules/Library/Structure/ContentView/CheckBox.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.CheckBoxStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.CheckBoxStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/ComboBox.cs
+++ b/src/Rules/Library/Structure/ContentView/ComboBox.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.ComboBoxStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.ComboBoxStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/DataGrid.cs
+++ b/src/Rules/Library/Structure/ContentView/DataGrid.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.DataGridStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.DataGridStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Edit.cs
+++ b/src/Rules/Library/Structure/ContentView/Edit.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.EditStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.EditStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Hyperlink.cs
+++ b/src/Rules/Library/Structure/ContentView/Hyperlink.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.HyperlinkStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.HyperlinkStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/List.cs
+++ b/src/Rules/Library/Structure/ContentView/List.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.ListStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.ListStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/ListItem.cs
+++ b/src/Rules/Library/Structure/ContentView/ListItem.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.ListItemStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.ListItemStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Menu.cs
+++ b/src/Rules/Library/Structure/ContentView/Menu.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.MenuStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.MenuStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/ProgressBar.cs
+++ b/src/Rules/Library/Structure/ContentView/ProgressBar.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.ProgressBarStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.ProgressBarStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/RadioButton.cs
+++ b/src/Rules/Library/Structure/ContentView/RadioButton.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.RadioButtonStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.RadioButtonStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Slider.cs
+++ b/src/Rules/Library/Structure/ContentView/Slider.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.SliderStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.SliderStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Spinner.cs
+++ b/src/Rules/Library/Structure/ContentView/Spinner.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.SpinnerStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.SpinnerStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/SplitButton.cs
+++ b/src/Rules/Library/Structure/ContentView/SplitButton.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.SplitButtonStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.SplitButtonStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/StatusBar.cs
+++ b/src/Rules/Library/Structure/ContentView/StatusBar.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.StatusBarStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.StatusBarStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Tab.cs
+++ b/src/Rules/Library/Structure/ContentView/Tab.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.TabStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.TabStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Tree.cs
+++ b/src/Rules/Library/Structure/ContentView/Tree.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.TreeStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.TreeStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/TreeItem.cs
+++ b/src/Rules/Library/Structure/ContentView/TreeItem.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ContentView.TreeItemStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ContentView.TreeItemStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Button.cs
+++ b/src/Rules/Library/Structure/ControlView/Button.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ButtonStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ButtonStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Calendar.cs
+++ b/src/Rules/Library/Structure/ControlView/Calendar.cs
@@ -17,7 +17,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.CalendarStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.CalendarStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/CheckBox.cs
+++ b/src/Rules/Library/Structure/ControlView/CheckBox.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.CheckBoxStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.CheckBoxStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/ComboBox.cs
+++ b/src/Rules/Library/Structure/ControlView/ComboBox.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ComboBoxStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ComboBoxStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/DataGrid.cs
+++ b/src/Rules/Library/Structure/ControlView/DataGrid.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.DataGridStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.DataGridStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Edit.cs
+++ b/src/Rules/Library/Structure/ControlView/Edit.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.EditStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.EditStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Header.cs
+++ b/src/Rules/Library/Structure/ControlView/Header.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.HeaderStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.HeaderStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/HeaderItem.cs
+++ b/src/Rules/Library/Structure/ControlView/HeaderItem.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.HeaderItemStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.HeaderItemStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Hyperlink.cs
+++ b/src/Rules/Library/Structure/ControlView/Hyperlink.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.HyperlinkStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.HyperlinkStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Image.cs
+++ b/src/Rules/Library/Structure/ControlView/Image.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ImageStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ImageStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/List.cs
+++ b/src/Rules/Library/Structure/ControlView/List.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ListStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ListStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/ListItem.cs
+++ b/src/Rules/Library/Structure/ControlView/ListItem.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ListItemStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ListItemStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Menu.cs
+++ b/src/Rules/Library/Structure/ControlView/Menu.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.MenuStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.MenuStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/ProgressBar.cs
+++ b/src/Rules/Library/Structure/ControlView/ProgressBar.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ProgressBarStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ProgressBarStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/RadioButton.cs
+++ b/src/Rules/Library/Structure/ControlView/RadioButton.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.RadioButtonStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.RadioButtonStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Scrollbar.cs
+++ b/src/Rules/Library/Structure/ControlView/Scrollbar.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ScrollbarStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ScrollbarStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/SemanticZoom.cs
+++ b/src/Rules/Library/Structure/ControlView/SemanticZoom.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.SemanticZoomStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.SemanticZoomStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Separator.cs
+++ b/src/Rules/Library/Structure/ControlView/Separator.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.SeparatorStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.SeparatorStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Slider.cs
+++ b/src/Rules/Library/Structure/ControlView/Slider.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.SliderStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.SliderStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Spinner.cs
+++ b/src/Rules/Library/Structure/ControlView/Spinner.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.SpinnerStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.SpinnerStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/SplitButton.cs
+++ b/src/Rules/Library/Structure/ControlView/SplitButton.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.SplitButtonStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.SplitButtonStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/StatusBar.cs
+++ b/src/Rules/Library/Structure/ControlView/StatusBar.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.StatusBarStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.StatusBarStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Tab.cs
+++ b/src/Rules/Library/Structure/ControlView/Tab.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.TabStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.TabStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Thumb.cs
+++ b/src/Rules/Library/Structure/ControlView/Thumb.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ThumbStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ThumbStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/ToolTip.cs
+++ b/src/Rules/Library/Structure/ControlView/ToolTip.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ToolTipStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ToolTipStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Tree.cs
+++ b/src/Rules/Library/Structure/ControlView/Tree.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.TreeStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.TreeStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/TreeItem.cs
+++ b/src/Rules/Library/Structure/ControlView/TreeItem.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.TreeItemStructure);
             this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.TreeItemStructure);
             this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Note;
+            this.Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/RulesMD/EvaluationCodeDescriptions.md
+++ b/src/RulesMD/EvaluationCodeDescriptions.md
@@ -10,4 +10,4 @@ The given element did not meet the success criteria of the rule evaluation, but 
 
 ### NeedsReview
 
-The rule requires human review to decide if it was satisfied.
+The rule highlights possible accessibility issues that need to be reviewed and verified by a human.

--- a/src/RulesMD/EvaluationCodeDescriptions.md
+++ b/src/RulesMD/EvaluationCodeDescriptions.md
@@ -8,10 +8,6 @@ The given element did not meet the success criteria of the rule evaluation. The 
 
 The given element did not meet the success criteria of the rule evaluation, but the cause is known to be difficult for developers to fix (as in issues caused by the platform itself) or impact to users has been determined to be low.
 
-### Open
+### NeedsReview
 
-There may be a problem, but the rule is unable to make a definitive determination. The element should be investigated.
-
-### Note
-
-The rule's description is informational and does not indicate success or failure.
+The rule requires human review to decide if it was satisfied.

--- a/src/RulesTest/MonsterTest.cs
+++ b/src/RulesTest/MonsterTest.cs
@@ -34,7 +34,7 @@ namespace Axe.Windows.RulesTests
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ChildrenNotAllowedInContentView]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.SiblingUniqueAndFocusable]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.SiblingUniqueAndNotFocusable]);
-            Assert.AreEqual(EvaluationCode.Note, results[RuleId.ContentViewButtonStructure]);
+            Assert.AreEqual(EvaluationCode.NeedsReview, results[RuleId.ContentViewButtonStructure]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ContentViewCalendarStructure]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ContentViewCheckBoxStructure]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ContentViewComboBoxStructure]);
@@ -565,7 +565,7 @@ namespace Axe.Windows.RulesTests
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.NameExcludesLocalizedControlType]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.NameExcludesPrivateUnicodeCharacters]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.NameIsInformative]);
-            Assert.AreEqual(EvaluationCode.Note, results[RuleId.NameNoSiblingsOfSameType]);
+            Assert.AreEqual(EvaluationCode.NeedsReview, results[RuleId.NameNoSiblingsOfSameType]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.NameNotEmpty]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.NameNotNull]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.NameNotWhiteSpace]);
@@ -643,7 +643,7 @@ namespace Axe.Windows.RulesTests
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ControlViewCheckBoxStructure]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ControlViewComboBoxStructure]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ControlViewDataGridStructure]);
-            Assert.AreEqual(EvaluationCode.Note, results[RuleId.ControlViewEditStructure]);
+            Assert.AreEqual(EvaluationCode.NeedsReview, results[RuleId.ControlViewEditStructure]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ControlViewHeaderItemStructure]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ControlViewHeaderStructure]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ControlViewHyperlinkStructure]);

--- a/src/RulesTest/RuleRunnerTests.cs
+++ b/src/RulesTest/RuleRunnerTests.cs
@@ -106,7 +106,7 @@ namespace Axe.Windows.RulesTests
 
             var infoStub = new RuleInfo
             {
-                ErrorCode = EvaluationCode.Note,
+                ErrorCode = EvaluationCode.NeedsReview,
             };
 
             var ruleMock = new Mock<IRule>(MockBehavior.Strict);
@@ -139,7 +139,7 @@ namespace Axe.Windows.RulesTests
 
             var infoStub = new RuleInfo
             {
-                ErrorCode = EvaluationCode.Note,
+                ErrorCode = EvaluationCode.NeedsReview,
             };
 
             var ruleMock = new Mock<IRule>(MockBehavior.Strict);
@@ -153,7 +153,7 @@ namespace Axe.Windows.RulesTests
             var runner = new RuleRunner(providerMock.Object);
             var result = runner.RunRuleByID(default(RuleId), e);
 
-            Assert.AreEqual(EvaluationCode.Note, result.EvaluationCode);
+            Assert.AreEqual(EvaluationCode.NeedsReview, result.EvaluationCode);
             Assert.AreEqual(e, result.element);
             Assert.AreEqual(ruleMock.Object.Info, result.RuleInfo);
 

--- a/src/RulesTest/RuleRunnerTests.cs
+++ b/src/RulesTest/RuleRunnerTests.cs
@@ -79,7 +79,7 @@ namespace Axe.Windows.RulesTests
             var conditionMock = new Mock<Condition>(MockBehavior.Strict);
             conditionMock.Setup(m => m.Matches(e)).Returns(true).Verifiable();
 
-            var ruleMock = CreateRuleMock(conditionMock.Object, EvaluationCode.Open, e);
+            var ruleMock = CreateRuleMock(conditionMock.Object, EvaluationCode.NeedsReview, e);
 
             var providerMock = new Mock<IRuleProvider>(MockBehavior.Strict);
             providerMock.Setup(m => m.GetRule(It.IsAny<RuleId>())).Returns(() => ruleMock.Object).Verifiable();
@@ -87,7 +87,7 @@ namespace Axe.Windows.RulesTests
             var runner = new RuleRunner(providerMock.Object);
             var result = runner.RunRuleByID(default(RuleId), e);
 
-            Assert.AreEqual(EvaluationCode.Open, result.EvaluationCode);
+            Assert.AreEqual(EvaluationCode.NeedsReview, result.EvaluationCode);
             Assert.AreEqual(e, result.element);
             Assert.AreEqual(ruleMock.Object.Info, result.RuleInfo);
 


### PR DESCRIPTION
#### Details

#617 calls out some concerns about the rules descriptions. This change does the following:
1. Renames `EvaluationCode.Open` to `EvaluationCode.NeedsReview`, updates its description
2. Remaps all uses of `EvaluationCode.Note` to `EvaluationCode.NeedsReview`
3. Removes `EvaluationCode.Note`
4. Updates the rules generator to use the new descriptions

##### Motivation

Address #617

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
We may wish to remove the rules that formerly used `EvaluationCode.Note`, since they are more of a best practice rule, and other Accessibility Insights products filter them out.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #617 
