### PR TITLE
feat(framework-issues-logic): Infrastructure for framework issue links

### DIFF
--- a/src/CLI/OutputGenerator.cs
+++ b/src/CLI/OutputGenerator.cs
@@ -153,9 +153,18 @@ namespace AxeWindowsCLI
             foreach (ScanResult scanResult in scanResults.Errors)
             {
                 _writer.WriteLine(DisplayStrings.ScanResultDetailHeader, ++errorCount, scanResult.Rule.Description);
+                WriteFrameworkLink(scanResult);
                 WriteProperties(scanResult);
                 WritePatterns(scanResult);
                 _writer.WriteLine(DisplayStrings.ScanResultDetailFooter);
+            }
+        }
+
+        private void WriteFrameworkLink(ScanResult scanResult)
+        {
+            if (scanResult.Rule.FrameworkIssueLink != null)
+            {
+                _writer.WriteLine(DisplayStrings.FrameworkIssueLink, scanResult.Rule.FrameworkIssueLink);
             }
         }
 

--- a/src/CLI/Resources/DisplayStrings.Designer.cs
+++ b/src/CLI/Resources/DisplayStrings.Designer.cs
@@ -115,6 +115,15 @@ namespace AxeWindowsCLI.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to   Potential Framework Issue: {0}.
+        /// </summary>
+        internal static string FrameworkIssueLink {
+            get {
+                return ResourceManager.GetString("FrameworkIssueLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to   {0} seconds before scan..
         /// </summary>
         internal static string ScanDelayCountdownMoreThanOneSecondLeft {

--- a/src/CLI/Resources/DisplayStrings.resx
+++ b/src/CLI/Resources/DisplayStrings.resx
@@ -140,6 +140,10 @@
   <data name="ErrorNoTarget" xml:space="preserve">
     <value>Please specify either processId or processName on the command line.</value>
   </data>
+  <data name="FrameworkIssueLink" xml:space="preserve">
+    <value>  Potential Framework Issue: {0}</value>
+    <comment>{0} is the link to the known framework issue</comment>
+  </data>
   <data name="ScanDelayCountdownMoreThanOneSecondLeft" xml:space="preserve">
     <value>  {0} seconds before scan.</value>
     <comment>{0} is the remaining countdown. Leading spaces are intentional</comment>

--- a/src/CLITests/OutputGeneratorUnitTests.cs
+++ b/src/CLITests/OutputGeneratorUnitTests.cs
@@ -36,6 +36,7 @@ namespace AxeWindowsCLITests
         const string ErrorVerbosePatternsHeaderStart = "  Element Patterns";
         const string ErrorVerbosePatternIndex = "    {0}";
         const string ErrorVerboseSeparatorStart = "---------------------";
+        const string FrameworkIssueLinkOneParam = "  Potential Framework Issue: {0}";
         const string OutputFileStart = "Results were written ";
         const string UnableToComplete = "Unable to complete. ";
         const string NoFurtherData = "No further data is available.";
@@ -265,7 +266,7 @@ namespace AxeWindowsCLITests
         }
 
         private ScanResults BuildTestScanResults(int errorCount = 0, string a11yTestFile = null,
-            int? propertyCount = null, int? patternCount = null)
+            int? propertyCount = null, int? patternCount = null, string frameworkIssueLink = null)
         {
             List<ScanResult> errors = new List<ScanResult>(errorCount);
 
@@ -281,6 +282,7 @@ namespace AxeWindowsCLITests
                     Rule = new RuleInfo
                     {
                         Description = "Test Rule",
+                        FrameworkIssueLink = frameworkIssueLink,
                     },
                 }); ;
             };
@@ -472,6 +474,7 @@ namespace AxeWindowsCLITests
                 new WriteCall(AppTitleStart, WriteSource.WriteLineOneParam),
                 new WriteCall(ErrorCountGeneralStart, WriteSource.WriteLineOneParam),
                 new WriteCall(ErrorVerboseCountStart, WriteSource.WriteLineTwoParams),
+                new WriteCall(FrameworkIssueLinkOneParam, WriteSource.WriteLineOneParam),
                 new WriteCall(ErrorVerbosePropertiesHeaderStart, WriteSource.WriteLineStringOnly),
                 new WriteCall(ErrorVerbosePropertyPairStart, WriteSource.WriteLineTwoParams),
                 new WriteCall(ErrorVerbosePropertyPairStart, WriteSource.WriteLineTwoParams),
