### PR TITLE
chore: Fix various spelling and typographical errors in source code comments and strings (Rules namespace).

### DIFF
--- a/docs/RulesDescription.md
+++ b/docs/RulesDescription.md
@@ -4,14 +4,14 @@
 Name | Severity | Description | Standard referenced
 --- | --- | --- | ---
 BoundingRectangleNotAllZeros | Error | The BoundingRectangle property must not be defined as [0,0,0,0] | Section 508 502.3.1 ObjectInformation
-BoundingRectangleNotNull | Error | An onscreen element must not have a null BoundingRectangle property. | Section 508 502.3.1 ObjectInformation
+BoundingRectangleNotNull | Error | An on-screen element must not have a null BoundingRectangle property. | Section 508 502.3.1 ObjectInformation
 BoundingRectangleNotValidButOffScreen | NeedsReview | The BoundingRectangle property is not valid, but the element is off-screen. | Section 508 502.3.1 ObjectInformation
 BoundingRectangleDataFormatCorrect | Error | The BoundingRectangle property must return a valid rectangle. | Section 508 502.3.1 ObjectInformation
 BoundingRectangleCompletelyObscuresContainer | Error | An element's BoundingRectangle must not obscure its container element. | Section 508 502.3.1 ObjectInformation
 BoundingRectangleContainedInParent | Warning | An element's BoundingRectangle must be contained within its parent element. | Section 508 502.3.1 ObjectInformation
 BoundingRectangleSizeReasonable | Error | The BoundingRectangle property must represent an area of at least 25 pixels. | Section 508 502.3.1 ObjectInformation
-BoundingRectangleNotNullListViewXAML | Error | An onscreen element must not have a null BoundingRectangle property. | Section 508 502.3.1 ObjectInformation
-BoundingRectangleNotNullTextBlockXAML | Error | An onscreen element must not have a null BoundingRectangle property. | Section 508 502.3.1 ObjectInformation
+BoundingRectangleNotNullListViewXAML | Error | An on-screen element must not have a null BoundingRectangle property. | Section 508 502.3.1 ObjectInformation
+BoundingRectangleNotNullTextBlockXAML | Error | An on-screen element must not have a null BoundingRectangle property. | Section 508 502.3.1 ObjectInformation
 SplitButtonInvokeAndTogglePatterns | Error | A split button must support exactly one of the Invoke or Toggle patterns. | WCAG 4.1.2 NameRoleValue
 ButtonShouldHavePatterns | Error | A button must support one of these patterns: Invoke, Toggle, or ExpandCollapse. | WCAG 4.1.2 NameRoleValue
 ButtonInvokeAndTogglePatterns | Error | A button must not support both the Invoke and Toggle patterns. | WCAG 4.1.2 NameRoleValue
@@ -115,7 +115,7 @@ IsKeyboardFocusableShouldBeTrue | Warning | The IsKeyboardFocusable property for
 IsKeyboardFocusableFalseButDisabled | NeedsReview | The IsKeyboardFocusable property is false for an element where it would normally be true. However, the IsEnabled property on the element is also false, so the value of IsKeyboardFocusable may be acceptable. | WCAG 2.1.1 Keyboard
 IsKeyboardFocusableForListItemShouldBeTrue | Warning | The IsKeyboardFocusable property for the given list item is false, but the element has children that are focusable. The element should probably be focusable instead of its children. | WCAG 2.1.1 Keyboard
 IsKeyboardFocusableFalseButOffscreen | NeedsReview | The IsKeyboardFocusable property for the given element is false for an element where it would normally be true. However, the IsOffscreen property on the element is true, so the value of IsKeyboardFocusable may be acceptable. | WCAG 2.1.1 Keyboard
