### PR TITLE
feat(async-api): Multiple scan roots are always enabled

### DIFF
--- a/src/Automation/Data/Config.cs
+++ b/src/Automation/Data/Config.cs
@@ -42,11 +42,6 @@ namespace Axe.Windows.Automation
         public string CustomUIAConfigPath { get; private set; }
 
         /// <summary>
-        /// Determines whether multiple UIA roots will be scanned or just the first one.
-        /// </summary>
-        public bool AreMultipleScanRootsEnabled { get; private set; }
-
-        /// <summary>
         /// Custom handling of DPI awareness. The default handling is to set the entire process as DPI-aware
         /// before running the scan, and to leave it in that state after the scan completes. If your process
         /// needs to be non-DPI aware, create your own implementation of IDPIAwareness that meets your needs.
@@ -125,16 +120,6 @@ namespace Axe.Windows.Automation
             }
 
             /// <summary>
-            /// Enables the scanning of multiple top level UIA roots.
-            /// </summary>
-            /// <returns></returns>
-            public Builder WithMultipleScanRootsEnabled()
-            {
-                _config.AreMultipleScanRootsEnabled = true;
-                return this;
-            }
-
-            /// <summary>
             /// Build an instance of <see cref="Config"/>
             /// </summary>
             /// <returns></returns>
@@ -146,7 +131,6 @@ namespace Axe.Windows.Automation
                     OutputFileFormat = _config.OutputFileFormat,
                     OutputDirectory = _config.OutputDirectory,
                     CustomUIAConfigPath = _config.CustomUIAConfigPath,
-                    AreMultipleScanRootsEnabled = _config.AreMultipleScanRootsEnabled,
                     DPIAwareness = _config.DPIAwareness,
                 };
             }

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -90,7 +90,7 @@ namespace Axe.Windows.Automation
         }
 
         /// <summary>
