### PR TITLE
fix: Fix process UIA scanning to also work on UWP apps by walking UIA tree manually

### DIFF
--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -72,7 +72,6 @@ namespace Axe.Windows.Desktop.UIAutomation
             {
                 if (FindProcessMatchingChildren(root, walker, pid, matchingElements, nonMatchingElements))
                 {
-                    ReleaseElements(walker, nonMatchingElements);
                     return matchingElements;
                 }
 
@@ -80,7 +79,6 @@ namespace Axe.Windows.Desktop.UIAutomation
                 {
                     if (FindProcessMatchingChildren(nonMatchingElement, walker, pid, matchingElements, nonMatchingElementsSecondLevel))
                     {
-                        ReleaseElements(walker, nonMatchingElements, nonMatchingElementsSecondLevel);
                         return matchingElements;
                     }
                 }


### PR DESCRIPTION
#### Details
As outlined in #730 , scanning UWP apps was broken when we switched how we scan children nodes in #676. This PR based on https://github.com/DaveTryon/axe-windows/pull/45 fixes this by manually walking the UIA tree. In my personal testing, this change did not seem to create a big performance difference (if one at all) when running the interaction tests.
<!-- Usually a sentence or two describing what the PR changes -->

##### Motivation
Addresses issue #730 
<!-- This can be as simple as "addresses issue #123" -->

##### Context

Ideally, we would want a test with a UWP being scanned, however due to the complexity of installing the app on the remote machine and then running it, I'm fairly sure this would not be that easy. This issue of testing a UWP app was also discussed in another issue (can't remember which :/) with the same outcome.
<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #730
