### PR TITLE
fix: Run BinSkim on the SystemAbstractions assembly

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -245,6 +245,7 @@ jobs:
                       src\\Desktop\\bin\\Release\\*.dll;\
                       src\\Rules\\bin\\Release\\*.dll;\
                       src\\RuleSelection\\bin\\Release\\*.dll;\
+                      src\\SystemAbstractions\\bin\\Release\\*.dll;\
                       src\\Telemetry\\bin\\Release\\*.dll;\
                       src\\Win32\\bin\\Release\\*.dll;"
 


### PR DESCRIPTION
#### Details

The `SystemAbstractions` assembly was added in #108, but the BinSkim config wasn't updated to scan the new assembly. This PR corrects that oversight.

##### Motivation

Conform to shipping requirements

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
