### PR TITLE
feat(compliance-win-june-2022): Use localizable text for ArgumentExceptions

### DIFF
--- a/src/Desktop/ColorContrastAnalyzer/ColorContrastConfig.cs
+++ b/src/Desktop/ColorContrastAnalyzer/ColorContrastConfig.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using Axe.Windows.Desktop.Resources;
 
 namespace Axe.Windows.Desktop.ColorContrastAnalyzer
 {
@@ -60,19 +61,19 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
 
             if (HighConfidenceThreshold <= MidConfidenceThreshold)
             {
-                throw new ArgumentException("High Confidence threshold must be larger than Mid confidence threshold");
+                throw new ArgumentException(ErrorMessages.InvalidHighConfidenceThresholdGreaterThanMidThreshold);
             }
             if (MidConfidenceThreshold <= LowConfidenceThreshold)
             {
-                throw new ArgumentException("Mid Confidence threshold must be larger than Low confidence threshold");
+                throw new ArgumentException(ErrorMessages.InvalidMidConfidenceThreshold);
             }
             if (HighConfidenceThreshold >= 1.0)
             {
-                throw new ArgumentException("High Confidence threshold must be < 1.0");
+                throw new ArgumentException(ErrorMessages.InvalidHighConfidenceThreshold);
             }
             if (lowConfidenceThreshold <= 0.0)
             {
-                throw new ArgumentException("Low Confidence threshold must be > 0.0");
+                throw new ArgumentException(ErrorMessages.InvalidLowConfidenceThreshold);
             }
         }
     }

--- a/src/Desktop/Resources/ErrorMessages.Designer.cs
+++ b/src/Desktop/Resources/ErrorMessages.Designer.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.Desktop.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ErrorMessages {
@@ -75,6 +75,42 @@ namespace Axe.Windows.Desktop.Resources {
         internal static string InvalidColor {
             get {
                 return ResourceManager.GetString("InvalidColor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to High Confidence threshold must be &lt; 1.0.
+        /// </summary>
+        internal static string InvalidHighConfidenceThreshold {
+            get {
+                return ResourceManager.GetString("InvalidHighConfidenceThreshold", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to High Confidence threshold must be larger than Mid confidence threshold.
+        /// </summary>
+        internal static string InvalidHighConfidenceThresholdGreaterThanMidThreshold {
+            get {
+                return ResourceManager.GetString("InvalidHighConfidenceThresholdGreaterThanMidThreshold", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Low Confidence threshold must be &gt; 0.0.
+        /// </summary>
+        internal static string InvalidLowConfidenceThreshold {
+            get {
+                return ResourceManager.GetString("InvalidLowConfidenceThreshold", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Mid Confidence threshold must be larger than Low confidence threshold.
+        /// </summary>
+        internal static string InvalidMidConfidenceThreshold {
+            get {
+                return ResourceManager.GetString("InvalidMidConfidenceThreshold", resourceCulture);
             }
         }
         

--- a/src/Desktop/Resources/ErrorMessages.resx
+++ b/src/Desktop/Resources/ErrorMessages.resx
@@ -123,6 +123,18 @@
   <data name="InvalidColor" xml:space="preserve">
     <value>Color components are values between 0 and 255</value>
   </data>
+  <data name="InvalidHighConfidenceThreshold" xml:space="preserve">
+    <value>High Confidence threshold must be &lt; 1.0</value>
+  </data>
+  <data name="InvalidHighConfidenceThresholdGreaterThanMidThreshold" xml:space="preserve">
+    <value>High Confidence threshold must be larger than Mid confidence threshold</value>
+  </data>
+  <data name="InvalidLowConfidenceThreshold" xml:space="preserve">
+    <value>Low Confidence threshold must be &gt; 0.0</value>
+  </data>
+  <data name="InvalidMidConfidenceThreshold" xml:space="preserve">
+    <value>Mid Confidence threshold must be larger than Low confidence threshold</value>
+  </data>
   <data name="PatternNoLongerValid" xml:space="preserve">
     <value>The pattern may no longer be valid</value>
     <comment>Pattern may not be valid any more.</comment>


### PR DESCRIPTION
#### Details

As part of compliance, this change moves hardcoded strings found in ArgumentExeptions into a resource file.

##### Motivation

Reduce obstacles for localization.


##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
