### PR TITLE
feat(async-api): Improve DataManager

### DIFF
--- a/src/Actions/Actions/DataManager.cs
+++ b/src/Actions/Actions/DataManager.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Actions.Attributes;
 using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Actions.Enums;
@@ -32,6 +33,8 @@ namespace Axe.Windows.Actions
         /// keep the record of all element context added by AddElementContext
         /// </summary>
         readonly Dictionary<Guid, ElementContext> ElementContexts = new Dictionary<Guid, ElementContext>();
+
+        static readonly Object LockObject = new Object();
 
         /// <summary>
         /// Get A11yPattern from an indicated element/elementcontext
@@ -86,8 +89,8 @@ namespace Axe.Windows.Actions
         /// Remove DataContext from an ElementContext
         /// </summary>
         /// <param name="ecId">ElementContext Id</param>
-        /// <param name="keepMainElment">true, keep it</param>
-        internal void RemoveDataContext(Guid ecId)
+        /// <param name="keepMainElement">true, keep it</param>
+        internal void RemoveDataContext(Guid ecId, bool keepMainElement = true)
         {
             // check whether key exists. if not, just silently ignore.
             if (this.ElementContexts.ContainsKey(ecId))
@@ -95,8 +98,11 @@ namespace Axe.Windows.Actions
                 var ec = this.ElementContexts[ecId];
                 if (ec.DataContext != null)
                 {
-                    // make sure that selected element is not disposed by removing it from the list in DataContext
-                    ec.DataContext.Elements.Remove(ec.Element.UniqueId);
+                    if (keepMainElement)
+                    {
+                        // make sure that selected element is not disposed by removing it from the list in DataContext
+                        ec.DataContext.Elements.Remove(ec.Element.UniqueId);
+                    }
 
                     ec.DataContext.Dispose();
                     ec.DataContext = null;
@@ -160,63 +166,57 @@ namespace Axe.Windows.Actions
             return elementContext.DataContext.Screenshot;
         }
 
-        #region constants
-        /// <summary>
-        /// default instance name constant
-        /// </summary>
-        const string DefaultInstanceName = "Axe.WindowsDefault";
-        #endregion
-
         #region static members
-        static readonly Dictionary<string, DataManager> sDataManagers = new Dictionary<string, DataManager>();
+
+        static DataManager DefaultInstance;
 
         /// <summary>
         /// Get default Data Manager instance
-        /// if it doesn't exist, create one.
+        /// if it doesn't exist, create it.
         /// </summary>
-        /// <returns></returns>
         public static DataManager GetDefaultInstance()
         {
-            var dm = GetInstance(DefaultInstanceName);
-            if (dm == null)
+            if (DefaultInstance == null)
             {
-                sDataManagers.Add(DefaultInstanceName, new DataManager());
+                lock (LockObject)
+                {
+#pragma warning disable CA1508 // Analyzer doesn't understand check/lock/check pattern
+                    if (DefaultInstance == null)
+                    {
+                        DefaultInstance = CreateInstance();
+                    }
+#pragma warning restore CA1508 // Analyzer doesn't understand check/lock/check pattern
+                }
             }
 
-            return dm;
+            return DefaultInstance;
         }
 
         /// <summary>
-        /// Get DataManager by key.
-        /// if it doesn't exist, create a new instance with the key.
+        /// Clear the default instance
         /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        static DataManager GetInstance(string key)
+        public static void ClearDefaultInstance()
         {
-            DataManager dm;
-            if (sDataManagers.ContainsKey(key))
+            if (DefaultInstance != null)
             {
-                dm = sDataManagers[key];
+                lock (LockObject)
+                {
+#pragma warning disable CA1508 // Analyzer doesn't understand check/lock/check pattern
+                    if (DefaultInstance != null)
+                    {
+                        DefaultInstance.Dispose();
+                        DefaultInstance = null;
+                    }
+#pragma warning restore CA1508 // Analyzer doesn't understand check/lock/check pattern
+                }
             }
-            else
-            {
-                dm = new DataManager();
-                sDataManagers.Add(key, dm);
-            }
-
-            return dm;
         }
 
-        /// <summary>
-        /// Clear all Data Managers
-        /// </summary>
-        /// <returns></returns>
-        public static void Clear()
+        public static DataManager CreateInstance()
         {
-            sDataManagers.Values.AsParallel().ForAll(dm => dm.Dispose());
-            sDataManagers.Clear();
+            return new DataManager();
         }
+
         #endregion
 
         #region IDisposable Support
@@ -228,18 +228,25 @@ namespace Axe.Windows.Actions
             {
                 if (disposing)
                 {
-                    // TODO: dispose managed state (managed objects).
+                    // We need an immutble copy of the ecId values for cleanup
+                    var ecIdList = ElementContexts.Keys.ToList();
+                    foreach(Guid ecId in ecIdList)
+                    {
+                        RemoveDataContext(ecId, false);
+                    }
+
+                    ElementContexts.Clear();
                 }
 
                 disposedValue = true;
             }
         }
 
-        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
-        // ~DataManager() {
-        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        //   Dispose(false);
-        // }
+        ~DataManager()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(false);
+        }
 
         // This code added to correctly implement the disposable pattern.
         public void Dispose()

--- a/src/Actions/Actions/DataManager.cs
+++ b/src/Actions/Actions/DataManager.cs
@@ -34,7 +34,7 @@ namespace Axe.Windows.Actions
         /// </summary>
         readonly Dictionary<Guid, ElementContext> ElementContexts = new Dictionary<Guid, ElementContext>();
 