-IsKeyboardFocusableForCustomShouldBeTrue | Warning | The IsKeyboardFocusable property for a custome element should be true when the element supports actionable patterns. | WCAG 2.1.1 Keyboard
+IsKeyboardFocusableForCustomShouldBeTrue | Warning | The IsKeyboardFocusable property for a custom element should be true when the element supports actionable patterns. | WCAG 2.1.1 Keyboard
 IsKeyboardFocusableDescendantTextPattern | NeedsReview | The IsKeyboardFocusable property may be false when the given element supports the text pattern and is the descendant of an element that also supports the text pattern. Please consider if the given element should or should not be focusable. | WCAG 2.1.1 Keyboard
 IsKeyboardFocusableOnEmptyContainer | NeedsReview | The IsKeyboardFocusable property should be true when you want an empty container to be discoverable by assistive technology users. IsKeyboardFocusable may be false when you want an empty container not to be discoverable by AT users. | WCAG 2.1.1 Keyboard
 IsKeyboardFocusableShouldBeFalse | Warning | The IsKeyboardFocusable property for the given element is expected to be false because of the element's control type. | WCAG 2.1.1 Keyboard

--- a/src/Rules/PropertyConditions/ElementGroups.cs
+++ b/src/Rules/PropertyConditions/ElementGroups.cs
@@ -113,7 +113,7 @@ namespace Axe.Windows.Rules.PropertyConditions
             // the ignore list used to include SpinButton, which was removed below because that seems like an error.
             // The Tree type was also ignored. It was moved to the EmptyContainer condition.
             // exclude custom from this scan since Custom control type behavior is a matter of App implementation.
-            // titlebar and image are added here based on the V1 rule since the two are causing extra erros on Office apps.
+            // titlebar and image are added here based on the V1 rule since the two are causing extra errors in Office apps.
             var ignoreTypes = AppBar | Custom | DataItem | Group | Image | Header | Pane | Separator | StatusBar | TitleBar | Thumb | Text | ToolBar | ToolTip | Window;
 
             ignoreTypes |= (ListItem & Parent(ComboBox)) | Container;

--- a/src/Rules/PropertyConditions/Relationships.cs
+++ b/src/Rules/PropertyConditions/Relationships.cs
@@ -217,7 +217,7 @@ namespace Axe.Windows.Rules.PropertyConditions
             var description = string.Format(CultureInfo.InvariantCulture, ConditionDescriptions.AllChildren, c);
 
             // we must check for the existence of children because MatchAnyChild will return false if there are no children
-            // and the nott operator (~) below will cause this function to return true erroneously when no children exist.
+            // and the not operator (~) below will cause this function to return true erroneously when no children exist.
             return (ChildrenExist & ~AnyChild(~c))[description];
         }
 