-        /// This method is our atomic scanner. When we add async support, keep it all within the scope of a single thread.
+        /// This method is our atomic scanner. It needs to run within the scope of a single thread.
         /// </summary>
         private static void ScanAndProcessResults(Config config, IScanTools scanTools, List<WindowScanOutput> resultList, IEnumerable<A11yElement> rootElements, bool multipleTopLevelWindowsExist, int targetIndex, A11yElement rootElement, IActionContext actionContext)
         {

--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -112,16 +112,7 @@ namespace Axe.Windows.AutomationTests
         [Timeout(30000)]
         public void Scan_Integration_WindowsFormsMultiWindowSample(bool sync)
         {
-            ScanIntegrationCore(sync, WindowsFormsMultiWindowSamplerAppPath, WindowsFormsMultiWindowSamplerAppAllErrorCount, true, 2);
-        }
-
-        [DataTestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
-        [Timeout(30000)]
-        public void Scan_Integration_WindowsFormsMultiWindowSample_SingleWindow(bool sync)
-        {
-            ScanIntegrationCore(sync, WindowsFormsMultiWindowSamplerAppPath, WindowsFormsMultiWindowSamplerSingleWindowAllErrorCount);
+            ScanIntegrationCore(sync, WindowsFormsMultiWindowSamplerAppPath, WindowsFormsMultiWindowSamplerAppAllErrorCount, 2);
         }
 
         [DataTestMethod]
@@ -157,29 +148,24 @@ namespace Axe.Windows.AutomationTests
             Assert.IsTrue(task.IsCanceled);
         }
 
-        private WindowScanOutput ScanIntegrationCore(bool sync, string testAppPath, int expectedErrorCount, bool enableMultipleScanRoots = false, int expectedWindowCount = 1)
+        private WindowScanOutput ScanIntegrationCore(bool sync, string testAppPath, int expectedErrorCount, int expectedWindowCount = 1)
         {
             if (sync)
             {
-                return SyncScanIntegrationCore(testAppPath, expectedErrorCount, enableMultipleScanRoots, expectedWindowCount);
+                return SyncScanIntegrationCore(testAppPath, expectedErrorCount, expectedWindowCount);
             }
             else
             {
-                return AsyncScanIntegrationCore(testAppPath, expectedErrorCount, enableMultipleScanRoots, expectedWindowCount);
+                return AsyncScanIntegrationCore(testAppPath, expectedErrorCount, expectedWindowCount);
             }
         }
 
-        private WindowScanOutput SyncScanIntegrationCore(string testAppPath, int expectedErrorCount, bool enableMultipleScanRoots = false, int expectedWindowCount = 1)
+        private WindowScanOutput SyncScanIntegrationCore(string testAppPath, int expectedErrorCount, int expectedWindowCount = 1)
         {
             LaunchTestApp(testAppPath);
             var builder = Config.Builder.ForProcessId(TestProcess.Id)
                 .WithOutputDirectory(OutputDir)
                 .WithOutputFileFormat(OutputFileFormat.A11yTest);
-
-            if (enableMultipleScanRoots)
-            {
-                builder = builder.WithMultipleScanRootsEnabled();
-            }
 
             var config = builder.Build();
 
@@ -190,17 +176,12 @@ namespace Axe.Windows.AutomationTests
             return ValidateOutput(output, expectedErrorCount, expectedWindowCount);
         }
 
-        private WindowScanOutput AsyncScanIntegrationCore(string testAppPath, int expectedErrorCount, bool enableMultipleScanRoots = false, int expectedWindowCount = 1)
+        private WindowScanOutput AsyncScanIntegrationCore(string testAppPath, int expectedErrorCount, int expectedWindowCount = 1)
         {
             LaunchTestApp(testAppPath);
             var builder = Config.Builder.ForProcessId(TestProcess.Id)
                 .WithOutputDirectory(OutputDir)
                 .WithOutputFileFormat(OutputFileFormat.A11yTest);
-
-            if (enableMultipleScanRoots)
-            {
-                builder = builder.WithMultipleScanRootsEnabled();
-            }
 
             var config = builder.Build();
 

--- a/src/AutomationTests/ConfigTests.cs
+++ b/src/AutomationTests/ConfigTests.cs
@@ -21,7 +21,7 @@ namespace Axe.Windows.AutomationTests
 
         private void AssertBuiltValues(string outputDirectory = null,
             IDPIAwareness dpiAwareness = null, OutputFileFormat? outputFileFormat = null,
-            string customUIAConfig = null, bool multipleScanRoots = false)
+            string customUIAConfig = null)
         {
             Config config = _builder.Build();
 
@@ -78,14 +78,6 @@ namespace Axe.Windows.AutomationTests
 
         [TestMethod]
         [Timeout(1000)]
-        public void Builder_WithMultipleScanRootsEnabled_SetsMultipleScanRootsEnabled()
-        {
-            _builder.WithMultipleScanRootsEnabled();
-            AssertBuiltValues(multipleScanRoots: true);
-        }
-
-        [TestMethod]
-        [Timeout(1000)]
         public void Builder_ChainingTest_AllValuesAreSet()
         {
             const string testOutputDirectory = "put tests here";
@@ -95,12 +87,11 @@ namespace Axe.Windows.AutomationTests
             Config.Builder builder = _builder
                 .WithCustomUIAConfig(testUIAConfig)
                 .WithDPIAwareness(dpiAwarenessMock.Object)
-                .WithMultipleScanRootsEnabled()
                 .WithOutputDirectory(testOutputDirectory)
                 .WithOutputFileFormat(testOutputFileFormat);
             Assert.AreSame(builder, _builder);
             AssertBuiltValues(customUIAConfig: testUIAConfig, dpiAwareness: dpiAwarenessMock.Object,
-                multipleScanRoots: true, outputDirectory: testOutputDirectory,
+                outputDirectory: testOutputDirectory,
                 outputFileFormat: testOutputFileFormat);
         }
     }

--- a/src/CLI/IOptions.cs
+++ b/src/CLI/IOptions.cs
@@ -12,6 +12,5 @@ namespace AxeWindowsCLI
         VerbosityLevel VerbosityLevel { get; }
         int DelayInSeconds { get; }
         string CustomUia { get; }
-        bool AreMultipleScanRootsEnabled { get; }
     }
 }

--- a/src/CLI/Options.cs
+++ b/src/CLI/Options.cs
@@ -32,9 +32,6 @@ namespace AxeWindowsCLI
         [Option(Required = false, HelpText = "CustomUia", ResourceType = typeof(Resources.OptionsHelpText))]
         public string CustomUia { get; set; }
 
-        [Option(Required = false, HelpText = "AreMultipleScanRootsEnabled", ResourceType = typeof(Resources.OptionsHelpText))]
-        public bool AreMultipleScanRootsEnabled { get; set; }
-
         // CommandLineParser will never set this value!
         public VerbosityLevel VerbosityLevel { get; set; } = VerbosityLevel.Default;
     }

--- a/src/CLI/OptionsEvaluator.cs
+++ b/src/CLI/OptionsEvaluator.cs
@@ -64,7 +64,6 @@ namespace AxeWindowsCLI
                 VerbosityLevel = verbosityLevel,
                 DelayInSeconds = delayInSeconds,
                 CustomUia = rawInputs.CustomUia,
