### PR TITLE
feat(framework-issues-logic): BoundingRectangleNotNull*

### DIFF
--- a/docs/RulesDescription.md
+++ b/docs/RulesDescription.md
@@ -10,6 +10,8 @@ BoundingRectangleDataFormatCorrect | Error | The BoundingRectangle property must
 BoundingRectangleCompletelyObscuresContainer | Error | An element's BoundingRectangle must not obscure its container element. | Section 508 502.3.1 ObjectInformation
 BoundingRectangleContainedInParent | Warning | An element's BoundingRectangle must be contained within its parent element. | Section 508 502.3.1 ObjectInformation
 BoundingRectangleSizeReasonable | Error | The BoundingRectangle property must represent an area of at least 25 pixels. | Section 508 502.3.1 ObjectInformation
+BoundingRectangleNotNullListViewXAML | Error | An onscreen element must not have a null BoundingRectangle property. | Section 508 502.3.1 ObjectInformation
+BoundingRectangleNotNullTextBlockXAML | Error | An onscreen element must not have a null BoundingRectangle property. | Section 508 502.3.1 ObjectInformation
 SplitButtonInvokeAndTogglePatterns | Error | A split button must support exactly one of the Invoke or Toggle patterns. | WCAG 4.1.2 NameRoleValue
 ButtonShouldHavePatterns | Error | A button must support one of these patterns: Invoke, Toggle, or ExpandCollapse. | WCAG 4.1.2 NameRoleValue
 ButtonInvokeAndTogglePatterns | Error | A button must not support both the Invoke and Toggle patterns. | WCAG 4.1.2 NameRoleValue

--- a/src/Core/Enums/RuleId.cs
+++ b/src/Core/Enums/RuleId.cs
@@ -31,6 +31,10 @@ namespace Axe.Windows.Core.Enums
         BoundingRectangleContainedInParent,
         BoundingRectangleSizeReasonable,
 
+        // 2 special case rules for known framework issues
+        BoundingRectangleNotNullListViewXAML,
+        BoundingRectangleNotNullTextBlockXAML,
+
         // Axe.Windows.Rules
         SplitButtonInvokeAndTogglePatterns,
         ButtonShouldHavePatterns, // check whether button has at least one of three patterns(Invoke,Toggle,ExpandCollapse)

--- a/src/Rules/Library/BoundingRectangleNotNull.cs
+++ b/src/Rules/Library/BoundingRectangleNotNull.cs
@@ -40,7 +40,11 @@ namespace Axe.Windows.Rules.Library
             // These two are excluded since Windows 10 sets the bounding rectangles of these as null by default.
             // WPF Scrollbar page buttons may sometimes
             // legitimately be null or all zeros when the thumb control is at the maximum or minimum value.
+            //
+            // We also exclude cases handled by rules split from this rule
             return IsNotOffScreen
+                & ~ListXAML                  // Covered by BoundingRectangleNotNullListViewXAML
+                & ~HyperlinkInTextXAML       // Covered by BoundingRectangleNotNullTextBlockXAML
                 & ~WPFScrollBarPageButtons
                 & ~NonFocusableSliderButtons
                 & ~sysmenubar

--- a/src/Rules/Library/BoundingRectangleNotNullListViewXAML.cs
+++ b/src/Rules/Library/BoundingRectangleNotNullListViewXAML.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Rules.PropertyConditions;
+using Axe.Windows.Rules.Resources;
+using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
+using static Axe.Windows.Rules.PropertyConditions.ElementGroups;
+
+namespace Axe.Windows.Rules.Library
+{
+    [RuleInfo(ID = RuleId.BoundingRectangleNotNullListViewXAML)]
+    class BoundingRectangleNotNullListViewXAML : Rule
+    {
+        public BoundingRectangleNotNullListViewXAML()
+        {
+            this.Info.Standard = A11yCriteriaId.ObjectInformation;
+            this.Info.PropertyID = Axe.Windows.Core.Types.PropertyType.UIA_BoundingRectanglePropertyId;
+            this.Info.Description = Descriptions.BoundingRectangleNotNull;
+            this.Info.HowToFix = HowToFix.BoundingRectangleNotNull;
+            this.Info.ErrorCode = EvaluationCode.Error;
+            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-BoundingRectangleNotNullListViewXAML";
+        }
+
+        public override bool PassesTest(IA11yElement e)
+        {
+            return BoundingRectangle.NotNull.Matches(e);
+        }
+
+        protected override Condition CreateCondition()
+        {
+            // This rule is scoped to XAML List elements
+            return IsNotOffScreen
+                & ListXAML;
+        }
+    } // class
+} // namespace

