### PR TITLE
chore: Fix various spelling and typographical errors in source code comments and strings (Core namespace)

### DIFF
--- a/src/Core/Enums/RuleId.cs
+++ b/src/Core/Enums/RuleId.cs
@@ -28,7 +28,7 @@ namespace Axe.Windows.Core.Enums
         ButtonShouldHavePatterns, // check whether button has at least one of three patterns(Invoke,Toggle,ExpandCollapse)
         ButtonInvokeAndTogglePatterns, // Button should not have Invoke and Toggle patterns together.
         ButtonInvokeAndExpandCollapsePatterns, // Button may have Invoke and ExpandCollapse patterns together. (warning)
-        ButtonToggleAndExpandCollapsePatterns, // Button should have Toggle and ExpandCollapse patterns together.
+        ButtonToggleAndExpandCollapsePatterns, // Button should not have Toggle and ExpandCollapse patterns together.
 
         SiblingUniqueAndFocusable,
         SiblingUniqueAndNotFocusable,

--- a/src/Core/Enums/RuleId.cs
+++ b/src/Core/Enums/RuleId.cs
@@ -28,7 +28,7 @@ namespace Axe.Windows.Core.Enums
         ButtonShouldHavePatterns, // check whether button has at least one of three patterns(Invoke,Toggle,ExpandCollapse)
         ButtonInvokeAndTogglePatterns, // Button should not have Invoke and Toggle patterns together.
         ButtonInvokeAndExpandCollapsePatterns, // Button may have Invoke and ExpandCollapse patterns together. (warning)
-        ButtonToggleAndExpandCollapsePatterns, // Button should have have Toggle and ExpandCollapse patterns together.
+        ButtonToggleAndExpandCollapsePatterns, // Button should have Toggle and ExpandCollapse patterns together.
 
         SiblingUniqueAndFocusable,
         SiblingUniqueAndNotFocusable,

--- a/src/Core/Misc/BoundedCounter.cs
+++ b/src/Core/Misc/BoundedCounter.cs
@@ -49,7 +49,7 @@ namespace Axe.Windows.Core.Misc
         /// <summary>
         /// Attempt to increment Count
         /// </summary>
-        /// <returns>true iff we can increment without exceeding UpperBound</returns>
+        /// <returns>true if and only if we can increment without exceeding UpperBound</returns>
         public bool TryIncrement()
         {
             if (Attempts == int.MaxValue)
@@ -67,7 +67,7 @@ namespace Axe.Windows.Core.Misc
         /// TryIncrement value times.
         /// </summary>
         /// <param name="valueToAdd">The value to add. Must be non-negative</param>
-        /// <returns>true iff we can add valueToAdd without exceeding UpperBound</returns>
+        /// <returns>true if and only if we can add valueToAdd without exceeding UpperBound</returns>
         public bool TryAdd(int valueToAdd)
         {
             if (valueToAdd < 0)

--- a/src/Core/Misc/ExtensionMethods.cs
+++ b/src/Core/Misc/ExtensionMethods.cs
@@ -259,7 +259,7 @@ namespace Axe.Windows.Core.Misc
         }
 
         /// <summary>
-        /// Get the POI element with test results from this element and descendents
+        /// Get the POI element with test results from this element and descendants
         /// POI element Unique ID should be 0.
         /// </summary>
         /// <param name="element">The root of the element tree</param>
@@ -603,7 +603,7 @@ namespace Axe.Windows.Core.Misc
         }
 
         /// <summary>
-        /// Check whether the UI element is offscreen or not based on IsOffScreen property.
+        /// Check whether the UI element is off-screen or not based on IsOffScreen property.
         /// </summary>
         /// <param name="e"></param>
         /// <returns></returns>

--- a/src/Core/Types/PropertyType.cs
+++ b/src/Core/Types/PropertyType.cs
@@ -7,7 +7,7 @@ namespace Axe.Windows.Core.Types
     /// <summary>
     /// Class for Element Property Type IDs
     /// List is built based on UIAutomationClient.h
-    /// Any of pattern property should be modifiled like below.
+    /// Any of pattern property should be modified like below.
     ///
     /// UIA_ValueValuePropertyId => UIA_ValuePattern_ValuePropertyId
     ///

--- a/src/Core/Types/TypeBase.cs
+++ b/src/Core/Types/TypeBase.cs
@@ -64,7 +64,7 @@ namespace Axe.Windows.Core.Types
         }
 
         /// <summary>
-        /// check whether the contant should be part of List
+        /// check whether the content should be part of List
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>


### PR DESCRIPTION
#### Details
This PR fixes various spelling and typographical errors found in strings and comments in the `Core` namespace.

##### Motivation
Motivated by errors discovered while working on microsoft/accessibility-insights-windows#1323.

##### Context
One of a series of PRs.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