-                AreMultipleScanRootsEnabled = rawInputs.AreMultipleScanRootsEnabled
             };
         }
 

--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -16,33 +16,29 @@ You invoke the scanner by running `AxeWindowsCLI.exe`. By default, this tool get
 If you run the tool without parameters, you'll be presented with the help screen. An example follows:
 
 ```
-AxeWindowsCLI 1.1.8
+AxeWindowsCLI 2.0.0
 Copyright c 2020
 
-  --processid                      Process Id
+  --processid                Process Id
 
-  --processname                    Process Name
+  --processname              Process Name
 
-  --outputdirectory                Output directory
+  --outputdirectory          Output directory
 
-  --scanid                         Scan ID
+  --scanid                   Scan ID
 
-  --verbosity                      Verbosity level (Quiet/Default/Verbose)
+  --verbosity                Verbosity level (Quiet/Default/Verbose)
 
-  --showthirdpartynotices          Display Third Party Notices (opens file in
-                                   browser without executing scan). If
-                                   specified, all other options will be ignored.
+  --showthirdpartynotices    Display Third Party Notices (opens file in browser
+                             without executing scan). If specified, all other
+                             options will be ignored.
 
-  --delayinseconds                 How many seconds to delay before triggering
-                                   the scan. Valid range is 0 to 60 seconds,
-                                   with a default of 0.
+  --delayinseconds           How many seconds to delay before triggering the
+                             scan. Valid range is 0 to 60 seconds, with a
+                             default of 0.
 
-  --customuia                      The path to a configuration file specifying
-                                   custom UI Automation attributes
-
-  --aremultiplescanrootsenabled    Determines if multiple top-level windows of
-                                   the target process should be scanned (true)
-                                   or just the first one (false).
+  --customuia                The path to a configuration file specifying custom
+                             UI Automation attributes
 ```
 
 To scan an application, you need to specify the application's process via either the `--processId` or `--processName` parameters
@@ -59,7 +55,6 @@ verbosity|Identifies the level of detail you want in the output. Valid values ar
 showThirdPartyNotices|If specified, displays the third party notices for components used by AxeWindowsCLI. This information is also available in the `thirdpartynotices.html` file that is installed with AxeWindowsCLI.
 delayInSeconds|Optionally inserts a delay before triggering the scan. This allows transient controls (menus, drop-down-lists, etc.) to be scanned.
 customUia|Optionally provides a path to a [custom UIA configuration file](../../docs/CustomUIA.md). By default, only system-defined UIA properties will be included in the scan.
-areMultipleScanRootsEnabled|This has no effect for applications with a single top-level window. For applications with multiple top-level windows, the default is to scan just one window, with no programmatic way to predict which window will be chosen. Settings this flag to `true` will cause _all_ top-level windows to be scanned. An `a11ytest` file will be generated for each top-level window, even if no errors are found.
 
 ### Scan results
 A summary of scan results will be displayed after the scan is run. In addition, an A11yTest file will be generated if 1 or more errors were detected. The location of this file will be reported in the tool output (see the documentation of the `--outputDirectory` and `--scanId` parameters for ways to alter the name or location of the output file). This file can then be opened with **Accessibility Insights for Windows**, which is freely available at http://accessibilityinsights.io

--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -57,7 +57,7 @@ delayInSeconds|Optionally inserts a delay before triggering the scan. This allow
 customUia|Optionally provides a path to a [custom UIA configuration file](../../docs/CustomUIA.md). By default, only system-defined UIA properties will be included in the scan.
 
 ### Scan results
-A summary of scan results will be displayed after the scan is run. In addition, an A11yTest file will be generated if 1 or more errors were detected. The location of this file will be reported in the tool output (see the documentation of the `--outputDirectory` and `--scanId` parameters for ways to alter the name or location of the output file). This file can then be opened with **Accessibility Insights for Windows**, which is freely available at http://accessibilityinsights.io
+A summary of scan results will be displayed after the scan is run. In addition, an `.a11ytest` file will be generated if 1 or more errors were detected. The location of this file will be reported in the tool output (see the documentation of the `--outputDirectory` and `--scanId` parameters for ways to alter the name or location of the output file). This file can then be opened with **Accessibility Insights for Windows**, which is freely available at http://accessibilityinsights.io. If you scan an application with multiple top-level windows, an `.a11ytest` file will be generated for _each_ top-level window, even if no errors are detected.
 
 A detailed description of scan results will also be displayed if you specify verbose output (see the `verbosity` parameter).
 

