### PR TITLE
chore: Add .editorconfig file

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -86,6 +86,7 @@ csharp_style_deconstructed_variable_declaration = true:suggestion
 csharp_prefer_simple_default_expression = true:suggestion
 csharp_style_pattern_local_over_anonymous_function = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
+csharp_prefer_simple_using_statement = false:silent
 ###############################
 # C# Formatting Rules         #
 ###############################

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,118 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+###############################
+# Core EditorConfig Options   #
+###############################
+root = true
+# All files
+[*]
+indent_style = space
+# Code files
+[*.{cs,csx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs}]
+# Organize usings
+dotnet_sort_system_directives_first = false
+# this. preferences
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_readonly_field = true:suggestion
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+###############################
+# Naming Conventions          #
+###############################
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+# Use PascalCase for constant fields  
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+###############################
+# C# Coding Conventions       #
+###############################
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+# Expression-level preferences
+csharp_prefer_braces = true:silent
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+###############################
+# C# Formatting Rules         #
+###############################
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true

--- a/src/AutomationTests/SnapshotCommandTests.cs
+++ b/src/AutomationTests/SnapshotCommandTests.cs
@@ -206,7 +206,7 @@ namespace Axe.Windows.AutomationTests
             _actionsMock.VerifyAll();
             _resultsAssemblerMock.VerifyAll();
         }
-        
+
         [TestMethod]
         [Timeout(1000)]
         public void Execute_ReturnsExpectedResults_MultiRoot()
@@ -305,7 +305,7 @@ namespace Axe.Windows.AutomationTests
             _actionsMock.VerifyAll();
             _resultsAssemblerMock.VerifyAll();
         }
-        
+
         [TestMethod]
         [Timeout(1000)]
         public void Execute_NoErrors_MultiRootHasOutputFiles()

--- a/src/AxeWindows.sln
+++ b/src/AxeWindows.sln
@@ -75,6 +75,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InteropDummy", "InteropDumm
 		{7E616C64-EAD7-458C-92AC-B50643E64D38} = {7E616C64-EAD7-458C-92AC-B50643E64D38}
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7B4C4F1E-5D41-4052-81F6-BA8534F2DFD4}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/RuleSelection/RuleRunner.cs
+++ b/src/RuleSelection/RuleRunner.cs
@@ -9,7 +9,6 @@ using Axe.Windows.Rules;
 using Axe.Windows.RuleSelection.Resources;
 using Axe.Windows.Telemetry;
 using System;
-using static System.FormattableString;
 
 namespace Axe.Windows.RuleSelection
 {

--- a/src/RuleSelection/RuleRunner.cs
+++ b/src/RuleSelection/RuleRunner.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -105,15 +105,5 @@ namespace Axe.Windows.RuleSelection
         }
 
         public static string RuleVersion => RuleVersions.Version;
-
-        private static Exception Error(string message)
-        {
-#if DEBUG
-            var callStack = new System.Diagnostics.StackFrame(1, true);
-            return new AxeWindowsException(Invariant($"{message} in {callStack.GetMethod()} at line {callStack.GetFileLineNumber()} in {callStack.GetFileName()}"));
-#else
-            return new AxeWindowsException(message);
-#endif
-        }
     } // class
 } // namespace

--- a/src/RuleSelection/RuleRunner.cs
+++ b/src/RuleSelection/RuleRunner.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
-using Axe.Windows.Core.Exceptions;
 using Axe.Windows.Core.HelpLinks;
 using Axe.Windows.Core.Results;
 using Axe.Windows.Rules;

--- a/src/RulesTest/Library/IsControlElementTrueRequiredButtonWPFTests.cs
+++ b/src/RulesTest/Library/IsControlElementTrueRequiredButtonWPFTests.cs
@@ -45,7 +45,7 @@ namespace Axe.Windows.RulesTests.Library
         public void Condition_EmptyBoundingRectangle_ReturnsFalse()
         {
             _elementMock.Setup(m => m.BoundingRectangle).Returns(Rectangle.Empty);
-            
+
             Assert.IsFalse(Rule.Condition.Matches(_elementMock.Object));
 
             VerifyAllMocks();

--- a/src/RulesTest/Library/IsControlElementTrueRequiredTests.cs
+++ b/src/RulesTest/Library/IsControlElementTrueRequiredTests.cs
@@ -39,7 +39,7 @@ namespace Axe.Windows.RulesTests.Library
         public void Condition_EmptyBoundingRectangle_ReturnsFalse()
         {
             _elementMock.Setup(m => m.BoundingRectangle).Returns(Rectangle.Empty);
-            
+
             Assert.IsFalse(Rule.Condition.Matches(_elementMock.Object));
 
             VerifyAllMocks();

--- a/src/RulesTest/Library/IsControlElementTrueRequiredTextInEditXAMLTests.cs
+++ b/src/RulesTest/Library/IsControlElementTrueRequiredTextInEditXAMLTests.cs
@@ -45,7 +45,7 @@ namespace Axe.Windows.RulesTests.Library
         public void Condition_EmptyBoundingRectangle_ReturnsFalse()
         {
             _elementMock.Setup(m => m.BoundingRectangle).Returns(Rectangle.Empty);
-            
+
             Assert.IsFalse(Rule.Condition.Matches(_elementMock.Object));
 
             VerifyAllMocks();


### PR DESCRIPTION
#### Details

We've previously discussed adding an `.editorconfig` file to help maintain consistency in code styling and make the IDE more useful. This PR does the following:
1. Allow VS to auto-generate an .editorconfig file based on the existing code standards
2. Remove any VB file extensions since we don't use them
3. Mark the file as being a root dependency so we have consistent results
4. Use VS to run code cleanup using the `.editorconfig` file

##### Motivation

Leverage tools for code consistency

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
A future change will probably do something to minimize the analyzer noise in the IDE. For example, the analyzer suggests the `using` declaration style that was added in C# 8.0. Unfortunately, .NET Standard only supports .NET 7.3 so the suggestions are nothing more than noise ☹️ 

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
