### PR TITLE
chore: Remove unused RuleId values

### DIFF
--- a/src/Actions/Misc/ExtensionMethods.cs
+++ b/src/Actions/Misc/ExtensionMethods.cs
@@ -72,7 +72,7 @@ namespace Axe.Windows.Actions.Misc
         ///
         /// example:
         /// {
-        ///     "RuleId":"NameNonEmpty",
+        ///     "RuleId":"NameNotEmpty",
         ///     "SingleTestResults":[{"ControlType":"Window","UIFramework":"WPF","Pass":"1"},
         ///                          {"ControlType":"MenuBar","UIFramework":"WPF","Pass":"2", "Fail":"4"}]
         /// }

--- a/src/Core/Enums/RuleId.cs
+++ b/src/Core/Enums/RuleId.cs
@@ -4,12 +4,7 @@
 namespace Axe.Windows.Core.Enums
 {
     /// <summary>
-    /// Strong rule ids. Previously rules were only identifiable through
-    ///     their string description values
-    /// Rules are grouped by scan via whitespace when relevant
-    /// If writing a ScanException, generally the first rule within a scan grouping
-    ///     is appropriate to use in the constructor of GetRuleResultInstance(...)
-    ///
+    /// Strong rule ids. Each rule must have a unique ID.
     /// Unneeded RuleId values should be removed from this enum when the rule is removed.
     /// </summary>
     public enum RuleId
@@ -17,12 +12,6 @@ namespace Axe.Windows.Core.Enums
         // this value will be used if the RuleResult.Rule is loaded from disk
         Indecisive = 0,
 
-        ScanMutedByException,
-
-        // scans
-        BoundingRectangleExists,
-
-        // Axe.Windows.Rules
         BoundingRectangleNotAllZeros,
         BoundingRectangleNotNull,
         BoundingRectangleNotValidButOffScreen,
@@ -31,24 +20,17 @@ namespace Axe.Windows.Core.Enums
         BoundingRectangleContainedInParent,
         BoundingRectangleSizeReasonable,
 
-        // Axe.Windows.Rules
         SplitButtonInvokeAndTogglePatterns,
         ButtonShouldHavePatterns, // check whether button has at least one of three patterns(Invoke,Toggle,ExpandCollapse)
         ButtonInvokeAndTogglePatterns, // Button should not have Invoke and Toggle patterns together.
         ButtonInvokeAndExpandCollapsePatterns, // Button may have Invoke and ExpandCollapse patterns together. (warning)
         ButtonToggleAndExpandCollapsePatterns, // Button should have have Toggle and ExpandCollapse patterns together.
 
-        // scans
-        ChildUniqueNameOrType,
-
-        // Axe.Windows.Rules
         SiblingUniqueAndFocusable,
         SiblingUniqueAndNotFocusable,
 
-        // Axe.Windows.Rules
         ChildrenNotAllowedInContentView,
 
-        // Axe.Windows.Rules
         ContentViewButtonStructure,
         ContentViewCalendarStructure,
         ContentViewCheckBoxStructure,
@@ -96,7 +78,6 @@ namespace Axe.Windows.Core.Enums
         ControlViewTreeStructure,
         ControlViewTreeItemStructure,
 
-        // Axe.Windows.Rules
         ComboBoxShouldNotSupportScrollPattern,
         ControlShouldNotSupportInvokePattern,
         ControlShouldNotSupportScrollPattern,
@@ -118,12 +99,10 @@ namespace Axe.Windows.Core.Enums
         ControlShouldSupportTransformPattern,
         ControlShouldSupportTextPattern,
 
-        // Axe.Windows.Rules
         EditSupportsIncorrectRangeValuePattern,
 
         HeadingLevelDescendsWhenNested,
 
-        // Axe.Windows.Rules
         LandmarkBannerIsTopLevel,
         LandmarkComplementaryIsTopLevel,
         LandmarkContentInfoIsTopLevel,
@@ -140,30 +119,18 @@ namespace Axe.Windows.Core.Enums
 
         PatternsSupportedByControlType,
 
-        PatternsExpectedBasedOnParent,
-
-        PatternsExpectedBasedOnControlType,
-
-        HelpTextExists,
         HelpTextNotEqualToName,
 
         HyperlinkNameShouldBeUnique,
 
         IsControlElementPropertyExists,
-        IsControlElementPropertyCorrect,
 
-        // Axe.Windows.Rules
         IsContentElementPropertyExists,
         IsContentElementFalseOptional,
         IsContentElementTrueOptional,
         IsControlElementTrueOptional,
         IsControlElementTrueRequired,
 
-        // Scans
-        IsKeyboardFocusable,
-        IsKeyboardFocusableBasedOnPatterns,
-
-        // Axe.Windows.Rules
         IsKeyboardFocusableShouldBeTrue,
         IsKeyboardFocusableFalseButDisabled,
         IsKeyboardFocusableForListItemShouldBeTrue,
@@ -174,19 +141,10 @@ namespace Axe.Windows.Core.Enums
         IsKeyboardFocusableShouldBeFalse,
         IsKeyboardFocusableTopLevelTextPattern,
 
-        ItemTypeCorrect,
-
-        // Axe.Windows.Rules
         ItemTypeRecommended,
 
-        // Axe.Windows.Rules
-        LocalizedControlTypeExists,
         LocalizedControlTypeReasonable,
 
-        // scans
-        NameNonEmpty,
-
-        // Axe.Windows.Rules
         NameNotEmpty,
         NameExcludesControlType,
         NameExcludesLocalizedControlType,
@@ -195,17 +153,6 @@ namespace Axe.Windows.Core.Enums
         OrientationPropertyExists,
         ProgressBarRangeValue,
 
-        IncludesWebContent,
-
-        // These come from the "ScanPropertyAttribute" scan, which
-        // are used in Scanner.Controls in a dynamic way, e.g.
-        // [ScanProperty(PropertyTypes.UIA_IsContentElementPropertyId, ExpectedValue = false, ...
-        // But each such property will require its own rule id here.
-        // given by ExtensionMethods.GetPropertyCorrectRule(int A11yProperty)
-        IsContentElementPropertyCorrect,
-        ItemStatusPropertyCorrect,
-
-        // Axe.Windows.Rules
         ItemStatusExists,
 
         // given by ExtensionMethods.GetTreeStructureRule(TreeViewModes)
@@ -231,7 +178,6 @@ namespace Axe.Windows.Core.Enums
 
         ParentChildShouldNotHaveSameNameAndLocalizedControlType,
 
-        // Axe.Windows.Rules
         SelectionPatternSelectionRequired,
         SelectionPatternSingleSelection,
         SelectionItemPatternSingleSelection,


### PR DESCRIPTION
#### Details

This PR removes unused RuleId values, including some that were artifacts of the legacy scan engine that was removed in 2019. It also corrects some comments that refer to the old scan engine. Finally, since all of the RuleId values now deal with `Axe.Windows.Rules`, there is no need to have comments that were originally intended to help to categorize the rules.

##### Motivation

Code hygiene

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
