### PR TITLE
feat(framework-issues-logic): Add rule `ControlShouldSupportTextPatternEditWinform`

### DIFF
--- a/docs/RulesDescription.md
+++ b/docs/RulesDescription.md
@@ -86,6 +86,7 @@ ControlShouldSupportTablePattern | Error | An element of the given ControlType m
 ControlShouldSupportTogglePattern | Error | An element of the given ControlType must support the Toggle pattern. | Section 508 502.3.10 AvailableActions
 ControlShouldSupportTransformPattern | Error | An element that can be resized must support the Transform pattern. | Section 508 502.3.10 AvailableActions
 ControlShouldSupportTextPattern | Error | An element of the given ControlType must support the Text pattern. | Section 508 502.3.10 AvailableActions
+ControlShouldSupportTextPatternEditWinform | Error | An element of the given ControlType must support the Text pattern. | Section 508 502.3.10 AvailableActions
 EditSupportsIncorrectRangeValuePattern | Error | The RangeValue pattern of an edit control must have a null LargeChange property. | Section 508 502.3.10 AvailableActions
 HeadingLevelDescendsWhenNested | Error | An element's HeadingLevel must be greater than or equal to that of its ancestors. | WCAG 1.3.1 InfoAndRelationships
 LandmarkBannerIsTopLevel | Error | An element with LocalizedLandmarkType "banner" must not descend from another landmark. | WCAG 1.3.1 InfoAndRelationships

--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -20,10 +20,10 @@ namespace Axe.Windows.AutomationTests
         // These values should change only in response to intentional rule modifications
         const int WildlifeManagerKnownErrorCount = 15;
         const int Win32ControlSamplerKnownErrorCount = 0;
-        const int WindowsFormsControlSamplerKnownErrorCount = 4;
+        const int WindowsFormsControlSamplerKnownErrorCount = 6;
         const int WpfControlSamplerKnownErrorCount = 7;
-        const int WindowsFormsMultiWindowSamplerAppAllErrorCount = 8;
-        const int WindowsFormsMultiWindowSamplerSingleWindowAllErrorCount = 4;
+        const int WindowsFormsMultiWindowSamplerAppAllErrorCount = 12;
+        const int WindowsFormsMultiWindowSamplerSingleWindowAllErrorCount = 6;
 
         readonly string WildlifeManagerAppPath = Path.GetFullPath("../../../../../tools/WildlifeManager/WildlifeManager.exe");
         readonly string Win32ControlSamplerAppPath = Path.GetFullPath("../../../../../tools/Win32ControlSampler/Win32ControlSampler.exe");

--- a/src/Core/Enums/RuleId.cs
+++ b/src/Core/Enums/RuleId.cs
@@ -103,6 +103,9 @@ namespace Axe.Windows.Core.Enums
         ControlShouldSupportTransformPattern,
         ControlShouldSupportTextPattern,
 
+        // special case rule for known framework issue
+        ControlShouldSupportTextPatternEditWinform,
+
         EditSupportsIncorrectRangeValuePattern,
 
         HeadingLevelDescendsWhenNested,

--- a/src/Rules/Library/ControlShouldSupportTextPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTextPattern.cs
@@ -7,6 +7,7 @@ using Axe.Windows.Rules.Resources;
 using System;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.ElementGroups;
 using static Axe.Windows.Rules.PropertyConditions.Framework;
 
 namespace Axe.Windows.Rules.Library
@@ -31,14 +32,13 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            var winFormsEdit = Edit & WinForms;
             var win32Edit = Edit & Win32Framework;
             var nonfocusableDirectUIEdit = Edit & ~IsKeyboardFocusable & DirectUI;
 
             return Document
                 | (Edit
                 & ~win32Edit
-                & ~winFormsEdit
+                & ~WinFormsEdit
                 & ~nonfocusableDirectUIEdit);
         }
     } // class

--- a/src/Rules/Library/ControlShouldSupportTextPatternEditWinform.cs
+++ b/src/Rules/Library/ControlShouldSupportTextPatternEditWinform.cs
@@ -5,8 +5,7 @@ using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using static Axe.Windows.Rules.PropertyConditions.ControlType;
-using static Axe.Windows.Rules.PropertyConditions.Framework;
+using static Axe.Windows.Rules.PropertyConditions.ElementGroups;
 
 namespace Axe.Windows.Rules.Library
 {
@@ -31,7 +30,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return Edit & WinForms;
+            return WinFormsEdit;
         }
     } // class
 } // namespace

