### PR TITLE
feat(framework-issues-logic): Add WPF-specific IsClickablePointOnScreen rule

### DIFF
--- a/docs/RulesDescription.md
+++ b/docs/RulesDescription.md
@@ -149,6 +149,7 @@ NameExcludesPrivateUnicodeCharacters | Error | The Name property must not contai
 HelpTextExcludesPrivateUnicodeCharacters | Error | The HelpText property must not contain any characters in the private Unicode range. | Section 508 502.3.1 ObjectInformation
 LocalizedControlTypeExcludesPrivateUnicodeCharacters | Error | The LocalizedControlType property must not contain any characters in the private Unicode range. | Section 508 502.3.1 ObjectInformation
 ClickablePointOnScreen | Error | An element's IsOffScreen property must be false when its clickable point is on screen. | Section 508 502.3.1 ObjectInformation
+ClickablePointOnScreenWPF | Error | An element's IsOffScreen property must be false when its clickable point is on screen. | Section 508 502.3.1 ObjectInformation
 ClickablePointOffScreen | Warning | An element's IsOffScreen property must be true when its clickable point is off screen. | Section 508 502.3.1 ObjectInformation
 FrameworkDoesNotSupportUIAutomation | Error | The framework used to build this application does not support UI Automation. | Section 508 502.3.1 ObjectInformation
 EdgeBrowserHasBeenDeprecated | Error | The non-Chromium version of Microsoft Edge has been deprecated. | Section 508 502.3.1 ObjectInformation

--- a/src/Core/Enums/RuleId.cs
+++ b/src/Core/Enums/RuleId.cs
@@ -192,6 +192,7 @@ namespace Axe.Windows.Core.Enums
         LocalizedControlTypeExcludesPrivateUnicodeCharacters,
 
         ClickablePointOnScreen,
+        ClickablePointOnScreenWPF,
         ClickablePointOffScreen,
 
         FrameworkDoesNotSupportUIAutomation,

--- a/src/Rules/Library/ClickablePointOnScreenWPF.cs
+++ b/src/Rules/Library/ClickablePointOnScreenWPF.cs
@@ -11,16 +11,17 @@ using static Axe.Windows.Rules.PropertyConditions.Framework;
 
 namespace Axe.Windows.Rules.Library
 {
-    [RuleInfo(ID = RuleId.ClickablePointOnScreen)]
-    class ClickablePointOnScreen : Rule
+    [RuleInfo(ID = RuleId.ClickablePointOnScreenWPF)]
+    class ClickablePointOnScreenWPF : Rule
     {
-        public ClickablePointOnScreen()
+        public ClickablePointOnScreenWPF()
         {
             this.Info.Description = Descriptions.ClickablePointOnScreen;
             this.Info.HowToFix = HowToFix.ClickablePointOnScreen;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_IsOffscreenPropertyId;
             this.Info.ErrorCode = EvaluationCode.Error;
+            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-ClickablePointOnScreenListViewWPF";
         }
 
         public override bool PassesTest(IA11yElement e)
@@ -32,7 +33,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return (IsKeyboardFocusable & ClickablePoint.OnScreen) & ~WPF;
+            return IsKeyboardFocusable & ClickablePoint.OnScreen & WPF;
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/ClickablePointOnScreen.cs
+++ b/src/RulesTest/Library/ClickablePointOnScreen.cs
@@ -58,7 +58,7 @@ namespace Axe.Windows.RulesTests.Library
         }
 
         [TestMethod]
-        public void ClickablePointOnScreen_FocusableClickable_FrameworkIsWPF_NoMatche()
+        public void ClickablePointOnScreen_FocusableClickable_FrameworkIsWPF_NoMatches()
         {
             SetupTryGetProperty(new Point(100, 100));
             mockElement.Setup(m => m.IsKeyboardFocusable).Returns(true);

--- a/src/RulesTest/Library/ClickablePointOnScreenWPFTests.cs
+++ b/src/RulesTest/Library/ClickablePointOnScreenWPFTests.cs
@@ -9,9 +9,9 @@ using System.Drawing;
 namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
-    public class ClickablePointOnScreenTests
+    public class ClickablePointOnScreenWPFTests
     {
-        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ClickablePointOnScreen();
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ClickablePointOnScreenWPF();
         private Mock<IA11yElement> mockElement = new Mock<IA11yElement>(MockBehavior.Strict);
         private delegate void TryGetDelegate(int propertyId, out Point value);
 
@@ -32,6 +32,12 @@ namespace Axe.Windows.RulesTests.Library
         }
 
         [TestMethod]
+        public void FrameworkIssueLink_IsNotNull()
+        {
+            Assert.IsNotNull(Rule.Info.FrameworkIssueLink);
+        }
+
+        [TestMethod]
         public void ClickablePointOnScreen_OffScreen_Error()
         {
             mockElement.Setup(m => m.IsOffScreen).Returns(true);
@@ -48,31 +54,22 @@ namespace Axe.Windows.RulesTests.Library
         }
 
         [TestMethod]
-        public void ClickablePointOnScreen_FocusableClickable_FrameworkIsNotWPF_Matches()
+        public void ClickablePointOnScreen_FocusableClickable_FrameworkIsNotWPF_NoMatch()
         {
             SetupTryGetProperty(new Point(100, 100));
             mockElement.Setup(m => m.IsKeyboardFocusable).Returns(true);
             mockElement.Setup(m => m.Framework).Returns("Anything but WPF");
-            Assert.IsTrue(Rule.Condition.Matches(mockElement.Object));
+            Assert.IsFalse(Rule.Condition.Matches(mockElement.Object));
             mockElement.VerifyAll();
         }
 
         [TestMethod]
-        public void ClickablePointOnScreen_FocusableClickable_FrameworkIsWPF_NoMatche()
+        public void ClickablePointOnScreen_FocusableClickable_FrameworkIsWPF_Matche()
         {
             SetupTryGetProperty(new Point(100, 100));
             mockElement.Setup(m => m.IsKeyboardFocusable).Returns(true);
             mockElement.Setup(m => m.Framework).Returns("WPF");
-            Assert.IsFalse(Rule.Condition.Matches(mockElement.Object));
-            mockElement.VerifyAll();
-        }
-
-        [TestMethod]
-        public void ClickablePointOnScreen_IsNotClickable_NoMatch()
-        {
-            SetupTryGetProperty(new Point(-100, -100));
-            mockElement.Setup(m => m.IsKeyboardFocusable).Returns(true);
-            Assert.IsFalse(Rule.Condition.Matches(mockElement.Object));
+            Assert.IsTrue(Rule.Condition.Matches(mockElement.Object));
             mockElement.VerifyAll();
         }
 


### PR DESCRIPTION
#### Details

Add framework-specific rule to point people to https://github.com/dotnet/wpf/issues/4631. We originally scoped this feature to ListViewItems, but upon further digging, it applies more broadly. The [fix](https://github.com/dotnet/wpf/pull/5126/files) actually changes the base [AutomationPeer](https://github.com/dotnet/wpf/blob/main/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs), so it will impact _all_ WPF control types. Based on that, the new rule is called `ClickablePointOnScreenWPF`. The framework issue link still says ListView but we can change that separately since it will also impact the docs.

##### Motivation

Framework issues feature.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