--- a/src/Rules/Library/BoundingRectangleNotNullTextBlockXAML.cs
+++ b/src/Rules/Library/BoundingRectangleNotNullTextBlockXAML.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Rules.PropertyConditions;
+using Axe.Windows.Rules.Resources;
+using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
+using static Axe.Windows.Rules.PropertyConditions.ElementGroups;
+
+namespace Axe.Windows.Rules.Library
+{
+    [RuleInfo(ID = RuleId.BoundingRectangleNotNullTextBlockXAML)]
+    class BoundingRectangleNotNullTextBlockXAML : Rule
+    {
+        public BoundingRectangleNotNullTextBlockXAML()
+        {
+            this.Info.Standard = A11yCriteriaId.ObjectInformation;
+            this.Info.PropertyID = Axe.Windows.Core.Types.PropertyType.UIA_BoundingRectanglePropertyId;
+            this.Info.Description = Descriptions.BoundingRectangleNotNull;
+            this.Info.HowToFix = HowToFix.BoundingRectangleNotNull;
+            this.Info.ErrorCode = EvaluationCode.Error;
+            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-BoundingRectangleNotNullTextBlockXAML";
+        }
+
+        public override bool PassesTest(IA11yElement e)
+        {
+            return BoundingRectangle.NotNull.Matches(e);
+        }
+
+        protected override Condition CreateCondition()
+        {
+            // This rule is scoped to XAML Hyperlink elements parented by Text elements
+            return IsNotOffScreen
+                & HyperlinkInTextXAML;
+        }
+    } // class
+} // namespace

--- a/src/Rules/PropertyConditions/ElementGroups.cs
+++ b/src/Rules/PropertyConditions/ElementGroups.cs
@@ -39,6 +39,8 @@ namespace Axe.Windows.Rules.PropertyConditions
         public static Condition IsControlElementTrueOptional = CreateIsControlOptionalCondition();
         public static Condition WPFDataGridCell = WPF & StringProperties.ClassName.Is("DataGridCell");
         public static Condition IsButtonText = Text & Parent(Button);
+        public static Condition ListXAML = List & XAML;
+        public static Condition HyperlinkInTextXAML = Hyperlink & XAML & Parent(Text);
 
         public static Condition AllowSameNameAndControlType = CreateAllowSameNameAndControlTypeCondition();
 