--- a/src/CLI/Resources/OptionsHelpText.Designer.cs
+++ b/src/CLI/Resources/OptionsHelpText.Designer.cs
@@ -61,15 +61,6 @@ namespace AxeWindowsCLI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Determines if multiple top-level windows of the target process should be scanned (true) or just the first one (false)..
-        /// </summary>
-        public static string AreMultipleScanRootsEnabled {
-            get {
-                return ResourceManager.GetString("AreMultipleScanRootsEnabled", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The path to a configuration file specifying custom UI Automation attributes.
         /// </summary>
         public static string CustomUia {

--- a/src/CLI/Resources/OptionsHelpText.resx
+++ b/src/CLI/Resources/OptionsHelpText.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AreMultipleScanRootsEnabled" xml:space="preserve">
-    <value>Determines if multiple top-level windows of the target process should be scanned (true) or just the first one (false).</value>
-  </data>
   <data name="CustomUia" xml:space="preserve">
     <value>The path to a configuration file specifying custom UI Automation attributes</value>
   </data>

--- a/src/CLI/ScanRunner.cs
+++ b/src/CLI/ScanRunner.cs
@@ -25,9 +25,6 @@ namespace AxeWindowsCLI
             if (!string.IsNullOrEmpty(options.OutputDirectory))
                 builder = builder.WithOutputDirectory(options.OutputDirectory);
 
-            if (options.AreMultipleScanRootsEnabled)
-                builder = builder.WithMultipleScanRootsEnabled();
-
             return ScannerFactory.CreateScanner(builder.Build());
         }
     }

--- a/src/CLITests/OptionsEvaluatorTests.cs
+++ b/src/CLITests/OptionsEvaluatorTests.cs
@@ -31,7 +31,7 @@ namespace AxeWindowsCLITests
 
         private void ValidateOptions(IOptions options, string processName = TestProcessName,
             int processId = TestProcessId, string outputDirectory = null, string scanId = null,
-            VerbosityLevel verbosityLevel = VerbosityLevel.Default, int delayInSeconds = 0, bool areMultipleScanRootsEnabled = false)
+            VerbosityLevel verbosityLevel = VerbosityLevel.Default, int delayInSeconds = 0)
         {
             Assert.AreEqual(processName, options.ProcessName);
             Assert.AreEqual(processId, options.ProcessId);
@@ -39,7 +39,6 @@ namespace AxeWindowsCLITests
             Assert.AreEqual(outputDirectory, options.OutputDirectory);
             Assert.AreEqual(verbosityLevel, options.VerbosityLevel);
             Assert.AreEqual(delayInSeconds, options.DelayInSeconds);
-            Assert.AreEqual(areMultipleScanRootsEnabled, options.AreMultipleScanRootsEnabled);
         }
 
         [TestMethod]
@@ -283,10 +282,9 @@ namespace AxeWindowsCLITests
             Options input = new Options
             {
                 ProcessName = TestProcessName,
-                AreMultipleScanRootsEnabled = true
             };
             ValidateOptions(OptionsEvaluator.ProcessInputs(input, _processHelperMock.Object),
-                processId: TestProcessId, areMultipleScanRootsEnabled: true);
+                processId: TestProcessId);
             VerifyAllMocks();
         }
     }


### PR DESCRIPTION
#### Details

This is a BREAKING change to the CLI. Scripts that called the CLI with the --aremultiplescanrootsenabled  parameter will reject the arguments. To be fair, though, we know of nobody who uses this parameter. The only known case of scanning multiple top-level windows goes directly to the Automation API and does not use the CLI.

When we added multiple scan roots, we jumped through some hoops to ensure it would be non-breaking. The 2.0 Automation API is a breaking change, so we've decided to simplify multiple scan roots. They're always enabled and currently have no means of disabling them. If requested, it's easy to add at a later time.

One other change in behavior to call out: For anyone who used the Automation API and specified multiple root window support, scans would generate an a11ytestfile even if only one top-level window was scanned and no errors were found. This changes this. When a single top-level window is scanned, the a11ytest file will be generated only if errors exist. When multiple top-level windows are scanned, an a11ytest file will be generated per top-level window, regardless of error status.

##### Motivation

- Part of async feature work
- Simplify usage
- Steer people towards what we consider to be the long-term scenario.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
There is no way to say "Only scan one top-level window if multiple top-level windows exist in the process". This is by design, as the order in which top-level windows is deterministic but hard to concisely describe. We punted support of this before, and are not adding it here.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