@@ -480,6 +483,7 @@ namespace AxeWindowsCLITests
                 new WriteCall(ErrorVerbosePatternIndex, WriteSource.WriteLineOneParam),
                 new WriteCall(ErrorVerboseSeparatorStart, WriteSource.WriteLineStringOnly),
                 new WriteCall(ErrorVerboseCountStart, WriteSource.WriteLineTwoParams),
+                new WriteCall(FrameworkIssueLinkOneParam, WriteSource.WriteLineOneParam),
                 new WriteCall(ErrorVerbosePropertiesHeaderStart, WriteSource.WriteLineStringOnly),
                 new WriteCall(ErrorVerbosePropertyPairStart, WriteSource.WriteLineTwoParams),
                 new WriteCall(ErrorVerbosePropertyPairStart, WriteSource.WriteLineTwoParams),
@@ -491,7 +495,7 @@ namespace AxeWindowsCLITests
             };
             TextWriterVerifier textWriterVerifier = new TextWriterVerifier(_writerMock, expectedCalls);
             ScanResults scanResults = BuildTestScanResults(errorCount: 2, a11yTestFile: TestA11yTestFile,
-                patternCount: 2, propertyCount: 2);
+                patternCount: 2, propertyCount: 2, frameworkIssueLink: "https://docs.microsoft.com");
 
             _testSubject.WriteOutput(_optionsMock.Object, scanResults, null);
 

--- a/src/Core/Results/RuleResult.cs
+++ b/src/Core/Results/RuleResult.cs
@@ -60,6 +60,12 @@ namespace Axe.Windows.Core.Results
         public Uri IssueLink { get; set; }
 
         /// <summary>
+        /// The link to a known framework issue that can cause this rule to fail.
+        /// This field will be null if no known framework issue exists.
+        /// </summary>
+        public string FrameworkIssueLink { get; set; }
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="status"></param>
@@ -67,7 +73,8 @@ namespace Axe.Windows.Core.Results
         /// <param name="source"></param>
         /// <param name="url"></param>
         /// <param name="meta"></param>
-        internal RuleResult(RuleId id, string desc, string source, HelpUrl url, ScanMetaInfo meta)
+        /// <param name="frameworkIssueLink"></param>
+        internal RuleResult(RuleId id, string desc, string source, HelpUrl url, string frameworkIssueLink, ScanMetaInfo meta)
         {
             this.Rule = id;
             this.Description = desc;
@@ -75,6 +82,7 @@ namespace Axe.Windows.Core.Results
             this.Messages = new List<string>();
             this.MetaInfo = meta;
             this.HelpUrl = url;
+            this.FrameworkIssueLink = frameworkIssueLink;
         }
 
         /// <summary>

--- a/src/Core/Results/ScanResult.cs
+++ b/src/Core/Results/ScanResult.cs
@@ -53,6 +53,12 @@ namespace Axe.Windows.Core.Results
         public HelpUrl HelpUrl { get; set; }
 
         /// <summary>
+        /// The link to a known framework issue that can cause this rule to fail.
+        /// This field will be null if no known framework issue exists.
+        /// </summary>
+        public string FrameworkIssueLink { get; set; }
+
+        /// <summary>
         /// Keep the Meta Info Scan Result
         /// </summary>
         public ScanMetaInfo MetaInfo { get; set; }
@@ -71,10 +77,11 @@ namespace Axe.Windows.Core.Results
         /// <param name="e">A11yElement</param>
         /// <param name="propertyId"> if the value is 0, it means that it is not using property for scan</param>
         /// <param name="status"></param>
-        public ScanResult(string description, string source, IA11yElement e, int propertyId = 0)
+        public ScanResult(string description, string source, string frameworkIssueLink, IA11yElement e, int propertyId = 0)
         {
             this.Description = description;
             this.Source = source;
+            this.FrameworkIssueLink = frameworkIssueLink;
             this.MetaInfo = propertyId != 0 ? new ScanMetaInfo(e, propertyId) : new ScanMetaInfo(e);
             this.Items = new List<RuleResult>();
         }
@@ -93,11 +100,10 @@ namespace Axe.Windows.Core.Results
         /// </summary>
         /// <param name="status"></param>
         /// <param name="desc"></param>
-        /// <param name="frameworkIssueLink"></param>
         /// <returns></returns>
