### PR TITLE
chore: Refresh README that installs with CLI

### DIFF
--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -16,7 +16,7 @@ You invoke the scanner by running `AxeWindowsCLI.exe`. By default, this tool get
 If you run the tool without parameters, you'll be presented with the help screen. An example follows:
 
 ```
-AxeWindowsCLI 1.1.7
+AxeWindowsCLI 1.1.8
 Copyright c 2020
 
   --processid                      Process Id

--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -16,42 +16,50 @@ You invoke the scanner by running `AxeWindowsCLI.exe`. By default, this tool get
 If you run the tool without parameters, you'll be presented with the help screen. An example follows:
 
 ```
-AxeWindowsCLI 1.0.9
+AxeWindowsCLI 1.1.7
 Copyright c 2020
 
-  --processid                Process Id
+  --processid                      Process Id
 
-  --processname              Process Name
+  --processname                    Process Name
 
-  --outputdirectory          Output directory
+  --outputdirectory                Output directory
 
-  --scanid                   Scan ID
+  --scanid                         Scan ID
 
-  --verbosity                Verbosity level (Quiet/Default/Verbose)
+  --verbosity                      Verbosity level (Quiet/Default/Verbose)
 
-  --showthirdpartynotices    Display Third Party Notices (opens file in browser without executing scan). If specified,
-                             all other options will be ignored.
+  --showthirdpartynotices          Display Third Party Notices (opens file in
+                                   browser without executing scan). If
+                                   specified, all other options will be ignored.
 
-  --delayinseconds           How many seconds to delay before triggering the scan. Valid range is 0 to 60 seconds, with
-                             a default of 0.
+  --delayinseconds                 How many seconds to delay before triggering
+                                   the scan. Valid range is 0 to 60 seconds,
+                                   with a default of 0.
 
-  --customuia                The path to a configuration file specifying custom UI Automation attributes
+  --customuia                      The path to a configuration file specifying
+                                   custom UI Automation attributes
+
+  --aremultiplescanrootsenabled    Determines if multiple top-level windows of
+                                   the target process should be scanned (true)
+                                   or just the first one (false).
 ```
 
-  To scan an application, you need to specify the application's process via either the `--processId` or `--processName` parameters
+To scan an application, you need to specify the application's process via either the `--processId` or `--processName` parameters
 
 ### Command line parameters
 
 Parameter|Description
-|---|---|
-|processId|Identifies the process ID of the application to be scanned. Must be specified as an integer value|
-|processName|Identifies the name of the process to be scanned. Requires that the process to scan be the _only_ process of that name currently running on the system.|
-|outputDirectory|Identifies the folder where output files will be created. If not specified, this will default to `.\AxeWindowsOutputFiles` (relative to the current working directory)|
-|scanid|Identifies the specific ID of the scan. This allows you to preassign a name to the given scan (and output file). If omitted, an dynamic name in the format AxeWindows_YY-MM-DD_hh-mm-ss.fffffff will be used.|
-|verbosity|Identifies the level of detail you want in the output. Valid values are `quiet` (minimal output), `default` (typical output), or `verbose` (maximum output).
-|showThirdPartyNotices|If specified, displays the third party notices for components used by AxeWindowsCLI. This information is also available in the `thirdpartynotices.html` file that is installed with AxeWindowsCLI.
-|delayInSeconds|Optionally inserts a delay before triggering the scan. This allows transient controls (menus, drop-down-lists, etc.) to be scanned.
-|customuia|The path to a [custom UIA configuration file](../../docs/CustomUIA.md).
+---|---
+processId|Identifies the process ID of the application to be scanned. Must be specified as an integer value
+processName|Identifies the name of the process to be scanned. Requires that the process to scan be the _only_ process of that name currently running on the system.
+outputDirectory|Identifies the folder where output files will be created. If not specified, this will default to `.\AxeWindowsOutputFiles` (relative to the current working directory)
+scanId|Identifies the specific ID of the scan. This allows you to preassign a name to the given scan (and output file). If omitted, an dynamic name in the format AxeWindows_YY-MM-DD_hh-mm-ss.fffffff will be used.
+verbosity|Identifies the level of detail you want in the output. Valid values are `quiet` (minimal output), `default` (typical output), or `verbose` (maximum output).
+showThirdPartyNotices|If specified, displays the third party notices for components used by AxeWindowsCLI. This information is also available in the `thirdpartynotices.html` file that is installed with AxeWindowsCLI.
+delayInSeconds|Optionally inserts a delay before triggering the scan. This allows transient controls (menus, drop-down-lists, etc.) to be scanned.
+customUia|Optionally provides a path to a [custom UIA configuration file](../../docs/CustomUIA.md). By default, only system-defined UIA properties will be included in the scan.
+areMultipleScanRootsEnabled|This has no effect for applications with a single top-level window. For applications with multiple top-level windows, the default is to scan just one window, with no programmatic way to predict which window will be chosen. Settings this flag to `true` will cause _all_ top-level windows to be scanned. An `a11ytest` file will be generated for each top-level window, even if no errors are found.
 
 ### Scan results
 A summary of scan results will be displayed after the scan is run. In addition, an A11yTest file will be generated if 1 or more errors were detected. The location of this file will be reported in the tool output (see the documentation of the `--outputDirectory` and `--scanId` parameters for ways to alter the name or location of the output file). This file can then be opened with **Accessibility Insights for Windows**, which is freely available at http://accessibilityinsights.io


### PR DESCRIPTION
#### Details

I noticed that the CLI's readme.md file was not as complete as it ought to be (it was last updated with version 1.0.8). Changes included:
- Include the help output from the current version (line breaks are different because of the presence of the `areMultipleScanRootsEnabled` parameter
- Bump the version so that it's in sync with the build version (see note under context)
- Remove superfluous `|` characters at start and stop of lines in the table that documents command line parameters
- Add documentation for the `areMultipleScanRootsEnabled` option
- Expand the explanation of the `customUia` note

##### Motivation

The readme that ships in the product should be in sync with what the user encounters when running the product.

##### Context

Q: Why update the build version to be in sync with `version.props`?
A: Ideally, the version in the readme should stay in sync with the version in `version.props`. In the future there should never be an edit to `version.props` without a corresponding edit to the readme. There may be cases (new options or improved documentation, for example) where the readme changes independently of the `version.props` file.

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
