### PR TITLE
chore: Fix various spelling and typographical errors in source code comments and strings (UnitTestSharedLibrary namespace)

### DIFF
--- a/src/UnitTestSharedLibrary/Snapshots/MonsterDataGrid.snapshot
+++ b/src/UnitTestSharedLibrary/Snapshots/MonsterDataGrid.snapshot
@@ -1415,7 +1415,7 @@
                   {
                     "Messages": [
                       "Rule Exception: Parent is ScrollBar/HeaderItem",
-                      "Since the thumb control is a child of HeaderItem(50035) , it is ok to have no Transform pattern"
+                      "Since the thumb control is a child of HeaderItem(50035) , it is OK to have no Transform pattern"
                     ],
                     "Status": 1,
                     "Description": "Required control pattern(s)",
@@ -1757,7 +1757,7 @@
                   {
                     "Messages": [
                       "Rule Exception: Parent is ScrollBar/HeaderItem",
-                      "Since the thumb control is a child of HeaderItem(50035) , it is ok to have no Transform pattern"
+                      "Since the thumb control is a child of HeaderItem(50035) , it is OK to have no Transform pattern"
                     ],
                     "Status": 1,
                     "Description": "Required control pattern(s)",
@@ -1808,7 +1808,7 @@
                   "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
                   "The BoundingRectagle of the current element is [l=1893,t=685,r=1993,b=721].",
                   "The BoundingRectangle of text \"First Name\" child is [l=1900,t=691,r=1986,b=715]",
-                  "The BoundingRectangle of {0} child is zero size. possibily collapsed. it is considered as contained.",
+                  "The BoundingRectangle of {0} child is zero size. possibly collapsed. it is considered as contained.",
                   "The BoundingRectangle of thumb \"\" child is [l=1981,t=685,r=1993,b=721]"
                 ],
                 "Status": 1,
@@ -1821,7 +1821,7 @@
               },
               {
                 "Messages": [
-                  "UI element is not keyboard focusible though it has some actionable control patterns.",
+                  "UI element is not keyboard focusable though it has some actionable control patterns.",
                   "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                   "UI interactable Pattern: InvokePattern, TransformPattern"
                 ],
@@ -2863,7 +2863,7 @@
                   {
                     "Messages": [
                       "Rule Exception: Parent is ScrollBar/HeaderItem",
-                      "Since the thumb control is a child of HeaderItem(50035) , it is ok to have no Transform pattern"
+                      "Since the thumb control is a child of HeaderItem(50035) , it is OK to have no Transform pattern"
                     ],
                     "Status": 1,
                     "Description": "Required control pattern(s)",
@@ -3205,7 +3205,7 @@
                   {
                     "Messages": [
                       "Rule Exception: Parent is ScrollBar/HeaderItem",
-                      "Since the thumb control is a child of HeaderItem(50035) , it is ok to have no Transform pattern"
+                      "Since the thumb control is a child of HeaderItem(50035) , it is OK to have no Transform pattern"
                     ],
                     "Status": 1,
                     "Description": "Required control pattern(s)",
@@ -3269,7 +3269,7 @@
               },
               {
                 "Messages": [
-                  "UI element is not keyboard focusible though it has some actionable control patterns.",
+                  "UI element is not keyboard focusable though it has some actionable control patterns.",
                   "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                   "UI interactable Pattern: InvokePattern, TransformPattern"
                 ],
@@ -3365,7 +3365,7 @@
               },
               {
                 "Messages": [
-                  "thumb is excluded, since it would be ok to have childrens with same name and localized control type."
+                  "thumb is excluded, since it would be OK to have children with same name and localized control type."
                 ],
                 "Status": 1,
                 "Description": "Children with same name and LocalizedControlType",

--- a/src/UnitTestSharedLibrary/Snapshots/MonsterEdit.snapshot
+++ b/src/UnitTestSharedLibrary/Snapshots/MonsterEdit.snapshot
@@ -1003,8 +1003,8 @@
         "Messages": [
           "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
           "The BoundingRectagle of the current element is [l=246,t=778,r=546,b=804].",
-          "The BoundingRectangle of {0} child is zero size. possibily collapsed. it is considered as contained.",
-          "The BoundingRectangle of {0} child is zero size. possibily collapsed. it is considered as contained."
+          "The BoundingRectangle of {0} child is zero size. possibly collapsed. it is considered as contained.",
+          "The BoundingRectangle of {0} child is zero size. possibly collapsed. it is considered as contained."
         ],
         "Status": 1,
         "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",

--- a/src/UnitTestSharedLibrary/Snapshots/MonsterListView.snapshot
+++ b/src/UnitTestSharedLibrary/Snapshots/MonsterListView.snapshot
@@ -944,7 +944,7 @@
           {
             "Messages": [
               "There is child control(s) which are not image.",
-              "It may be ok not to have itemtype property since the type can be recognized via child element."
+              "It may be OK not to have itemtype property since the type can be recognized via child element."
             ],
             "Status": 1,
             "Description": "Property: ItemType",
@@ -1669,7 +1669,7 @@
           {
             "Messages": [
               "There is child control(s) which are not image.",
-              "It may be ok not to have itemtype property since the type can be recognized via child element."
+              "It may be OK not to have itemtype property since the type can be recognized via child element."
             ],
             "Status": 1,
             "Description": "Property: ItemType",
@@ -2394,7 +2394,7 @@
           {
             "Messages": [
               "There is child control(s) which are not image.",
-              "It may be ok not to have itemtype property since the type can be recognized via child element."
+              "It may be OK not to have itemtype property since the type can be recognized via child element."
             ],
             "Status": 1,
             "Description": "Property: ItemType",

--- a/src/UnitTestSharedLibrary/Snapshots/Taskbar.snapshot
+++ b/src/UnitTestSharedLibrary/Snapshots/Taskbar.snapshot
@@ -1942,7 +1942,7 @@
                   },
                   {
                     "Messages": [
-                      "UI element is not keyboard focusible though it has some actionable control patterns.",
+                      "UI element is not keyboard focusable though it has some actionable control patterns.",
                       "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                       "UI interactable Pattern: InvokePattern"
                     ],
@@ -2183,7 +2183,7 @@
         "Items": [
           {
             "Messages": [
-              "Name doesn't exit or empty. but it is ok for this control type.(Pane(50033))"
+              "Name doesn't exist or is empty. but it is OK for this control type.(Pane(50033))"
             ],
             "Status": 1,
             "Description": "[4.1.2] Name",
@@ -3832,7 +3832,7 @@
                       },
                       {
                         "Messages": [
-                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "UI element is not keyboard focusable though it has some actionable control patterns.",
                           "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                           "UI interactable Pattern: InvokePattern"
                         ],
@@ -4254,7 +4254,7 @@
                       },
                       {
                         "Messages": [
-                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "UI element is not keyboard focusable though it has some actionable control patterns.",
                           "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                           "UI interactable Pattern: InvokePattern"
                         ],
@@ -4676,7 +4676,7 @@
                       },
                       {
                         "Messages": [
-                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "UI element is not keyboard focusable though it has some actionable control patterns.",
                           "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                           "UI interactable Pattern: InvokePattern"
                         ],
@@ -5098,7 +5098,7 @@
                       },
                       {
                         "Messages": [
-                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "UI element is not keyboard focusable though it has some actionable control patterns.",
                           "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                           "UI interactable Pattern: InvokePattern"
                         ],
@@ -5520,7 +5520,7 @@
                       },
                       {
                         "Messages": [
-                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "UI element is not keyboard focusable though it has some actionable control patterns.",
                           "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                           "UI interactable Pattern: InvokePattern"
                         ],
@@ -5948,7 +5948,7 @@
                       },
                       {
                         "Messages": [
-                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "UI element is not keyboard focusable though it has some actionable control patterns.",
                           "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                           "UI interactable Pattern: InvokePattern"
                         ],
@@ -6370,7 +6370,7 @@
                       },
                       {
                         "Messages": [
-                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "UI element is not keyboard focusable though it has some actionable control patterns.",
                           "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                           "UI interactable Pattern: InvokePattern"
                         ],
@@ -6792,7 +6792,7 @@
                       },
                       {
                         "Messages": [
-                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "UI element is not keyboard focusable though it has some actionable control patterns.",
                           "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                           "UI interactable Pattern: InvokePattern"
                         ],
@@ -7214,7 +7214,7 @@
                       },
                       {
                         "Messages": [
-                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "UI element is not keyboard focusable though it has some actionable control patterns.",
                           "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                           "UI interactable Pattern: InvokePattern"
                         ],
@@ -7636,7 +7636,7 @@
                       },
                       {
                         "Messages": [
-                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "UI element is not keyboard focusable though it has some actionable control patterns.",
                           "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                           "UI interactable Pattern: InvokePattern"
                         ],
@@ -8058,7 +8058,7 @@
                       },
                       {
                         "Messages": [
-                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "UI element is not keyboard focusable though it has some actionable control patterns.",
                           "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                           "UI interactable Pattern: InvokePattern"
                         ],
@@ -8492,7 +8492,7 @@
                       },
                       {
                         "Messages": [
-                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "UI element is not keyboard focusable though it has some actionable control patterns.",
                           "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                           "UI interactable Pattern: InvokePattern, ExpandCollapsePattern"
                         ],
@@ -8867,7 +8867,7 @@
                       },
                       {
                         "Messages": [
-                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "UI element is not keyboard focusable though it has some actionable control patterns.",
                           "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                           "UI interactable Pattern: InvokePattern"
                         ],
@@ -9289,7 +9289,7 @@
                       },
                       {
                         "Messages": [
-                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "UI element is not keyboard focusable though it has some actionable control patterns.",
                           "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                           "UI interactable Pattern: InvokePattern"
                         ],
@@ -9668,7 +9668,7 @@
         "Items": [
           {
             "Messages": [
-              "Name doesn't exit or empty. but it is ok for this control type.(Pane(50033))"
+              "Name doesn't exist or is empty. but it is OK for this control type.(Pane(50033))"
             ],
             "Status": 1,
             "Description": "[4.1.2] Name",
@@ -11316,7 +11316,7 @@
                       },
                       {
                         "Messages": [
-                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "UI element is not keyboard focusable though it has some actionable control patterns.",
                           "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                           "UI interactable Pattern: InvokePattern"
                         ],
@@ -11738,7 +11738,7 @@
                       },
                       {
                         "Messages": [
-                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "UI element is not keyboard focusable though it has some actionable control patterns.",
                           "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
                           "UI interactable Pattern: InvokePattern"
                         ],
@@ -11978,7 +11978,7 @@
             "Items": [
               {
                 "Messages": [
-                  "Name doesn't exit or empty. but it is ok for this control type.(Pane(50033))"
+                  "Name doesn't exist or is empty. but it is OK for this control type.(Pane(50033))"
                 ],
                 "Status": 1,
                 "Description": "[4.1.2] Name",
@@ -13392,7 +13392,7 @@
         "Items": [
           {
             "Messages": [
-              "Name doesn't exit or empty. but it is ok for this control type.(Pane(50033))"
+              "Name doesn't exist or is empty. but it is OK for this control type.(Pane(50033))"
             ],
             "Status": 1,
             "Description": "[4.1.2] Name",
@@ -13526,7 +13526,7 @@
     "Items": [
       {
         "Messages": [
-          "Name doesn't exit or empty. but it is ok for this control type.(Pane(50033))"
+          "Name doesn't exist or is empty. but it is OK for this control type.(Pane(50033))"
         ],
         "Status": 1,
         "Description": "[4.1.2] Name",
@@ -13612,7 +13612,7 @@
       },
       {
         "Messages": [
-          "pane is excluded, since it would be ok to have childrens with same name and localized control type."
+          "pane is excluded, since it would be OK to have children with same name and localized control type."
         ],
         "Status": 1,
         "Description": "[4.1.2] Name: Child element should have unique name.",

--- a/src/UnitTestSharedLibrary/Utility.cs
+++ b/src/UnitTestSharedLibrary/Utility.cs
@@ -52,7 +52,7 @@ namespace Axe.Windows.UnitTestSharedLibrary
         }
 
         /// <summary>
-        /// Populates all descendents with test results and sets them to
+        /// Populates all descendants with test results and sets them to
         ///     pass if the control is a button (any predicate would work)
         ///     and returns number that should pass
         /// </summary>


### PR DESCRIPTION
#### Details
This PR fixes various spelling and typographical errors found in strings and comments in the `UnitTestSharedLibrary` namespace. Once again, a little worried that I've inadvertantly broken system tests that depend on the misspellings.

##### Motivation
Motivated by errors discovered while working on microsoft/accessibility-insights-windows#1323.

##### Context
One of a series of PRs.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