--- a/src/Rules/Resources/Descriptions.Designer.cs
+++ b/src/Rules/Resources/Descriptions.Designer.cs
@@ -97,7 +97,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An onscreen element must not have a null BoundingRectangle property..
+        ///   Looks up a localized string similar to An on-screen element must not have a null BoundingRectangle property..
         /// </summary>
         internal static string BoundingRectangleNotNull {
             get {
@@ -511,7 +511,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The IsKeyboardFocusable property for a custome element should be true when the element supports actionable patterns..
+        ///   Looks up a localized string similar to The IsKeyboardFocusable property for a custom element should be true when the element supports actionable patterns..
         /// </summary>
         internal static string IsKeyboardFocusableForCustomShouldBeTrue {
             get {

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -160,7 +160,7 @@
     <value>The IsKeyboardFocusable property for the given element is false for an element where it would normally be true. However, the IsOffscreen property on the element is true, so the value of IsKeyboardFocusable may be acceptable.</value>
   </data>
   <data name="IsKeyboardFocusableForCustomShouldBeTrue" xml:space="preserve">
-    <value>The IsKeyboardFocusable property for a custome element should be true when the element supports actionable patterns.</value>
+    <value>The IsKeyboardFocusable property for a custom element should be true when the element supports actionable patterns.</value>
   </data>
   <data name="IsKeyboardFocusableDescendantTextPattern" xml:space="preserve">
     <value>The IsKeyboardFocusable property may be false when the given element supports the text pattern and is the descendant of an element that also supports the text pattern. Please consider if the given element should or should not be focusable.</value>
@@ -307,7 +307,7 @@
     <value>The BoundingRectangle property must not be defined as [0,0,0,0]</value>
   </data>
   <data name="BoundingRectangleNotNull" xml:space="preserve">
-    <value>An onscreen element must not have a null BoundingRectangle property.</value>
+    <value>An on-screen element must not have a null BoundingRectangle property.</value>
   </data>
   <data name="BoundingRectangleSizeReasonable" xml:space="preserve">
     <value>The BoundingRectangle property must represent an area of at least 25 pixels.</value>

--- a/src/Rules/Resources/HowToFix.Designer.cs
+++ b/src/Rules/Resources/HowToFix.Designer.cs
@@ -107,8 +107,8 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If the element is offscreen, set its IsOffscreen property to TRUE.
-        ///If the element is onscreen, provide a BoundingRectangle property..
+        ///   Looks up a localized string similar to If the element is off-screen, set its IsOffscreen property to TRUE.
+        ///If the element is on-screen, provide a BoundingRectangle property..
         /// </summary>
         internal static string BoundingRectangleNotNull {
             get {
@@ -550,7 +550,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The IsKeyboardFocusable property for a custome element should be true when the element supports actionable patterns..
+        ///   Looks up a localized string similar to The IsKeyboardFocusable property for a custom element should be true when the element supports actionable patterns..
         /// </summary>
         internal static string IsKeyboardFocusableForCustomShouldBeTrue {
             get {

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -160,7 +160,7 @@
     <value>The IsKeyboardFocusable property for the given element is false for an element where it would normally be true. However, the IsOffscreen property on the element is true, so the value of IsKeyboardFocusable may be acceptable.</value>
   </data>
   <data name="IsKeyboardFocusableForCustomShouldBeTrue" xml:space="preserve">
-    <value>The IsKeyboardFocusable property for a custome element should be true when the element supports actionable patterns.</value>
+    <value>The IsKeyboardFocusable property for a custom element should be true when the element supports actionable patterns.</value>
   </data>
   <data name="IsKeyboardFocusableDescendantTextPattern" xml:space="preserve">
     <value>The IsKeyboardFocusable property may be false when the given element supports the text pattern and is the descendant of an element that also supports the text pattern. Please consider if the given element should or should not be focusable.</value>
@@ -347,8 +347,8 @@ If the element can't be resized, ensure the TransformPattern_CanResize property 
  4. Height</value>
   </data>
   <data name="BoundingRectangleNotNull" xml:space="preserve">
-    <value>If the element is offscreen, set its IsOffscreen property to TRUE.
-If the element is onscreen, provide a BoundingRectangle property.</value>
+    <value>If the element is off-screen, set its IsOffscreen property to TRUE.
+If the element is on-screen, provide a BoundingRectangle property.</value>
   </data>
   <data name="BoundingRectangleSizeReasonable" xml:space="preserve">
     <value>Modify the BoundingRectangle property so that its width and height define an area of at least 25 pixels.</value>

--- a/src/RulesTest/PropertyConditions/RelationshipsTests.cs
+++ b/src/RulesTest/PropertyConditions/RelationshipsTests.cs
@@ -1157,7 +1157,7 @@ namespace Axe.Windows.RulesTests.PropertyConditions
             // where the parent element is saved on the per-thread Context stack
             // and compared with its child in the HasSameType condition.
             // the idea of the test is that if the parents and children get out of sync, the assertion should fail.
-            // if all the assertions in the loop are true, then the the thread local storage worked as expected.
+            // if all the assertions in the loop are true, then the thread local storage worked as expected.
             var tasks = new System.Collections.Generic.List<Task>();
             for (var i = 0; i < 20; ++i)
             {


### PR DESCRIPTION
#### Details
This PR fixes various spelling and typographical errors found in strings and comments in the `Rules` namespace.

##### Motivation
Motivated by errors discovered while working on microsoft/accessibility-insights-windows#1323.

##### Context
One of a series of PRs.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
