### PR TITLE
feat(framework-issues-logic): Add framework issue links

### DIFF
--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -18,10 +18,10 @@ namespace Axe.Windows.AutomationTests
     public class AutomationIntegrationTests
     {
         // These values should change only in response to intentional rule modifications
-        const int WildlifeManagerKnownErrorCount = 12;
+        const int WildlifeManagerKnownErrorCount = 15;
         const int Win32ControlSamplerKnownErrorCount = 0;
         const int WindowsFormsControlSamplerKnownErrorCount = 4;
-        const int WpfControlSamplerKnownErrorCount = 5;
+        const int WpfControlSamplerKnownErrorCount = 7;
         const int WindowsFormsMultiWindowSamplerAppAllErrorCount = 8;
         const int WindowsFormsMultiWindowSamplerSingleWindowAllErrorCount = 4;
 

--- a/src/Rules/Library/ControlShouldSupportSetInfoWPF.cs
+++ b/src/Rules/Library/ControlShouldSupportSetInfoWPF.cs
@@ -19,6 +19,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.ControlShouldSupportSetInfo;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.ErrorCode = EvaluationCode.Warning;
+            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-ControlShouldSupportSetInfoWPF";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportSetInfoWPF.cs
+++ b/src/Rules/Library/ControlShouldSupportSetInfoWPF.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.ControlShouldSupportSetInfo;
             this.Info.HowToFix = HowToFix.ControlShouldSupportSetInfo;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            this.Info.ErrorCode = EvaluationCode.Error;
             this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-ControlShouldSupportSetInfoWPF";
         }
 

--- a/src/Rules/Library/EdgeBrowserHasBeenDeprecated.cs
+++ b/src/Rules/Library/EdgeBrowserHasBeenDeprecated.cs
@@ -16,6 +16,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.EdgeBrowserHasBeenDeprecated;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.ErrorCode = EvaluationCode.Error;
+            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-EdgeBrowserHasBeenDeprecated";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/FrameworkDoesNotSupportUIAutomation.cs
+++ b/src/Rules/Library/FrameworkDoesNotSupportUIAutomation.cs
@@ -23,6 +23,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.FrameworkDoesNotSupportUIAutomation;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.ErrorCode = EvaluationCode.Error;
+            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-FrameworkDoesNotSupportUIAutomation";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/RulesTest/Library/ControlShouldSupportSetInfoWPFTest.cs
+++ b/src/RulesTest/Library/ControlShouldSupportSetInfoWPFTest.cs
@@ -13,6 +13,12 @@ namespace Axe.Windows.RulesTests.Library
         private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportSetInfoWPF();
 
         [TestMethod]
+        public void FrameworkIssueLink_IsNotNull()
+        {
+            Assert.IsNotNull(Rule.Info.FrameworkIssueLink);
+        }
+
+        [TestMethod]
         public void TestControlShouldSupportSetInfoWPFNoPositionInSetPropertyFail()
         {
             var e = new MockA11yElement();

--- a/src/RulesTest/Library/EdgeBrowserHasBeenDeprecated.cs
+++ b/src/RulesTest/Library/EdgeBrowserHasBeenDeprecated.cs
@@ -21,6 +21,12 @@ namespace Axe.Windows.RulesTests.Library
         }
 
         [TestMethod]
+        public void FrameworkIssueLink_IsNotNull()
+        {
+            Assert.IsNotNull(Rule.Info.FrameworkIssueLink);
+        }
+
+        [TestMethod]
         public void Condition_FrameworkIsNotEdge_ReturnsFalse()
         {
             string[] nonWin32Values = { FrameworkId.DirectUI, FrameworkId.InternetExplorer, FrameworkId.WinForm, FrameworkId.WPF, FrameworkId.XAML, FrameworkId.Win32, "NotEdge" };

--- a/src/RulesTest/Library/FrameworkDoesNotSupportUIAutomationTests.cs
+++ b/src/RulesTest/Library/FrameworkDoesNotSupportUIAutomationTests.cs
@@ -22,6 +22,12 @@ namespace Axe.Windows.RulesTests.Library
         }
 
         [TestMethod]
+        public void FrameworkIssueLink_IsNotNull()
+        {
+            Assert.IsNotNull(Rule.Info.FrameworkIssueLink);
+        }
+
+        [TestMethod]
         public void Condition_FrameworkIsNotWin32_ReturnsFalse()
         {
             string[] nonWin32Values = { FrameworkId.DirectUI, FrameworkId.Edge, FrameworkId.InternetExplorer, FrameworkId.WinForm, FrameworkId.WPF, FrameworkId.XAML, "NotWin32" };


### PR DESCRIPTION
#### Details

Add aka.ms links for our existing rules where we want to document framework-related issues (does do not yet exist, so the aka.ms links resolve to our docs.microsoft.com landing page).

##### Motivation

Part of framework issues feature

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
The links will be redirected (outside of code) once the documentation pages exist

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [1951114](https://mseng.visualstudio.com/1ES/_workitems/edit/1951114), [1951116](https://mseng.visualstudio.com/1ES/_workitems/edit/1951116), [1951266](https://mseng.visualstudio.com/1ES/_workitems/edit/1951266)
