### PR TITLE
fix: Remove incorrect escaping in CLI messaging

### DIFF
--- a/src/CLI/Resources/DisplayStrings.Designer.cs
+++ b/src/CLI/Resources/DisplayStrings.Designer.cs
@@ -259,7 +259,7 @@ namespace AxeWindowsCLI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Results were written to \&quot;{0}\&quot;.
+        ///   Looks up a localized string similar to Results were written to &quot;{0}&quot;.
         /// </summary>
         internal static string ScanResultsLocationFormat {
             get {
@@ -322,7 +322,7 @@ namespace AxeWindowsCLI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Opening Third Party Notices in default browser. If this fails, manually open \&quot;{0}\&quot;.
+        ///   Looks up a localized string similar to Opening Third Party Notices in default browser. If this fails, manually open &quot;{0}&quot;.
         /// </summary>
         internal static string ThirdPartyNoticeFormat {
             get {

--- a/src/CLI/Resources/DisplayStrings.resx
+++ b/src/CLI/Resources/DisplayStrings.resx
@@ -201,7 +201,7 @@
     <comment>{0} is the error index. {1} is the error description</comment>
   </data>
   <data name="ScanResultsLocationFormat" xml:space="preserve">
-    <value>Results were written to \"{0}\"</value>
+    <value>Results were written to "{0}"</value>
     <comment>{0} is the path to the output file</comment>
   </data>
   <data name="ScanResultsMultipleErrorsFormat" xml:space="preserve">
@@ -226,7 +226,7 @@
     <value>,</value>
   </data>
   <data name="ThirdPartyNoticeFormat" xml:space="preserve">
-    <value>Opening Third Party Notices in default browser. If this fails, manually open \"{0}\"</value>
+    <value>Opening Third Party Notices in default browser. If this fails, manually open "{0}"</value>
     <comment>{0} is the path to the notices file</comment>
   </data>
   <data name="VersionFormat" xml:space="preserve">


### PR DESCRIPTION
#### Details

Quotes are escaped differently in resource files than they are in code files, so when string resources were copied from code to a resource file, we ended up with an extra backslash character in the output.

Output before the change--note the extra backslash just before each quote:
```
C:\demo>axewindowscli --showthirdpartynotices
Axe.Windows Accessibility Scanner CLI (version 1.1.7)
Opening Third Party Notices in default browser. If this fails, manually open \"c:\program files (x86)\AxeWindowsCLI\1.1.7\thirdpartynotices.html\"

C:\demo>axewindowscli --processname notepad++
Axe.Windows Accessibility Scanner CLI (version 1.1.7)
Scan Target: Process Name = notepad++, Process ID = 15228
3 errors were found
Results were written to \"C:\demo\AxeWindowsOutputFiles\AxeWindows_22-08-17_10-47-23.7137076.a11ytest\"
```

Output after the change, where the extra backslash has been removed:
```
C:\demo>axewindowscli --showthirdpartynotices
Axe.Windows Accessibility Scanner CLI (version 1.1.7)
Opening Third Party Notices in default browser. If this fails, manually open "c:\program files (x86)\AxeWindowsCLI\1.1.7\thirdpartynotices.html"

C:\demo>axewindowscli --processname notepad++
Axe.Windows Accessibility Scanner CLI (version 1.1.7)
Scan Target: Process Name = notepad++, Process ID = 15228
3 errors were found
Results were written to "C:\demo\AxeWindowsOutputFiles\AxeWindows_22-08-17_10-51-41.1706135.a11ytest"

```

I could find no other instances of `\&quot;` in Axe.Windows resource files, so I think these are the only places we need to fix.

##### Motivation

Improve user experience

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