-        static readonly Object LockObject = new Object();
+        static readonly object LockObject = new object();
 
         /// <summary>
         /// Get A11yPattern from an indicated element/elementcontext

--- a/src/Actions/Actions/DataManager.cs
+++ b/src/Actions/Actions/DataManager.cs
@@ -228,7 +228,7 @@ namespace Axe.Windows.Actions
             {
                 if (disposing)
                 {
-                    // We need an immutble copy of the ecId values for cleanup
+                    // We need an immutable copy of the ecId values for cleanup
                     var ecIdList = ElementContexts.Keys.ToList();
                     foreach(Guid ecId in ecIdList)
                     {

--- a/src/Actions/Actions/DataManager.cs
+++ b/src/Actions/Actions/DataManager.cs
@@ -34,8 +34,6 @@ namespace Axe.Windows.Actions
         /// </summary>
         readonly Dictionary<Guid, ElementContext> ElementContexts = new Dictionary<Guid, ElementContext>();
 
-        static readonly object LockObject = new object();
-
         /// <summary>
         /// Get A11yPattern from an indicated element/elementcontext
         /// </summary>
@@ -169,6 +167,7 @@ namespace Axe.Windows.Actions
         #region static members
 
         static DataManager DefaultInstance;
+        static readonly object LockObject = new object();
 
         /// <summary>
         /// Get default Data Manager instance

--- a/src/Actions/Actions/SetDataAction.cs
+++ b/src/Actions/Actions/SetDataAction.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Actions.Attributes;
 using Axe.Windows.Actions.Enums;
 using System;
@@ -27,7 +28,7 @@ namespace Axe.Windows.Actions
         /// </summary>
         public static void ReleaseAll()
         {
-            DataManager.Clear();
+            DataManager.ClearDefaultInstance();
         }
 
         /// <summary>

--- a/src/ActionsTests/Actions/DataManagerTests.cs
+++ b/src/ActionsTests/Actions/DataManagerTests.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Actions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Axe.Windows.ActionsTests.Actions
+{
+    [TestClass]
+    public class DataManagerTests
+    {
+        [TestMethod]
+        [Timeout(1000)]
+        public void CreateInstance_Returns_DataManager()
+        {
+            using (var dataManager = DataManager.CreateInstance())
+            {
+                Assert.IsNotNull(dataManager);
+            }
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void CreateInstance_CallTwice_ReturnsDifferentObjects()
+        {
+            using (var dataManager1 = DataManager.CreateInstance())
+            {
+                using (var dataManager2 = DataManager.CreateInstance())
+                {
+                    Assert.IsNotNull(dataManager1);
+                    Assert.IsNotNull(dataManager2);
+                    Assert.AreNotSame(dataManager1, dataManager2);
+                }
+            }
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void CreateInstance_GetDefaultInstance_ReturnsDifferentObjects()
+        {
+            using (var dataManager1 = DataManager.CreateInstance())
+            {
+                var dataManager2 = DataManager.GetDefaultInstance();
+
+                Assert.IsNotNull(dataManager1);
+                Assert.IsNotNull(dataManager2);
+                Assert.AreNotSame(dataManager1, dataManager2);
+            }
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void GetDefaultInstance_CallTwice_ReturnsSameObjects()
+        {
+            var dataManager1 = DataManager.GetDefaultInstance();
+            var dataManager2 = DataManager.GetDefaultInstance();
+
+            Assert.IsNotNull(dataManager1);
+            Assert.IsNotNull(dataManager2);
+            Assert.AreSame(dataManager1, dataManager2);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void GetDefaultInstance_CallTwiceWithClearInBetween_ReturnsDifferentObjects()
+        {
+            var dataManager1 = DataManager.GetDefaultInstance();
+            DataManager.ClearDefaultInstance();
+            var dataManager2 = DataManager.GetDefaultInstance();
+
+            Assert.IsNotNull(dataManager1);
+            Assert.IsNotNull(dataManager2);
+            Assert.AreNotSame(dataManager1, dataManager2);
+        }
+    }
+}


### PR DESCRIPTION
#### Details

This improves the `DataManager` class as follows as we prepare for an async API:
1. `DataManager.GetDefaultInstance` used a non-concurrent `Dictionary` to allow for side-by-side instances of `DataManager`, even though the code _never_ created anything but the default instance. This removes the `Dictionary`. Future changes will create separate `DataManager` objects that will be explicitly passed into API calls.
2. `DataManager.Dispose` was never implemented beyond the boilerplate, so it was essentially a NOP. The `Dispose` method will be a important part of our data cleanup in the async world, so we need a proper implementation. We'll be cleaning up UIA objects, so the finalizer is needed (the boilerplate added it commented)
3. `DataManager.RemoveDataContext` had a documented parameter whose code had been removed. This PR bring back this parameter since we'll use it in the `Dispose` method
4. `DataManager.Clear` has been renamed to `DataManager.ClearDefaultInstance`, since that's what it does
5. `DataManager.GetDefaultInstance` and `DataManager.ClearDefaultInstance` were not thread safe, so I added locking using the check/lock/check pattern. This confuses the analyzer, so suppress the CA1508 warning
6. Add `DataManager.CreateInstance` for creating a new `DataManager` object. We could just expose the constructor, but other changes in this feature will also use the `CreateInstance` pattern, so this sets us up for consistency

##### Motivation

Part of [1996306](https://mseng.visualstudio.com/1ES/_workitems/edit/1996306) to enable async API calls not to collide

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
This is the first of a series of PR's. I'm trying to keep them as manageable as possible and this was an easily detachable piece.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Contributes to [1996306](https://mseng.visualstudio.com/1ES/_workitems/edit/1996306)
