### PR TITLE
chore: Enable CodeQL analysis

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -228,12 +228,18 @@ jobs:
         outputfile: '$(System.DefaultWorkingDirectory)/thirdpartynotices.html'
         outputformat: html
 
+  - task: CodeQL3000Init@0
+    displayName: 'Initialize CodeQL'
+
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
     inputs:
       vsVersion: 17.0
       platform: '$(BuildPlatform)'
       configuration: release
+
+  - task: CodeQL3000Finalize@0
+    displayName: 'Finalize CodeQL'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
     displayName: 'Run BinSkim'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -194,6 +194,7 @@ jobs:
     SignAppForRelease: 'true'
     runCodesignValidationInjection: 'true'
     GDN_CODESIGN_TARGETDIRECTORY: '$(Build.ArtifactStagingDirectory)\SigningValidation'
+    Codeql.Enabled: 'true'
   steps:
   - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
     displayName: 'Install Signing Plugin'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -228,18 +228,12 @@ jobs:
         outputfile: '$(System.DefaultWorkingDirectory)/thirdpartynotices.html'
         outputformat: html
 
-  - task: CodeQL3000Init@0
-    displayName: 'Initialize CodeQL'
-
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
     inputs:
       vsVersion: 17.0
       platform: '$(BuildPlatform)'
       configuration: release
-
-  - task: CodeQL3000Finalize@0
-    displayName: 'Finalize CodeQL'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
     displayName: 'Run BinSkim'


### PR DESCRIPTION
#### Details

CodeQL analysis should be available via injection in default build pipelines. This PR sets the flag that is supposed to enable it. An intermediate commit included explicit tasks, which are supposedly not necessary in the default branch. We'll find out after merging this and triggering a build.

##### Motivation

New security requirement

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
This does not yet enable TSA uploads. That may occur at a later time

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