--- a/src/Rules/Library/ControlShouldSupportTextPatternEditWinform.cs
+++ b/src/Rules/Library/ControlShouldSupportTextPatternEditWinform.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Rules.PropertyConditions;
+using Axe.Windows.Rules.Resources;
+using System;
+using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
+
+namespace Axe.Windows.Rules.Library
+{
+    [RuleInfo(ID = RuleId.ControlShouldSupportTextPatternEditWinform)]
+    class ControlShouldSupportTextPatternEditWinform : Rule
+    {
+        public ControlShouldSupportTextPatternEditWinform()
+        {
+            this.Info.Description = Descriptions.ControlShouldSupportTextPattern;
+            this.Info.HowToFix = HowToFix.ControlShouldSupportTextPattern;
+            this.Info.Standard = A11yCriteriaId.AvailableActions;
+            this.Info.ErrorCode = EvaluationCode.Error;
+            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-ControlShouldSupportTextPatternEditWinForm";
+        }
+
+        public override bool PassesTest(IA11yElement e)
+        {
+            if (e == null) throw new ArgumentNullException(nameof(e));
+
+            return Patterns.Text.Matches(e);
+        }
+
+        protected override Condition CreateCondition()
+        {
+            return Edit & WinForms;
+        }
+    } // class
+} // namespace

--- a/src/Rules/PropertyConditions/ElementGroups.cs
+++ b/src/Rules/PropertyConditions/ElementGroups.cs
@@ -41,6 +41,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         public static Condition IsButtonText = Text & Parent(Button);
         public static Condition ListXAML = List & XAML;
         public static Condition HyperlinkInTextXAML = Hyperlink & XAML & Parent(Text);
+        public static Condition WinFormsEdit = Edit & WinForms;
 
         public static Condition AllowSameNameAndControlType = CreateAllowSameNameAndControlTypeCondition();
 

--- a/src/RulesTest/Library/ControlShouldSupportTextPatternEditWinform.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTextPatternEditWinform.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Axe.Windows.RulesTests.Library
+{
+    [TestClass]
+    public class ControlShouldSupportTextPatternEditWinformUnitTests
+    {
+        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportTextPatternEditWinform();
+
+        [TestMethod]
+        public void HasTextPattern_Pass()
+        {
+            var e = new MockA11yElement();
+            e.Patterns.Add(new A11yPattern(e, PatternType.UIA_TextPatternId));
+
+            Assert.IsTrue(Rule.PassesTest(e));
+        }
+
+        [TestMethod]
+        public void NoTextPattern_Error()
+        {
+            var e = new MockA11yElement();
+
+            Assert.IsFalse(Rule.PassesTest(e));
+        }
+
+        [TestMethod]
+        public void NoFramework_NotApplicable()
+        {
+            var e = new MockA11yElement();
+            e.ControlTypeId = ControlType.Edit;
+
+            Assert.IsFalse(Rule.Condition.Matches(e));
+        }
+
+        [TestMethod]
+        public void WinFormsEdit_Applicable()
+        {
+            var e = new MockA11yElement();
+            e.ControlTypeId = ControlType.Edit;
+            e.Framework = FrameworkId.WinForm;
+
+            Assert.IsTrue(Rule.Condition.Matches(e));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ArgumentNull_Exception()
+        {
+            Rule.PassesTest(null);
+        }
+    } // class
+} // namespace

--- a/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
+++ b/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
@@ -336,5 +336,21 @@ namespace Axe.Windows.RulesTests.PropertyConditions
                 Assert.IsFalse(ElementGroups.HyperlinkInTextXAML.Matches(e));
             } // using
         }
+
+        [TestMethod]
+        public void WinFormsEdit_MatchExpected()
+        {
+            using (var e = new MockA11yElement())
+            {
+                Assert.IsFalse(ElementGroups.WinFormsEdit.Matches(e));
+
+                e.ControlTypeId = Edit;
+                Assert.IsFalse(ElementGroups.WinFormsEdit.Matches(e));
+
+                e.Framework = "WinForm";
+                Assert.IsTrue(ElementGroups.WinFormsEdit.Matches(e));
+            } // using
+
+        }
     } // class
 } // namespace


### PR DESCRIPTION
#### Details

This rule `ControlShouldSupportTextPatternEditWinform` splits off from [ControlShouldSupportTextPattern](https://github.com/microsoft/axe-windows/blob/main/src/Rules/Library/ControlShouldSupportTextPattern.cs#L40) when Framework is `WinForm` and `ControlType` is `Edit`. 

We found that the `ControlShouldSupportTextPattern` already excludes the conditions (WinForm & Edit) and did not feel the original rule nor its tests required updates to prevent overlap:

https://github.com/microsoft/axe-windows/blob/d269eb404592121dc797f42dc1f694dc932ecd7e/src/Rules/Library/ControlShouldSupportTextPattern.cs#L32-L43

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [1951115](https://mseng.visualstudio.com/1ES/_workitems/edit/1951115)
