### PR TITLE
chore: Embed symbols in assemblies

### DIFF
--- a/build/NetStandardRelease.targets
+++ b/build/NetStandardRelease.targets
@@ -32,6 +32,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <Choose>

--- a/build/NetStandardRelease.targets
+++ b/build/NetStandardRelease.targets
@@ -11,7 +11,10 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <Import Project="..\src\props\version.props" />

--- a/docs/AutomationReference.md
+++ b/docs/AutomationReference.md
@@ -214,12 +214,20 @@ example below):
 
 #### Debugging with symbols
 
-There may be occasions where you want to debug assemblies within the Axe.Windows [NuGet package](https://www.nuget.org/packages/Axe.Windows) that your process is consuming. This is possible from inside Visual Studio via the following steps:
-1. In Visual Studio, go to **Tools** > **Options** > **Debugging** > **General** and uncheck "Enable Just My Code". This enables debugging of code from NuGet packages
-2. In Visual Studio, go to **Tools** > **Options** > **Debugging** > **Symbols** and check "NuGet.org Symbol Server". This tells Visual Studio to attempt to download symbols for NuGet packages. (Note that this download will occur on the first app boot after the setting is enabled or after a version changes, so you may experience a delay in loading the app after making this change)
+There may be occasions where you want to debug assemblies within the Axe.Windows [NuGet package](https://www.nuget.org/packages/Axe.Windows) that your process is consuming. The specific steps depend on the version of Axe.Windows that you are using.
+
+##### Axe.Windows 1.1.5 and earlier
+These versions require you to access the symbols from the NuGet symbol server for debugging. The steps to enable debugging are:
+1. In Visual Studio, go to **Tools** > **Options** > **Debugging** > **General** and uncheck "Enable Just My Code".
+2. In Visual Studio, go to **Tools** > **Options** > **Debugging** > **Symbols** and check "NuGet.org Symbol Server". This tells Visual Studio to attempt to download symbols for NuGet packages. (Note that this download will occur on the first app boot after the setting is enabled or after a version changes, so you may experience a delay in loading the app after making this change).
+3. You will need to have a local copy of the sources at the same commit as the release (one easy to do this is to download the source code zip file from the corresponding [release](https://github.com/microsoft/axe-windows/releases)). When Visual Studio needs the sources, it will prompt for the location of the source code.
+4. Run and debug as usual.
+
+##### Axe.Windows 1.1.6 and newer
+These versions embed the symbols into the assemblies and support [SourceLink](https://github.com/dotnet/sourcelink) to easily obtain the source code at the correct commit. The steps to enable debugging are:
+1. In Visual Studio, go to **Tools** > **Options** > **Debugging** > **General** and uncheck "Enable Just My Code".
+2. In Visual Studio, go to **Tools** > **Options** > **Debugging** > **General** and check "Enable Source Link support". When Visual Studio needs the sources, it will ask for permission to retrieve them, then it will cache a local copy for future use.
 3. Run and debug as usual.
-4. For Axe.Windows versions 1.1.5 and earlier, you will need to have a local copy of the sources at the same commit as the release (one easy to do this is to download the source code zip file from the corresponding [release](https://github.com/microsoft/axe-windows/releases)). When Visual Studio needs the sources, it will prompt for the location of the source code.
-5. For Axe.Windows versions 1.1.6 and later, Visual Studio has the ability to automatically fetch the correct sources. In Visual Studio, go to **Tools** > **Options** > **Debugging** > **General** and check "Enable Source Link support". When Visual Studio needs the sources, it will ask for permission to retrieve them, then it will cache a local copy for future use.
 
 #### Error handling
 

--- a/src/Actions/Actions.csproj
+++ b/src/Actions/Actions.csproj
@@ -17,10 +17,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Automation/Automation.csproj
+++ b/src/Automation/Automation.csproj
@@ -21,10 +21,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/CI/CI.csproj
+++ b/src/CI/CI.csproj
@@ -57,7 +57,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Condition=" '$(CreateAxeWindowsNugetPackage)' == 'true' " Name="Pack" AfterTargets="Build">
-    <Exec Command="nuget.exe pack -properties Configuration=$(Configuration);VersionString=&quot;$(SemVerNumber)$(SemVerSuffix)&quot; Axe.Windows.nuspec -OutputDirectory bin\$(Configuration)\NuGet\$(SemVerNumber)$(SemVerSuffix) -NonInteractive -Symbols -SymbolPackageFormat snupkg" />
+    <Exec Command="nuget.exe pack -properties Configuration=$(Configuration);VersionString=&quot;$(SemVerNumber)$(SemVerSuffix)&quot; Axe.Windows.nuspec -OutputDirectory bin\$(Configuration)\NuGet\$(SemVerNumber)$(SemVerSuffix) -NonInteractive" />
   </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -18,10 +18,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Desktop/Desktop.csproj
+++ b/src/Desktop/Desktop.csproj
@@ -17,10 +17,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/InteropDummy/InteropDummy.csproj
+++ b/src/InteropDummy/InteropDummy.csproj
@@ -9,10 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Interop.UIAutomationCore.Signed" Version="10.19041.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <Import Project="..\..\build\NetStandardTest.targets" />

--- a/src/RuleSelection/RuleSelection.csproj
+++ b/src/RuleSelection/RuleSelection.csproj
@@ -17,10 +17,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Rules/Rules.csproj
+++ b/src/Rules/Rules.csproj
@@ -17,10 +17,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SystemAbstractions/SystemAbstractions.csproj
+++ b/src/SystemAbstractions/SystemAbstractions.csproj
@@ -17,10 +17,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Telemetry/Telemetry.csproj
+++ b/src/Telemetry/Telemetry.csproj
@@ -17,10 +17,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Win32/Win32.csproj
+++ b/src/Win32/Win32.csproj
@@ -15,10 +15,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
#### Details

In #719, we enabled SourceLink support in the assemblies, but users still had to enable NuGet symbol servers to make things work as expected. This PR embeds the PDB files directly into the assemblies, instead of putting them into a `.snupkg` file. The net result is:
1. Size of all DLLs increases from about 1.9MB to 2.1MB
2. When debugging, the symbols can be instantly loaded into memory (no delay from fetching from the NuGet packages)
3. The CLI's also now include PDB data (we excluded it before since they has no corresponding `.snupkg` file

I validated by building the signed pipeline, downloading the `.nupkg` file from the [artifacts](https://dev.azure.com/mseng/1ES/_build/results?buildId=17676375&view=artifacts&pathAsName=false&type=publishedArtifacts), and consuming them locally in AIWin. Based on the experience, I updated the docs on how to consume the symbols in Visual Studio.

##### Motivation

Simplify debugging from apps that consume Axe.Windows. We're probably the main beneficiary, since this will make it a lot easier to debug Axe.Windows from AIWin.

##### Context

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
In #719, I intentionally kept the SourceLink changes in the csproj files for the DLLs because there was no reason to enable it for the EXE files. I could have added this to the csproj files for the EXE's, but opted to simply pull it into the common settings that we use for all release files. As demonstrated in AIWIn's [shared targets file](https://github.com/microsoft/accessibility-insights-windows/blame/main/build/NetFrameworkRelease.targets#L26), dependabot is able to update these files without any difficulty. 

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

A future PR might also consolidate things like analyzers and MicroBuild into the targets file, just to ensure that we're doing things consistently in all projects

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
