### PR TITLE
fix: CLI is throwing an exception, displaying help twice

### DIFF
--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -84,9 +84,16 @@ namespace AxeWindowsCLI
 
             if (_options != null)
             {
-                foreach (var scanResult in _scanResultsCollection)
+                if (_scanResultsCollection == null)
                 {
-                    _outputGenerator.WriteOutput(_options, scanResult, caughtException);
+                    _outputGenerator.WriteOutput(_options, null, caughtException);
+                }
+                else
+                {
+                    foreach (var scanResult in _scanResultsCollection)
+                    {
+                        _outputGenerator.WriteOutput(_options, scanResult, caughtException);
+                    }
                 }
             }
             return ReturnValueChooser.GetReturnValue(_scanResultsCollection, caughtException);

--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -57,11 +57,13 @@ namespace AxeWindowsCLI
         private int Run()
         {
             Exception caughtException = null;
+            bool parserError = false;
             try
             {
                 using (var parser = CaseInsensitiveParser())
                 {
                     ParserResult<Options> parserResult = parser.ParseArguments<Options>(_args);
+                    parserError = parserResult.Tag == ParserResultType.NotParsed;
                     parserResult.WithParsed(RunWithParsedInputs)
                         .WithNotParsed(_ =>
                         {
@@ -91,7 +93,7 @@ namespace AxeWindowsCLI
                     _outputGenerator.WriteOutput(_options, scanResult, caughtException);
                 }
             }
-            return ReturnValueChooser.GetReturnValue(_scanResultsCollection, caughtException);
+            return ReturnValueChooser.GetReturnValue(parserError, _scanResultsCollection, caughtException);
         }
 
         void RunWithParsedInputs(Options options)

--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -84,16 +84,11 @@ namespace AxeWindowsCLI
 
             if (_options != null)
             {
-                if (_scanResultsCollection == null)
+                IEnumerable<ScanResults> guaranteedScanResults = _scanResultsCollection ?? new List<ScanResults> { null };
+
+                foreach (var scanResult in guaranteedScanResults)
                 {
-                    _outputGenerator.WriteOutput(_options, null, caughtException);
-                }
-                else
-                {
-                    foreach (var scanResult in _scanResultsCollection)
-                    {
-                        _outputGenerator.WriteOutput(_options, scanResult, caughtException);
-                    }
+                    _outputGenerator.WriteOutput(_options, scanResult, caughtException);
                 }
             }
             return ReturnValueChooser.GetReturnValue(_scanResultsCollection, caughtException);

--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -109,15 +109,15 @@ namespace AxeWindowsCLI
             _scanResultsCollection = ScanRunner.RunScan(_options);
         }
 
-        private Parser CaseInsensitiveParser()
+        private static Parser CaseInsensitiveParser()
         {
             // CommandLineParser is case-sensitive by default (intentional choice by the code
             // owners for better compatibility with *nix platforms). This removes the case
-            // sensitivity and routes all output ot the same stream (Console.Out)
+            // sensitivity and disables default output so we can override it
             return new Parser((settings) =>
             {
                 settings.CaseSensitive = false;
-                settings.HelpWriter = _writer;
+                settings.HelpWriter = null;
             });
         }
 

--- a/src/CLI/ReturnValueChooser.cs
+++ b/src/CLI/ReturnValueChooser.cs
@@ -16,9 +16,9 @@ namespace AxeWindowsCLI
         public const int ThirdPartyNoticesDisplayed = 3;  // Used outside this class
         public const int BadInputParameters = 255;
 
-        public static int GetReturnValue(IReadOnlyCollection<ScanResults> scanResults, Exception caughtException)
+        public static int GetReturnValue(bool parserError, IReadOnlyCollection<ScanResults> scanResults, Exception caughtException)
         {
-            if (caughtException as ParameterException != null)
+            if (parserError || caughtException is ParameterException)
                 return BadInputParameters;
 
 #pragma warning disable CA1508

--- a/src/CLI/ReturnValueChooser.cs
+++ b/src/CLI/ReturnValueChooser.cs
@@ -22,7 +22,7 @@ namespace AxeWindowsCLI
                 return BadInputParameters;
 
 #pragma warning disable CA1508
-            if (caughtException != null || scanResults.Any(result => result == null))
+            if (caughtException != null || scanResults == null || scanResults.Any(result => result == null))
                 return ScanFailedToComplete;
 #pragma warning restore CA1508
 

--- a/tools/scripts/verification.scripts/ValidateCLI.ps1
+++ b/tools/scripts/verification.scripts/ValidateCLI.ps1
@@ -1,3 +1,14 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+<#
+.SYNOPSIS
+Automates some CLI checks to streamline release validation. Run from its location in the file system.
+
+.Example Usage
+.\ValidateCLI.ps1
+#>
+
 function ValidateExitCode($actualCode, $expectedCode)
 {
 	if ($expectedCode -ne $actualCode)

--- a/tools/scripts/verification.scripts/ValidateCLI.ps1
+++ b/tools/scripts/verification.scripts/ValidateCLI.ps1
@@ -1,0 +1,56 @@
+function ValidateExitCode($actualCode, $expectedCode)
+{
+	if ($expectedCode -ne $actualCode)
+	{
+		Write-Host 'WRONG ERROR CODE! Received' $actualCode 'instead of' $expectedCode
+		Exit 255
+	}
+}
+
+function PromptAndWait($prompt)
+{
+    Write-Host '--------------------------------------------'
+    Write-Host $prompt
+    Write-Host 'Press ENTER to continue'
+    Write-Host '--------------------------------------------'
+    Read-Host
+}
+
+# Const values
+$ScanCompletedAndFoundNoErrors = 0
+$ScanCompletedAndFoundErrors = 1
+$ScanFailedToComplete = 2
+$ThirdPartyNoticesDisplayed = 3
+$BadInputParameters = 255
+
+Clear
+PromptAndWait 'This script assumes that you are running from the scripts folder and that you have built a release version of the CLI.'
+
+# Note: I tried unsuccessfully to find a way to parameterize the command line and still get the exit code.
+# If you can find a way to make this work, then please refactor this code!
+
+Clear
+../../../src/cli/bin/Release/netcoreapp3.1/AxeWindowsCLI.exe
+ValidateExitCode $lastExitCode $BadInputParameters
+PromptAndWait 'The scenario should have displayed help text and thrown no exceptions'
+
+Clear
+../../../src/cli/bin/Release/netcoreapp3.1/AxeWindowsCLI.exe --UndefinedParameter
+ValidateExitCode $lastExitCode $BadInputParameters
+PromptAndWait "The scenario should have identified 'UndefinedParameter' as an unknown `nparameter, shown the help text, and thrown no exceptions"
+
+Clear
+../../../src/cli/bin/Release/netcoreapp3.1/AxeWindowsCLI.exe --ProcessName
+ValidateExitCode $lastExitCode $BadInputParameters
+PromptAndWait "The scenario should have indicated that the user needs to specify either `nprocessId or processName, and thrown no exceptions"
+
+Clear
+../../../src/cli/bin/Release/netcoreapp3.1/AxeWindowsCLI.exe --ProcessName ThisProcessDoesNotExist
+ValidateExitCode $lastExitCode $BadInputParameters
+PromptAndWait "The scenario should have indicated that it could not find a process named `nThisProcessDoesNotExist, and thrown no exceptions"
+
+Clear
+../../../src/cli/bin/Release/netcoreapp3.1/AxeWindowsCLI.exe --showthirdpartynotices
+ValidateExitCode $lastExitCode $ThirdPartyNoticesDisplayed
+PromptAndWait "The scenario should have opened the placeholder ThirdPartyNotices.html file `nin the default browser, and thrown no exceptions."
+

--- a/tools/scripts/verification.scripts/ValidateCLI.ps1
+++ b/tools/scripts/verification.scripts/ValidateCLI.ps1
@@ -11,11 +11,11 @@ Automates some CLI checks to streamline release validation. Run from its locatio
 
 function ValidateExitCode($actualCode, $expectedCode)
 {
-	if ($expectedCode -ne $actualCode)
-	{
-		Write-Host 'WRONG ERROR CODE! Received' $actualCode 'instead of' $expectedCode
-		Exit 255
-	}
+    if ($expectedCode -ne $actualCode)
+    {
+        Write-Host 'WRONG ERROR CODE! Received' $actualCode 'instead of' $expectedCode
+        Exit 255
+    }
 }
 
 function PromptAndWait($prompt)


### PR DESCRIPTION
#### Details

The CLI has recently regressed in 2 ways:
1. It is throwing an Exception when no scan is run (for example, just display the help). This occurs as the process exits, so scans complete as expected but the return code indicates failure. This regressed in #682 when a null check was dropped.
2. When displaying the help, it displays twice. This may have come from a recent change in CommandLineParser, but I haven't tried to pin it down.

These are both recent regressions that we didn't catch in the last validation pass.

##### Motivation

CLI usability

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
It would be awesome if the CLI tests could have detected the Exception, but I'm unsure of the best way to add that ability.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
