### PR TITLE
feat(framework-issues-logic): Add missing unit tests

### DIFF
--- a/src/RulesTest/Library/BoundingRectangleNotNullListViewXAMLTests.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotNullListViewXAMLTests.cs
@@ -13,6 +13,12 @@ namespace Axe.Windows.RulesTests.Library
         private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.BoundingRectangleNotNullListViewXAML();
 
         [TestMethod]
+        public void FrameworkIssueLink_IsNotNull()
+        {
+            Assert.IsNotNull(Rule.Info.FrameworkIssueLink);
+        }
+
+        [TestMethod]
         public void TestBoundingRectangleNotNullPass()
         {
             using (var e = new MockA11yElement())

--- a/src/RulesTest/Library/BoundingRectangleNotNullTextBlockXAMLTests.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotNullTextBlockXAMLTests.cs
@@ -13,6 +13,12 @@ namespace Axe.Windows.RulesTests.Library
         private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.BoundingRectangleNotNullTextBlockXAML();
 
         [TestMethod]
+        public void FrameworkIssueLink_IsNotNull()
+        {
+            Assert.IsNotNull(Rule.Info.FrameworkIssueLink);
+        }
+
+        [TestMethod]
         public void TestBoundingRectangleNotNullPass()
         {
             using (var e = new MockA11yElement())

--- a/src/RulesTest/Library/ControlShouldSupportTextPatternEditWinformTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTextPatternEditWinformTests.cs
@@ -14,6 +14,12 @@ namespace Axe.Windows.RulesTests.Library
         private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportTextPatternEditWinform();
 
         [TestMethod]
+        public void FrameworkIssueLink_IsNotNull()
+        {
+            Assert.IsNotNull(Rule.Info.FrameworkIssueLink);
+        }
+
+        [TestMethod]
         public void HasTextPattern_Pass()
         {
             var e = new MockA11yElement();


### PR DESCRIPTION
#### Details

I noticed that 3 of our framework issue rules didn't have unit tests the the link was non-null. This test probably wasn't in our original template, so this just fills it out.

##### Motivation

Make the tests better at detecting accidental breakage

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
