### PR TITLE
feat(async-api): Add cancellation token for TreeWalker and RuleRunner

### DIFF
--- a/src/Actions/Actions/CaptureAction.cs
+++ b/src/Actions/Actions/CaptureAction.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Actions.Attributes;
@@ -12,6 +12,7 @@ using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Axe.Windows.Actions
 {
@@ -117,12 +118,13 @@ namespace Axe.Windows.Actions
         {
             dc.TreeMode = tm;
             dc.Mode = dcMode;
+            var cancellationToken = CancellationToken.None; // In the future this will be passed in from the top level API
 
             switch (dcMode)
             {
                 case DataContextMode.Test:
                     var stw = NewTreeWalkerForTest(dc.Element, dc.ElementCounter);
-                    stw.RefreshTreeData(tm);
+                    stw.RefreshTreeData(tm, cancellationToken);
                     dc.Elements = stw.Elements.ToDictionary(l => l.UniqueId);
                     dc.RootElment = stw.TopMostElement;
                     break;

--- a/src/Actions/Actions/CaptureAction.cs
+++ b/src/Actions/Actions/CaptureAction.cs
@@ -118,13 +118,13 @@ namespace Axe.Windows.Actions
         {
             dc.TreeMode = tm;
             dc.Mode = dcMode;
-            var cancellationToken = CancellationToken.None; // In the future this will be passed in from the top level API
+            var dataContext = new TreeWalkerDataContext();
 
             switch (dcMode)
             {
                 case DataContextMode.Test:
                     var stw = NewTreeWalkerForTest(dc.Element, dc.ElementCounter);
-                    stw.RefreshTreeData(tm, cancellationToken);
+                    stw.RefreshTreeData(tm, dataContext);
                     dc.Elements = stw.Elements.ToDictionary(l => l.UniqueId);
                     dc.RootElment = stw.TopMostElement;
                     break;

--- a/src/Actions/Actions/CaptureAction.cs
+++ b/src/Actions/Actions/CaptureAction.cs
@@ -118,7 +118,7 @@ namespace Axe.Windows.Actions
         {
             dc.TreeMode = tm;
             dc.Mode = dcMode;
-            var dataContext = new TreeWalkerDataContext();
+            var dataContext = new TreeWalkerDataContext(); // TODO: Initialize from parameters
 
             switch (dcMode)
             {

--- a/src/ActionsTests/Actions/CaptureActionTests.cs
+++ b/src/ActionsTests/Actions/CaptureActionTests.cs
@@ -186,7 +186,7 @@ namespace Axe.Windows.ActionsTests.Actions
                 Assert.AreEqual(treeViewMode, result.TreeMode);
                 Assert.AreEqual(DataContextMode.Test, result.Mode);
                 Assert.AreEqual(mockTopMostElement, result.RootElment);
-                mockTreeWalkerForTest.Verify(w => w.RefreshTreeData(treeViewMode));
+                mockTreeWalkerForTest.Verify(w => w.RefreshTreeData(treeViewMode, null));
                 Assert.AreEqual(2, result.Elements.Count);
                 Assert.AreSame(mockElementsItem1, result.Elements[mockElementsItem1.UniqueId]);
                 Assert.AreSame(mockElementsItem2, result.Elements[mockElementsItem2.UniqueId]);

--- a/src/ActionsTests/Actions/CaptureActionTests.cs
+++ b/src/ActionsTests/Actions/CaptureActionTests.cs
@@ -187,7 +187,7 @@ namespace Axe.Windows.ActionsTests.Actions
                 Assert.AreEqual(treeViewMode, result.TreeMode);
                 Assert.AreEqual(DataContextMode.Test, result.Mode);
                 Assert.AreEqual(mockTopMostElement, result.RootElment);
-                mockTreeWalkerForTest.Verify(w => w.RefreshTreeData(treeViewMode, CancellationToken.None));
+                mockTreeWalkerForTest.Verify(w => w.RefreshTreeData(treeViewMode, It.IsAny<TreeWalkerDataContext>()));
                 Assert.AreEqual(2, result.Elements.Count);
                 Assert.AreSame(mockElementsItem1, result.Elements[mockElementsItem1.UniqueId]);
                 Assert.AreSame(mockElementsItem2, result.Elements[mockElementsItem2.UniqueId]);

--- a/src/ActionsTests/Actions/CaptureActionTests.cs
+++ b/src/ActionsTests/Actions/CaptureActionTests.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Axe.Windows.ActionsTests.Actions
 {
@@ -186,7 +187,7 @@ namespace Axe.Windows.ActionsTests.Actions
                 Assert.AreEqual(treeViewMode, result.TreeMode);
                 Assert.AreEqual(DataContextMode.Test, result.Mode);
                 Assert.AreEqual(mockTopMostElement, result.RootElment);
-                mockTreeWalkerForTest.Verify(w => w.RefreshTreeData(treeViewMode, null));
+                mockTreeWalkerForTest.Verify(w => w.RefreshTreeData(treeViewMode, CancellationToken.None));
                 Assert.AreEqual(2, result.Elements.Count);
                 Assert.AreSame(mockElementsItem1, result.Elements[mockElementsItem1.UniqueId]);
                 Assert.AreSame(mockElementsItem2, result.Elements[mockElementsItem2.UniqueId]);

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerDataContext.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerDataContext.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+
+namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
+{
+    /// <summary>
+    /// Data context for refreshing tree data for test
+    /// </summary>
+    internal class TreeWalkerDataContext
+    {
+        public CancellationToken CancellationToken { get; set; }
+
+        public TreeWalkerDataContext(CancellationToken? cancellationToken = null)
+        {
+            CancellationToken = cancellationToken ?? CancellationToken.None;
+        }
+    }
+}

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
     {
         IList<A11yElement> Elements { get; }
         A11yElement TopMostElement { get; }
-        void RefreshTreeData(TreeViewMode mode, CancellationToken? cancellationToken = null);
+        void RefreshTreeData(TreeViewMode mode, CancellationToken cancellationToken);
     }
 
     /// <summary>
@@ -58,9 +58,9 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// Refresh tree node data with all children at once.
         /// <param name="mode">indicate the mode</param>
         /// </summary>
-        public void RefreshTreeData(TreeViewMode mode, CancellationToken? cancellationToken = null)
+        public void RefreshTreeData(TreeViewMode mode, CancellationToken cancellationToken)
         {
-            cancellationToken?.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
 
             this.WalkerMode = mode;
             if (this.Elements.Count != 0)
@@ -112,7 +112,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             catch (AggregateException)
             {
                 // An aggregate exception might be caused by cancellation being requested
-                cancellationToken?.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
                 throw;
             }
 

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
@@ -17,7 +18,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
     {
         IList<A11yElement> Elements { get; }
         A11yElement TopMostElement { get; }
-        void RefreshTreeData(TreeViewMode mode);
+        void RefreshTreeData(TreeViewMode mode, CancellationToken? cancellationToken = null);
     }
 
     /// <summary>
@@ -57,15 +58,17 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// Refresh tree node data with all children at once.
         /// <param name="mode">indicate the mode</param>
         /// </summary>
-        public void RefreshTreeData(TreeViewMode mode)
+        public void RefreshTreeData(TreeViewMode mode, CancellationToken? cancellationToken = null)
         {
+            cancellationToken?.ThrowIfCancellationRequested();
+
             this.WalkerMode = mode;
             if (this.Elements.Count != 0)
             {
                 this.Elements.Clear();
             }
 
-            //Set parent of Root explicitly for testing.
+            // Set parent of Root explicitly for testing.
             var ancestry = new DesktopElementAncestry(this.WalkerMode, this.SelectedElement);
 
             // Pre-count the ancestors in our bounded count, so that our count is accurate
@@ -98,11 +101,21 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             }
 
             // run tests
-            list.AsParallel().ForAll(e =>
+            try
             {
-                e.ScanResults?.Items.Clear();
-                RuleRunner.Run(e);
-            });
+                list.AsParallel().ForAll(e =>
+                {
+                    e.ScanResults?.Items.Clear();
+                    RuleRunner.Run(e, cancellationToken);
+                });
+            }
+            catch (AggregateException)
+            {
+                // An aggregate exception might be caused by cancellation being requested
+                cancellationToken?.ThrowIfCancellationRequested();
+                throw;
+            }
+
         }
 
         /// <summary>

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
     {
         IList<A11yElement> Elements { get; }
         A11yElement TopMostElement { get; }
-        void RefreshTreeData(TreeViewMode mode, CancellationToken cancellationToken);
+        void RefreshTreeData(TreeViewMode mode, TreeWalkerDataContext dataContext);
     }
 
     /// <summary>
@@ -58,9 +58,9 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// Refresh tree node data with all children at once.
         /// <param name="mode">indicate the mode</param>
         /// </summary>
-        public void RefreshTreeData(TreeViewMode mode, CancellationToken cancellationToken)
+        public void RefreshTreeData(TreeViewMode mode, TreeWalkerDataContext dataContext)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            dataContext.CancellationToken.ThrowIfCancellationRequested();
 
             this.WalkerMode = mode;
             if (this.Elements.Count != 0)
@@ -106,13 +106,13 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
                 list.AsParallel().ForAll(e =>
                 {
                     e.ScanResults?.Items.Clear();
-                    RuleRunner.Run(e, cancellationToken);
+                    RuleRunner.Run(e, dataContext.CancellationToken);
                 });
             }
             catch (AggregateException)
             {
                 // An aggregate exception might be caused by cancellation being requested
-                cancellationToken.ThrowIfCancellationRequested();
+                dataContext.CancellationToken.ThrowIfCancellationRequested();
                 throw;
             }
 

--- a/src/DesktopTests/UIAutomation/TreeWalkerForTestTests.cs
+++ b/src/DesktopTests/UIAutomation/TreeWalkerForTestTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Core.Misc;
+using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Threading;
+
+namespace Axe.Windows.DesktopTests.UIAutomation
+{
+    [TestClass]
+    public class TreeWalkerForTestTests
+    {
+        private TreeWalkerForTest _treeWalker;
+
+        private Mock<A11yElement> _elementMock;
+        private Mock<BoundedCounter> _boundedCounterMock;
+
+        [TestInitialize]
+        public void BeforeEachTest()
+        {
+            _elementMock = new Mock<A11yElement>(MockBehavior.Strict);
+            _boundedCounterMock = new Mock<BoundedCounter>(MockBehavior.Strict, 1);
+            _treeWalker = new TreeWalkerForTest(_elementMock.Object, _boundedCounterMock.Object);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void RefreshTreeData_ThrowsWhenCancelled()
+        {
+            var cancellationToken = new CancellationTokenSource();
+            cancellationToken.Cancel();
+            var exception = Assert.ThrowsException<OperationCanceledException>(() => _treeWalker.RefreshTreeData(TreeViewMode.Raw, cancellationToken.Token));
+        }
+    }
+}

--- a/src/DesktopTests/UIAutomation/TreeWalkerForTestTests.cs
+++ b/src/DesktopTests/UIAutomation/TreeWalkerForTestTests.cs
@@ -34,7 +34,8 @@ namespace Axe.Windows.DesktopTests.UIAutomation
         {
             var cancellationToken = new CancellationTokenSource();
             cancellationToken.Cancel();
-            var exception = Assert.ThrowsException<OperationCanceledException>(() => _treeWalker.RefreshTreeData(TreeViewMode.Raw, cancellationToken.Token));
+            var dataContext = new TreeWalkerDataContext(cancellationToken.Token);
+            var exception = Assert.ThrowsException<OperationCanceledException>(() => _treeWalker.RefreshTreeData(TreeViewMode.Raw, dataContext));
         }
     }
 }

--- a/src/DesktopTests/UIAutomation/TreeWalkers/TreeWalkerForTestTests.cs
+++ b/src/DesktopTests/UIAutomation/TreeWalkers/TreeWalkerForTestTests.cs
@@ -10,7 +10,7 @@ using Moq;
 using System;
 using System.Threading;
 
-namespace Axe.Windows.DesktopTests.UIAutomation
+namespace Axe.Windows.DesktopTests.UIAutomation.TreeWalkers
 {
     [TestClass]
     public class TreeWalkerForTestTests
@@ -35,7 +35,7 @@ namespace Axe.Windows.DesktopTests.UIAutomation
             var cancellationToken = new CancellationTokenSource();
             cancellationToken.Cancel();
             var dataContext = new TreeWalkerDataContext(cancellationToken.Token);
-            var exception = Assert.ThrowsException<OperationCanceledException>(() => _treeWalker.RefreshTreeData(TreeViewMode.Raw, dataContext));
+            Assert.ThrowsException<OperationCanceledException>(() => _treeWalker.RefreshTreeData(TreeViewMode.Raw, dataContext));
         }
     }
 }

--- a/src/RuleSelection/RuleRunner.cs
+++ b/src/RuleSelection/RuleRunner.cs
@@ -8,6 +8,7 @@ using Axe.Windows.Rules;
 using Axe.Windows.RuleSelection.Resources;
 using Axe.Windows.Telemetry;
 using System;
+using System.Threading;
 
 namespace Axe.Windows.RuleSelection
 {
@@ -16,11 +17,15 @@ namespace Axe.Windows.RuleSelection
     /// </summary>
     public static class RuleRunner
     {
-        public static void Run(A11yElement e)
+        public static void Run(A11yElement e, CancellationToken? cancellationToken)
         {
             try
             {
-                RunUnsafe(e);
+                RunUnsafe(e, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
@@ -30,19 +35,19 @@ namespace Axe.Windows.RuleSelection
 #pragma warning restore CA1031 // Do not catch general exception types
         }
 
-        private static void RunUnsafe(A11yElement e)
+        private static void RunUnsafe(A11yElement e, CancellationToken? cancellationToken)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             if (e.ScanResults == null)
                 e.ScanResults = new ScanResults();
 
-            Run(e.ScanResults, e);
+            Run(e.ScanResults, e, cancellationToken);
         }
 
-        private static void Run(ScanResults results, A11yElement e)
+        private static void Run(ScanResults results, A11yElement e, CancellationToken? cancellationToken)
         {
-            var runResults = Axe.Windows.Rules.Rules.RunAll(e);
+            var runResults = Axe.Windows.Rules.Rules.RunAll(e, cancellationToken);
             foreach (var r in runResults)
             {
                 if (r.EvaluationCode == EvaluationCode.NotApplicable) continue;

--- a/src/RuleSelection/RuleRunner.cs
+++ b/src/RuleSelection/RuleRunner.cs
@@ -17,7 +17,7 @@ namespace Axe.Windows.RuleSelection
     /// </summary>
     public static class RuleRunner
     {
-        public static void Run(A11yElement e, CancellationToken? cancellationToken)
+        public static void Run(A11yElement e, CancellationToken cancellationToken)
         {
             try
             {
@@ -35,7 +35,7 @@ namespace Axe.Windows.RuleSelection
 #pragma warning restore CA1031 // Do not catch general exception types
         }
 
-        private static void RunUnsafe(A11yElement e, CancellationToken? cancellationToken)
+        private static void RunUnsafe(A11yElement e, CancellationToken cancellationToken)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
@@ -45,7 +45,7 @@ namespace Axe.Windows.RuleSelection
             Run(e.ScanResults, e, cancellationToken);
         }
 
-        private static void Run(ScanResults results, A11yElement e, CancellationToken? cancellationToken)
+        private static void Run(ScanResults results, A11yElement e, CancellationToken cancellationToken)
         {
             var runResults = Axe.Windows.Rules.Rules.RunAll(e, cancellationToken);
             foreach (var r in runResults)

--- a/src/Rules/RuleRunner.cs
+++ b/src/Rules/RuleRunner.cs
@@ -38,13 +38,13 @@ namespace Axe.Windows.Rules
             return retVal;
         }
 
-        public IEnumerable<RunResult> RunAll(IA11yElement element, CancellationToken? cancellationToken)
+        public IEnumerable<RunResult> RunAll(IA11yElement element, CancellationToken cancellationToken)
         {
             var results = new List<RunResult>();
 
             foreach (var rule in _provider.All)
             {
-                cancellationToken?.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
                 var result = RunRule(rule, element);
                 results.Add(result);
             } // for all rules

--- a/src/Rules/RuleRunner.cs
+++ b/src/Rules/RuleRunner.cs
@@ -5,6 +5,8 @@ using Axe.Windows.Core.Enums;
 using Axe.Windows.Telemetry;
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using static System.FormattableString;
 
 namespace Axe.Windows.Rules
@@ -36,12 +38,13 @@ namespace Axe.Windows.Rules
             return retVal;
         }
 
-        public IEnumerable<RunResult> RunAll(IA11yElement element)
+        public IEnumerable<RunResult> RunAll(IA11yElement element, CancellationToken? cancellationToken)
         {
             var results = new List<RunResult>();
 
             foreach (var rule in _provider.All)
             {
+                cancellationToken?.ThrowIfCancellationRequested();
                 var result = RunRule(rule, element);
                 results.Add(result);
             } // for all rules

--- a/src/Rules/Rules.cs
+++ b/src/Rules/Rules.cs
@@ -51,7 +51,7 @@ namespace Axe.Windows.Rules
         /// </summary>
         /// <param name="element"></param>
         /// <returns></returns>
-        public static IEnumerable<RunResult> RunAll(IA11yElement element, CancellationToken? cancellationToken)
+        public static IEnumerable<RunResult> RunAll(IA11yElement element, CancellationToken cancellationToken)
         {
             return Runner.RunAll(element, cancellationToken);
         }

--- a/src/Rules/Rules.cs
+++ b/src/Rules/Rules.cs
@@ -1,9 +1,10 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Axe.Windows.Rules
 {
@@ -50,9 +51,9 @@ namespace Axe.Windows.Rules
         /// </summary>
         /// <param name="element"></param>
         /// <returns></returns>
-        public static IEnumerable<RunResult> RunAll(IA11yElement element)
+        public static IEnumerable<RunResult> RunAll(IA11yElement element, CancellationToken? cancellationToken)
         {
-            return Runner.RunAll(element);
+            return Runner.RunAll(element, cancellationToken);
         }
     } // class
 } // namespace

--- a/src/RulesTest/MonsterTest.cs
+++ b/src/RulesTest/MonsterTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -208,7 +208,7 @@ namespace Axe.Windows.RulesTests
 
         private static Dictionary<RuleId, EvaluationCode> GetTestResultsAsDictionary(A11yElement e)
         {
-            var results = Axe.Windows.Rules.Rules.RunAll(e);
+            var results = Axe.Windows.Rules.Rules.RunAll(e, null);
             return results.ToDictionary(r => r.RuleInfo.ID, r => r.EvaluationCode);
         }
 

--- a/src/RulesTest/MonsterTest.cs
+++ b/src/RulesTest/MonsterTest.cs
@@ -6,7 +6,7 @@ using Axe.Windows.UnitTestSharedLibrary;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Threading;
 using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
 
 namespace Axe.Windows.RulesTests
@@ -208,7 +208,7 @@ namespace Axe.Windows.RulesTests
 
         private static Dictionary<RuleId, EvaluationCode> GetTestResultsAsDictionary(A11yElement e)
         {
-            var results = Axe.Windows.Rules.Rules.RunAll(e, null);
+            var results = Axe.Windows.Rules.Rules.RunAll(e, CancellationToken.None);
             return results.ToDictionary(r => r.RuleInfo.ID, r => r.EvaluationCode);
         }
 

--- a/src/RulesTest/RuleRunnerTests.cs
+++ b/src/RulesTest/RuleRunnerTests.cs
@@ -325,7 +325,7 @@ namespace Axe.Windows.RulesTests
             providerMock.Setup(m => m.All).Returns(() => rules).Verifiable();
 
             var runner = new RuleRunner(providerMock.Object);
-            var results = runner.RunAll(e, null);
+            var results = runner.RunAll(e, CancellationToken.None);
 
             Assert.AreEqual(codes.Count(), results.Count());
 
@@ -356,7 +356,7 @@ namespace Axe.Windows.RulesTests
             var runner = new RuleRunner(providerMock.Object);
             var cancellationToken = new CancellationTokenSource();
             cancellationToken.Cancel();
-            var exception = Assert.ThrowsException<OperationCanceledException>(() => runner.RunAll(e, cancellationToken.Token));
+            var exception = Assert.ThrowsException<OperationCanceledException>(() => runner.RunAll(e, CancellationToken.None));
         }
 
         private static Mock<IRule> CreateRuleMock(Condition condition, EvaluationCode code, A11yElement e)

--- a/src/RulesTest/RuleRunnerTests.cs
+++ b/src/RulesTest/RuleRunnerTests.cs
@@ -356,7 +356,7 @@ namespace Axe.Windows.RulesTests
             var runner = new RuleRunner(providerMock.Object);
             var cancellationToken = new CancellationTokenSource();
             cancellationToken.Cancel();
-            var exception = Assert.ThrowsException<OperationCanceledException>(() => runner.RunAll(e, CancellationToken.None));
+            var exception = Assert.ThrowsException<OperationCanceledException>(() => runner.RunAll(e, cancellationToken.Token));
         }
 
         private static Mock<IRule> CreateRuleMock(Condition condition, EvaluationCode code, A11yElement e)

--- a/src/RulesTest/RuleRunnerTests.cs
+++ b/src/RulesTest/RuleRunnerTests.cs
@@ -356,7 +356,7 @@ namespace Axe.Windows.RulesTests
             var runner = new RuleRunner(providerMock.Object);
             var cancellationToken = new CancellationTokenSource();
             cancellationToken.Cancel();
-            var exception = Assert.ThrowsException<OperationCanceledException>(() => runner.RunAll(e, cancellationToken.Token));
+            Assert.ThrowsException<OperationCanceledException>(() => runner.RunAll(e, cancellationToken.Token));
         }
 
         private static Mock<IRule> CreateRuleMock(Condition condition, EvaluationCode code, A11yElement e)

--- a/src/RulesTest/RuleRunnerTests.cs
+++ b/src/RulesTest/RuleRunnerTests.cs
@@ -8,6 +8,8 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Axe.Windows.RulesTests
 {
@@ -323,7 +325,7 @@ namespace Axe.Windows.RulesTests
             providerMock.Setup(m => m.All).Returns(() => rules).Verifiable();
 
             var runner = new RuleRunner(providerMock.Object);
-            var results = runner.RunAll(e);
+            var results = runner.RunAll(e, null);
 
             Assert.AreEqual(codes.Count(), results.Count());
 
@@ -341,6 +343,20 @@ namespace Axe.Windows.RulesTests
             }
 
             providerMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void RunAll_ThrowsOnCancellation()
+        {
+            var e = new MockA11yElement();
+            var ruleMock = new Mock<IRule>(MockBehavior.Strict);
+            var providerMock = new Mock<IRuleProvider>(MockBehavior.Strict);
+            providerMock.Setup(m => m.All).Returns(() => new IRule[] { ruleMock.Object }).Verifiable();
+
+            var runner = new RuleRunner(providerMock.Object);
+            var cancellationToken = new CancellationTokenSource();
+            cancellationToken.Cancel();
+            var exception = Assert.ThrowsException<OperationCanceledException>(() => runner.RunAll(e, cancellationToken.Token));
         }
 
         private static Mock<IRule> CreateRuleMock(Condition condition, EvaluationCode code, A11yElement e)


### PR DESCRIPTION
#### Details

Adding cancellation logic to two of the most time intensive operations performed during scanning, the tree walker and rule runner. 

Based on docs/ discussion online, it appears that the norm is to use `ThrowIfCancellationRequested` to check the cancellation token throughout the async call. This throws a `OperationCanceledException`, which will be wrapped in an `AggregateException` once these methods are wrapped in a task.

Also added bare minimum test coverage for cancellation in TreeWalkerForTest, which previously did not have any unit tests. 

##### Motivation

Part of [1986365](https://mseng.visualstudio.com/1ES/_workitems/edit/1986365) to enable cancellation

##### Context

This is the first in what will be multiple PRs to add cancellation tokens. In the future we will need to add the logic to pass the cancellation token to the methods changed in this PR, but that is blocked until we add a top level async scan API. .

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Contributes to [1986365](https://mseng.visualstudio.com/1ES/_workitems/edit/1986365)