--- a/src/RulesTest/Library/BoundingRectangleNotNullListViewXAMLTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotNullListViewXAMLTest.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
+using static Axe.Windows.RulesTests.ControlType;
+
+namespace Axe.Windows.RulesTests.Library
+{
+    [TestClass]
+    public class BoundingRectangleNotNullListViewXAMLTest
+    {
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.BoundingRectangleNotNullListViewXAML();
+
+        [TestMethod]
+        public void TestBoundingRectangleNotNullPass()
+        {
+            using (var e = new MockA11yElement())
+            {
+                e.BoundingRectangle = Rectangle.Empty;
+                Assert.IsTrue(Rule.PassesTest(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void TestBoundingRectangleNotNullFail()
+        {
+            using (var e = new MockA11yElement())
+            {
+                Assert.IsFalse(Rule.PassesTest(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void Condition_MatchesExpectation()
+        {
+            using (var e = new MockA11yElement())
+            {
+                // ElementGrouis.ListXAML is tested externally--keep it simple here
+                Assert.IsFalse(Rule.Condition.Matches(e));
+
+                // Make ListXAML return true
+                e.Framework = "XAML";
+                e.ControlTypeId = List;
+                Assert.IsTrue(Rule.Condition.Matches(e));
+
+                e.IsOffScreen = true;
+                Assert.IsFalse(Rule.Condition.Matches(e));
+
+                // Make ListXAML return false
+                e.Framework = "Something else";
+                Assert.IsFalse(Rule.Condition.Matches(e));
+            } // using
+        }
+    } // class
+} // namespace

--- a/src/RulesTest/Library/BoundingRectangleNotNullTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotNullTest.cs
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Enums;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
+using static Axe.Windows.RulesTests.ControlType;
 
 namespace Axe.Windows.RulesTests.Library
 {
@@ -123,6 +124,35 @@ namespace Axe.Windows.RulesTests.Library
             {
                 e.ControlTypeId = ControlType.MenuBar;
                 e.AutomationId = "SystemMenuBar";
+
+                Assert.IsFalse(Rule.Condition.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void BoundingRectangleNotNull_ListViewXAML_NotApplicable()
+        {
+            using (var e = new MockA11yElement())
+            {
+                e.IsOffScreen = true;
+                e.Framework = "XAML";
+                e.ControlTypeId = List;
+
+                Assert.IsFalse(Rule.Condition.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void BoundingRectangleNotNull_HyperlinkInTextBlockXAML_NotApplicable()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                parent.ControlTypeId = Text;
+                e.Parent = parent;
+                e.IsOffScreen = true;
+                e.Framework = "XAML";
+                e.ControlTypeId = Hyperlink;
 
                 Assert.IsFalse(Rule.Condition.Matches(e));
             } // using

--- a/src/RulesTest/Library/BoundingRectangleNotNullTextBlockXAMLTest.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotNullTextBlockXAMLTest.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
+using static Axe.Windows.RulesTests.ControlType;
+
+namespace Axe.Windows.RulesTests.Library
+{
+    [TestClass]
+    public class BoundingRectangleNotNullTextBlockXAMLTest
+    {
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.BoundingRectangleNotNullTextBlockXAML();
+
+        [TestMethod]
+        public void TestBoundingRectangleNotNullPass()
+        {
+            using (var e = new MockA11yElement())
+            {
+                e.BoundingRectangle = Rectangle.Empty;
+                Assert.IsTrue(Rule.PassesTest(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void TestBoundingRectangleNotNullFail()
+        {
+            using (var e = new MockA11yElement())
+            {
+                Assert.IsFalse(Rule.PassesTest(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void Condition_MatchesExpectation()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                // ElementGrouis.HyperlinkInTextXAML is tested externally--keep it simple here
+                Assert.IsFalse(Rule.Condition.Matches(e));
+
+                // Make HyperlinkInTextXAML return true
+                e.Framework = "XAML";
+                e.ControlTypeId = Hyperlink;
+                e.Parent = parent;
+                parent.ControlTypeId = Text;
+                Assert.IsTrue(Rule.Condition.Matches(e));
+
+                e.IsOffScreen = true;
+                Assert.IsFalse(Rule.Condition.Matches(e));
+
+                // Make HyperlinkInTextXAML return false
+                e.Framework = "Something else";
+                Assert.IsFalse(Rule.Condition.Matches(e));
+            } // using
+        }
+    } // class
+} // namespace

--- a/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
+++ b/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
@@ -288,5 +288,53 @@ namespace Axe.Windows.RulesTests.PropertyConditions
                 Assert.IsFalse(ElementGroups.IsWPFCheckBoxText.Matches(e));
             } // using
         }
+
+        [TestMethod]
+        public void ListXAML_MatchExpected()
+        {
+            using (var e = new MockA11yElement())
+            {
+                Assert.IsFalse(ElementGroups.ListXAML.Matches(e));
+
+                e.ControlTypeId = List;
+                Assert.IsFalse(ElementGroups.ListXAML.Matches(e));
+
+                e.Framework = "XAML";
+                Assert.IsTrue(ElementGroups.ListXAML.Matches(e));
+
+                e.ControlTypeId = ListItem;
+                Assert.IsFalse(ElementGroups.ListXAML.Matches(e));
+            } // using
+
+        }
+
+        [TestMethod]
+        public void HyperlinkInTextXAML_MatchExpected()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                Assert.IsFalse(ElementGroups.HyperlinkInTextXAML.Matches(e));
+
+                e.ControlTypeId = Hyperlink;
+                Assert.IsFalse(ElementGroups.HyperlinkInTextXAML.Matches(e));
+
+                e.Framework = "XAML";
+                Assert.IsFalse(ElementGroups.HyperlinkInTextXAML.Matches(e));
+
+                e.Parent = parent;
+                Assert.IsFalse(ElementGroups.HyperlinkInTextXAML.Matches(e));
+
+                parent.ControlTypeId = Text;
+                Assert.IsTrue(ElementGroups.HyperlinkInTextXAML.Matches(e));
+
+                e.ControlTypeId = Text;
+                Assert.IsFalse(ElementGroups.HyperlinkInTextXAML.Matches(e));
+
+                e.ControlTypeId = Hyperlink;
+                e.Framework = "WPF";
+                Assert.IsFalse(ElementGroups.HyperlinkInTextXAML.Matches(e));
+            } // using
+        }
     } // class
 } // namespace


### PR DESCRIPTION
#### Details

This PR splits the `BoundingRectangleNotNull` into 3 rules:
1. `BoundingRectangleNotNullListViewXAML` scans on-screen XAML List elements. The docs will eventually reference https://github.com/microsoft/microsoft-ui-xaml/issues/1979 and https://github.com/microsoft/microsoft-ui-xaml/issues/2036
2. `BoundingRectangleNotNullTextBlockXAML` scans on-screen XAML Hyperlink elements hosted in a Text element. The docs will eventually reference https://github.com/microsoft/microsoft-ui-xaml/issues/5666
3. The `BoundingRectangleNotNull` continues as before, although it excludes controls covered by the new rules

The new rule names are geared toward the XAML control names (`ListView` instead of `List` and `TextBlock` instead of `Text`). Failures of `BoundingRectangleNotNullTextBlockXAML` will be reported against the hyperlink element, but the bug actually exists inside the `TextBlock` class, which is why the name references TextBlock. We can change the names if we want--if we do, we should probably also take it into account for the contents of docs.microsoft.com.

##### Motivation

Part of framework issue feature

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [1951108](https://mseng.visualstudio.com/1ES/_workitems/edit/1951108) and [1951110](https://mseng.visualstudio.com/1ES/_workitems/edit/1951110)
