### PR TITLE
chore: Fix various spelling and typographical errors in source code comments and strings (Automation and Win32 namespaces)

### DIFF
--- a/src/Automation/Data/OutputFile.cs
+++ b/src/Automation/Data/OutputFile.cs
@@ -20,7 +20,7 @@ namespace Axe.Windows.Automation
         public string Sarif { get; }
 
         /// <summary>
-        /// Private ctor. Called by the BuildFrom* methods
+        /// Private constructor. Called by the BuildFrom* methods
         /// </summary>
         /// <param name="a11yTest">The A11yTest file that was created (if any)</param>
         /// <param name="sarif">The Sarif file that was created (if any)</param>

--- a/src/Automation/ReadMe.md
+++ b/src/Automation/ReadMe.md
@@ -60,6 +60,6 @@ Scan results data has been organized relationally to minimize the
 possible ripple effects of changing any single type of data. This is mainly
 done in the `IAutomationScanResult` interface. The interface contains only 
 the ids of a rule and an element. Therefore, the `IElementInfo` interface
-and the `IRuleInfo` interface can change completely independenly.
+and the `IRuleInfo` interface can change completely independently.
 And of course, unless something drastic happens, the `IAutomationScanResult` interface doesn't need to change.
 This has the added benefit of not duplicating data unnecessarily in memory.

--- a/src/AutomationTests/OutputFileHelperTests.cs
+++ b/src/AutomationTests/OutputFileHelperTests.cs
@@ -173,7 +173,7 @@ namespace Axe.Windows.AutomationTests
             var outputFileHelper = new OutputFileHelper(directory, mockSystem.Object);
             outputFileHelper.EnsureOutputDirectoryExists();
 
-            // the folowing verifies that Exists was called
+            // the following verifies that Exists was called
 
             mockSystem.VerifyAll();
             mockIO.VerifyAll();
@@ -198,7 +198,7 @@ namespace Axe.Windows.AutomationTests
             var outputFileHelper = new OutputFileHelper(directory, mockSystem.Object);
             outputFileHelper.EnsureOutputDirectoryExists();
 
-            // the folowing verifies that CreateDirectory was not called
+            // the following verifies that CreateDirectory was not called
 
             mockSystem.VerifyAll();
             mockIO.VerifyAll();

--- a/src/Win32/Win32Helper.cs
+++ b/src/Win32/Win32Helper.cs
@@ -90,7 +90,7 @@ namespace Axe.Windows.Win32
         /// Helper function to evaluate builds
         /// </summary>
         /// <param name="minimalBuild">The minimal build needed to pass</param>
-        /// <returns>True iff the OS is at least Win10 at the specified build</returns>
+        /// <returns>True if and only if the OS is at least Win10 at the specified build</returns>
         internal bool IsAtLeastWin10WithSpecificBuild(uint minimalBuild)
         {
             OsComparisonResult win10ComparisonResult = CompareWindowsVersionToWin10();
@@ -102,7 +102,7 @@ namespace Axe.Windows.Win32
         /// <summary>
         /// Check whether current OS is Win10 RS3 or later
         /// </summary>
-        /// <returns>True iff the OS is at least Win10 RS3</returns>
+        /// <returns>True if and only if the OS is at least Win10 RS3</returns>
         internal bool IsWindowsRS3OrLater()
         {
             return IsAtLeastWin10WithSpecificBuild(16228); // Build 16228 is confirmed in the RS3 range
@@ -111,7 +111,7 @@ namespace Axe.Windows.Win32
         /// <summary>
         /// Check whether current OS is Win10 RS5 or later
         /// </summary>
-        /// <returns>True iff the OS is at least Win10 RS5</returns>
+        /// <returns>True if and only if the OS is at least Win10 RS5</returns>
         internal bool IsWindowsRS5OrLater()
         {
             return IsAtLeastWin10WithSpecificBuild(17713); // Build 17713 is confirmed in the RS5 range


### PR DESCRIPTION
#### Details
This PR fixes various spelling and typographical errors found in strings and comments in the `Automation` and `Win32` namespaces.

##### Motivation
Motivated by errors discovered while working on microsoft/accessibility-insights-windows#1323.

##### Context
One of a series of PRs.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