-        public RuleResult GetRuleResultInstance(RuleId id, string desc, string frameworkIssueLink)
+        public RuleResult GetRuleResultInstance(RuleId id, string desc)
         {
-            var rr = new RuleResult(id, desc, this.Source, this.HelpUrl, frameworkIssueLink, this.MetaInfo.Clone());
+            var rr = new RuleResult(id, desc, this.Source, this.HelpUrl, this.FrameworkIssueLink, this.MetaInfo.Clone());
 
             this.Items.Add(rr);
 

--- a/src/Core/Results/ScanResult.cs
+++ b/src/Core/Results/ScanResult.cs
@@ -93,10 +93,11 @@ namespace Axe.Windows.Core.Results
         /// </summary>
         /// <param name="status"></param>
         /// <param name="desc"></param>
+        /// <param name="frameworkIssueLink"></param>
         /// <returns></returns>
-        public RuleResult GetRuleResultInstance(RuleId id, string desc)
+        public RuleResult GetRuleResultInstance(RuleId id, string desc, string frameworkIssueLink)
         {
-            var rr = new RuleResult(id, desc, this.Source, this.HelpUrl, this.MetaInfo.Clone());
+            var rr = new RuleResult(id, desc, this.Source, this.HelpUrl, frameworkIssueLink, this.MetaInfo.Clone());
 
             this.Items.Add(rr);
 

--- a/src/RuleSelection/RuleRunner.cs
+++ b/src/RuleSelection/RuleRunner.cs
@@ -62,7 +62,7 @@ namespace Axe.Windows.RuleSelection
             var scanResult = CreateResult(runResult.RuleInfo, runResult.element);
 
             var description = runResult.RuleInfo.Description;
-            var ruleResult = scanResult.GetRuleResultInstance(runResult.RuleInfo.ID, description);
+            var ruleResult = scanResult.GetRuleResultInstance(runResult.RuleInfo.ID, description, runResult.RuleInfo.FrameworkIssueLink);
             ruleResult.Status = ConvertEvaluationCodeToScanStatus(runResult.EvaluationCode);
             ruleResult.AddMessage(runResult.RuleInfo.HowToFix);
 

--- a/src/RuleSelection/RuleRunner.cs
+++ b/src/RuleSelection/RuleRunner.cs
@@ -62,7 +62,7 @@ namespace Axe.Windows.RuleSelection
             var scanResult = CreateResult(runResult.RuleInfo, runResult.element);
 
             var description = runResult.RuleInfo.Description;
-            var ruleResult = scanResult.GetRuleResultInstance(runResult.RuleInfo.ID, description, runResult.RuleInfo.FrameworkIssueLink);
+            var ruleResult = scanResult.GetRuleResultInstance(runResult.RuleInfo.ID, description);
             ruleResult.Status = ConvertEvaluationCodeToScanStatus(runResult.EvaluationCode);
             ruleResult.AddMessage(runResult.RuleInfo.HowToFix);
 
@@ -75,7 +75,7 @@ namespace Axe.Windows.RuleSelection
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var guidelineInfo = ReferenceLinks.GetGuidelineInfo(info.Standard);
-            var scanResult = new ScanResult(info.Description, guidelineInfo.ShortDescription, e, info.PropertyID)
+            var scanResult = new ScanResult(info.Description, guidelineInfo.ShortDescription, info.FrameworkIssueLink, e, info.PropertyID)
             {
                 HelpUrl = new HelpUrl
                 {

--- a/src/Rules/RuleInfo.cs
+++ b/src/Rules/RuleInfo.cs
@@ -59,6 +59,12 @@ namespace Axe.Windows.Rules
         public EvaluationCode ErrorCode { get; set; } = EvaluationCode.NotSet;
 
         /// <summary>
+        /// The link to a known framework issue that can cause this rule to fail.
+        /// This field will be null if no known framework issue exists.
+        /// </summary>
+        public string FrameworkIssueLink { get; set; }
+
+        /// <summary>
         /// Provides a string summary of the information contained in the RuleInfo object.
         /// </summary>
         public override string ToString()

--- a/src/RulesTest/RuleRunnerTests.cs
+++ b/src/RulesTest/RuleRunnerTests.cs
@@ -163,6 +163,70 @@ namespace Axe.Windows.RulesTests
         }
 
         [TestMethod]
+        public void RunRuleByID_FrameworkIssueLinkIsNull_PropagatesToResult()
+        {
+            var e = new MockA11yElement();
+
+            var conditionMock = new Mock<Condition>(MockBehavior.Strict);
+            conditionMock.Setup(m => m.Matches(e)).Returns(true).Verifiable();
+
+            var infoStub = new RuleInfo
+            {
+                ErrorCode = EvaluationCode.NeedsReview,
+            };
+
+            var ruleMock = new Mock<IRule>(MockBehavior.Strict);
+            ruleMock.Setup(m => m.Condition).Returns(conditionMock.Object).Verifiable();
+            ruleMock.Setup(m => m.PassesTest(e)).Returns(true).Verifiable();
+            ruleMock.Setup(m => m.Info).Returns(() => infoStub).Verifiable();
+
+            var providerMock = new Mock<IRuleProvider>(MockBehavior.Strict);
+            providerMock.Setup(m => m.GetRule(It.IsAny<RuleId>())).Returns(() => ruleMock.Object).Verifiable();
+
+            var runner = new RuleRunner(providerMock.Object);
+            var result = runner.RunRuleByID(default(RuleId), e);
+
+            Assert.IsNull(result.RuleInfo.FrameworkIssueLink);
+
+            conditionMock.VerifyAll();
+            ruleMock.VerifyAll();
+            providerMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void RunRuleByID_FrameworkIssueLinkIsNotNull_PropagatesToResult()
+        {
+            const string frameworkIssueLink = "htt[s://docs.microsoft.com/known-framework-link";
+            var e = new MockA11yElement();
+
+            var conditionMock = new Mock<Condition>(MockBehavior.Strict);
+            conditionMock.Setup(m => m.Matches(e)).Returns(true).Verifiable();
+
+            var infoStub = new RuleInfo
+            {
+                ErrorCode = EvaluationCode.NeedsReview,
+                FrameworkIssueLink = frameworkIssueLink,
+            };
+
+            var ruleMock = new Mock<IRule>(MockBehavior.Strict);
+            ruleMock.Setup(m => m.Condition).Returns(conditionMock.Object).Verifiable();
+            ruleMock.Setup(m => m.PassesTest(e)).Returns(true).Verifiable();
+            ruleMock.Setup(m => m.Info).Returns(() => infoStub).Verifiable();
+
+            var providerMock = new Mock<IRuleProvider>(MockBehavior.Strict);
+            providerMock.Setup(m => m.GetRule(It.IsAny<RuleId>())).Returns(() => ruleMock.Object).Verifiable();
+
+            var runner = new RuleRunner(providerMock.Object);
+            var result = runner.RunRuleByID(default(RuleId), e);
+
+            Assert.AreEqual(frameworkIssueLink, result.RuleInfo.FrameworkIssueLink);
+
+            conditionMock.VerifyAll();
+            ruleMock.VerifyAll();
+            providerMock.VerifyAll();
+        }
+
+        [TestMethod]
         public void RunRuleByID_ReturnsExecutionErrorWhenPassesTestThrowsException()
         {
             var e = new MockA11yElement();

--- a/src/RulesTest/RuleRunnerTests.cs
+++ b/src/RulesTest/RuleRunnerTests.cs
@@ -196,7 +196,7 @@ namespace Axe.Windows.RulesTests
         [TestMethod]
         public void RunRuleByID_FrameworkIssueLinkIsNotNull_PropagatesToResult()
         {
-            const string frameworkIssueLink = "htt[s://docs.microsoft.com/known-framework-link";
+            const string frameworkIssueLink = "https://docs.microsoft.com/known-framework-link";
             var e = new MockA11yElement();
 
             var conditionMock = new Mock<Condition>(MockBehavior.Strict);


### PR DESCRIPTION
#### Details

We're adding `RuleInfo.FrameworkIssueLink` to identify rules with known framework problems. If a rule sets this field, that serves as an indication that _every_ element that meets the condition of the rule is potentially caused by that known framework issue. The link will go to a documentation page that outlines how to determine if the app is using a framework that has this problem. Where possible, that page will also include links to issues in public GitHub repos, so teams already have an external bug to reference and possibly upvote.

##### Motivation

Needed for framework issue logic feature

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
This PR is purely infrastructure and changes no rules. The unit test simulate rules with known issues. I also tested it locally by adding some links to rules and confirming that they appear in the a11ytest file and in the console output.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
