### PR TITLE
feat(async-api): Provide instanced IUIAUtomation objects

### DIFF
--- a/src/Actions/Actions/CaptureAction.cs
+++ b/src/Actions/Actions/CaptureAction.cs
@@ -72,7 +72,7 @@ namespace Axe.Windows.Actions
             dc.TreeMode = mode;
             dc.Mode = DataContextMode.Live;
             var ltw = NewTreeWalkerForLive();
-            ltw.GetTreeHierarchy(dc.Element, mode, actionContext.TreeWalkerDataContext);
+            ltw.GetTreeHierarchy(dc.Element, mode, actionContext.DesktopDataContext);
             dc.RootElment = ltw.RootElement;
             dc.Elements = ltw.Elements.ToDictionary(i => i.UniqueId);
             ltw.Elements.Clear();
@@ -131,7 +131,7 @@ namespace Axe.Windows.Actions
             {
                 case DataContextMode.Test:
                     var stw = NewTreeWalkerForTest(dc.Element, dc.ElementCounter);
-                    stw.RefreshTreeData(tm, actionContext.TreeWalkerDataContext);
+                    stw.RefreshTreeData(tm, actionContext.DesktopDataContext);
                     dc.Elements = stw.Elements.ToDictionary(l => l.UniqueId);
                     dc.RootElment = stw.TopMostElement;
                     break;

--- a/src/Actions/Actions/CaptureAction.cs
+++ b/src/Actions/Actions/CaptureAction.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Actions.Attributes;
@@ -56,7 +56,7 @@ namespace Axe.Windows.Actions
             if (NeedNewDataContext(ec.DataContext, DataContextMode.Live, mode) || force)
             {
                 var dc = new ElementDataContext(ec.Element, MaxElements);
-                PopulateDataContextForLiveMode(dc, mode);
+                PopulateDataContextForLiveMode(dc, mode, actionContext);
 
                 ec.DataContext = dc;
             }
@@ -67,12 +67,12 @@ namespace Axe.Windows.Actions
         /// </summary>
         /// <param name="dc"></param>
         /// <param name="mode"></param>
-        static void PopulateDataContextForLiveMode(ElementDataContext dc, TreeViewMode mode)
+        static void PopulateDataContextForLiveMode(ElementDataContext dc, TreeViewMode mode, IActionContext actionContext)
         {
             dc.TreeMode = mode;
             dc.Mode = DataContextMode.Live;
             var ltw = NewTreeWalkerForLive();
-            ltw.GetTreeHierarchy(dc.Element, mode);
+            ltw.GetTreeHierarchy(dc.Element, mode, actionContext.TreeWalkerDataContext);
             dc.RootElment = ltw.RootElement;
             dc.Elements = ltw.Elements.ToDictionary(i => i.UniqueId);
             ltw.Elements.Clear();

--- a/src/Actions/Actions/GetDataAction.cs
+++ b/src/Actions/Actions/GetDataAction.cs
@@ -95,7 +95,7 @@ namespace Axe.Windows.Actions
         {
             var e = actionContext.DataManager.GetA11yElement(ecId, eId);
 
-            e?.PopulateAllPropertiesWithLiveData(actionContext.Registrar);
+            e?.PopulateAllPropertiesWithLiveData(actionContext.TreeWalkerDataContext);
 
             return e;
         }

--- a/src/Actions/Actions/GetDataAction.cs
+++ b/src/Actions/Actions/GetDataAction.cs
@@ -95,7 +95,7 @@ namespace Axe.Windows.Actions
         {
             var e = actionContext.DataManager.GetA11yElement(ecId, eId);
 
-            e?.PopulateAllPropertiesWithLiveData(actionContext.TreeWalkerDataContext);
+            e?.PopulateAllPropertiesWithLiveData(actionContext.DesktopDataContext);
 
             return e;
         }

--- a/src/Actions/Actions/SelectAction.cs
+++ b/src/Actions/Actions/SelectAction.cs
@@ -223,7 +223,7 @@ namespace Axe.Windows.Actions
 
         internal void SetCandidateElement(Guid ecId, int eId, IActionContext actionContext)
         {
-            var el = DataManager.GetA11yElement(ecId, eId).CloneForSelection(actionContext.TreeWalkerDataContext);
+            var el = DataManager.GetA11yElement(ecId, eId).CloneForSelection(actionContext.DesktopDataContext);
 
             SetCandidateElement(el);
         }

--- a/src/Actions/Actions/SelectAction.cs
+++ b/src/Actions/Actions/SelectAction.cs
@@ -218,7 +218,12 @@ namespace Axe.Windows.Actions
         /// <param name="eId"></param>
         public void SetCandidateElement(Guid ecId, int eId)
         {
-            var el = DataManager.GetA11yElement(ecId, eId).CloneForSelection();
+            SetCandidateElement(ecId, eId, DefaultActionContext.GetDefaultInstance());
+        }
+
+        internal void SetCandidateElement(Guid ecId, int eId, IActionContext actionContext)
+        {
+            var el = DataManager.GetA11yElement(ecId, eId).CloneForSelection(actionContext.TreeWalkerDataContext);
 
             SetCandidateElement(el);
         }

--- a/src/Actions/Contexts/DefaultActionContext.cs
+++ b/src/Actions/Contexts/DefaultActionContext.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Axe.Windows.Desktop.UIAutomation;
 using Axe.Windows.Desktop.UIAutomation.CustomObjects;
-using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using System;
 
 namespace Axe.Windows.Actions.Contexts
@@ -19,9 +19,9 @@ namespace Axe.Windows.Actions.Contexts
 
         public SelectAction SelectAction => SelectAction.GetDefaultInstance();
 
-        public Registrar Registrar => TreeWalkerDataContext.Registrar;
+        public Registrar Registrar => DesktopDataContext.Registrar;
         
-        public TreeWalkerDataContext TreeWalkerDataContext => TreeWalkerDataContext.DefaultContext;
+        public DesktopDataContext DesktopDataContext => DesktopDataContext.DefaultContext;
 
         protected virtual void Dispose(bool disposing)
         {

--- a/src/Actions/Contexts/IActionContext.cs
+++ b/src/Actions/Contexts/IActionContext.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Axe.Windows.Desktop.UIAutomation;
 using Axe.Windows.Desktop.UIAutomation.CustomObjects;
-using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using System;
 
 namespace Axe.Windows.Actions.Contexts
@@ -30,8 +30,8 @@ namespace Axe.Windows.Actions.Contexts
         Registrar Registrar { get; }
 
         /// <summary>
-        /// The <see cref="TreeWalkerDataContext"/> object to keep TreeWalker in the proper context
+        /// The <see cref="DesktopDataContext"/> object to keep Desktop in the proper context
         /// </summary>
-        TreeWalkerDataContext TreeWalkerDataContext { get; }
+        DesktopDataContext DesktopDataContext { get; }
     }
 }

--- a/src/Actions/Contexts/ScopedActionContext.cs
+++ b/src/Actions/Contexts/ScopedActionContext.cs
@@ -52,12 +52,11 @@ namespace Axe.Windows.Actions.Contexts
             GC.SuppressFinalize(this);
         }
 
-        // Override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
-        ~ScopedActionContext()
-        {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-            Dispose(false);
-        }
+        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+        // ~ScopedActionContext() {
+        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+        //   Dispose(false);
+        // }
 
         internal static IActionContext CreateInstance(CancellationToken cancellationToken)
         {

--- a/src/Actions/Contexts/ScopedActionContext.cs
+++ b/src/Actions/Contexts/ScopedActionContext.cs
@@ -16,11 +16,11 @@ namespace Axe.Windows.Actions.Contexts
     {
         private bool disposedValue;
 
-        private ScopedActionContext(DataManager dataManager, SelectAction selectAction, DesktopDataContext treeWalkerDataContext)
+        private ScopedActionContext(DataManager dataManager, SelectAction selectAction, DesktopDataContext desktopDataContext)
         {
             DataManager = dataManager ?? throw new ArgumentNullException(nameof(dataManager));
             SelectAction = selectAction ?? throw new ArgumentNullException(nameof(selectAction));
-            DesktopDataContext = treeWalkerDataContext ?? throw new ArgumentNullException(nameof(treeWalkerDataContext));
+            DesktopDataContext = desktopDataContext ?? throw new ArgumentNullException(nameof(desktopDataContext));
         }
 
         public DataManager DataManager { get; }

--- a/src/Actions/Contexts/ScopedActionContext.cs
+++ b/src/Actions/Contexts/ScopedActionContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Axe.Windows.Desktop.UIAutomation;
 using Axe.Windows.Desktop.UIAutomation.CustomObjects;
 using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using System;
@@ -64,7 +65,7 @@ namespace Axe.Windows.Actions.Contexts
             return new ScopedActionContext(
                 dataManager,
                 SelectAction.CreateInstance(dataManager),
-                new TreeWalkerDataContext(new Registrar(), cancellationToken));
+                new TreeWalkerDataContext(new Registrar(), A11yAutomation.CreateInstance(), cancellationToken));
         }
     }
 }

--- a/src/Actions/Contexts/ScopedActionContext.cs
+++ b/src/Actions/Contexts/ScopedActionContext.cs
@@ -52,11 +52,12 @@ namespace Axe.Windows.Actions.Contexts
             GC.SuppressFinalize(this);
         }
 
-        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
-        // ~ScopedActionContext() {
-        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        //   Dispose(false);
-        // }
+        // Override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+        ~ScopedActionContext()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(false);
+        }
 
         internal static IActionContext CreateInstance(CancellationToken cancellationToken)
         {

--- a/src/Actions/Contexts/ScopedActionContext.cs
+++ b/src/Actions/Contexts/ScopedActionContext.cs
@@ -3,7 +3,6 @@
 
 using Axe.Windows.Desktop.UIAutomation;
 using Axe.Windows.Desktop.UIAutomation.CustomObjects;
-using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using System;
 using System.Threading;
 
@@ -17,20 +16,20 @@ namespace Axe.Windows.Actions.Contexts
     {
         private bool disposedValue;
 
-        private ScopedActionContext(DataManager dataManager, SelectAction selectAction, TreeWalkerDataContext treeWalkerDataContext)
+        private ScopedActionContext(DataManager dataManager, SelectAction selectAction, DesktopDataContext treeWalkerDataContext)
         {
             DataManager = dataManager ?? throw new ArgumentNullException(nameof(dataManager));
             SelectAction = selectAction ?? throw new ArgumentNullException(nameof(selectAction));
-            TreeWalkerDataContext = treeWalkerDataContext ?? throw new ArgumentNullException(nameof(treeWalkerDataContext));
+            DesktopDataContext = treeWalkerDataContext ?? throw new ArgumentNullException(nameof(treeWalkerDataContext));
         }
 
         public DataManager DataManager { get; }
 
         public SelectAction SelectAction { get; }
 
-        public Registrar Registrar => TreeWalkerDataContext.Registrar;
+        public Registrar Registrar => DesktopDataContext.Registrar;
 
-        public TreeWalkerDataContext TreeWalkerDataContext { get; }
+        public DesktopDataContext DesktopDataContext { get; }
 
         protected virtual void Dispose(bool disposing)
         {
@@ -65,7 +64,7 @@ namespace Axe.Windows.Actions.Contexts
             return new ScopedActionContext(
                 dataManager,
                 SelectAction.CreateInstance(dataManager),
-                new TreeWalkerDataContext(new Registrar(), A11yAutomation.CreateInstance(), cancellationToken));
+                new DesktopDataContext(new Registrar(), A11yAutomation.CreateInstance(), cancellationToken));
         }
     }
 }

--- a/src/Actions/Trackers/BaseTracker.cs
+++ b/src/Actions/Trackers/BaseTracker.cs
@@ -77,7 +77,7 @@ namespace Axe.Windows.Actions.Trackers
         {
             if (e != null && Scope == SelectionScope.App)
             {
-                var el = ActionContext.TreeWalkerDataContext.A11yAutomation.GetAppElement(e, ActionContext.TreeWalkerDataContext);
+                var el = ActionContext.DesktopDataContext.A11yAutomation.GetAppElement(e, ActionContext.DesktopDataContext);
 
                 // if the original selection is Top most element of the app, it should not be released.
                 if (e != el)

--- a/src/Actions/Trackers/BaseTracker.cs
+++ b/src/Actions/Trackers/BaseTracker.cs
@@ -1,9 +1,10 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Actions.Enums;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
-using Axe.Windows.Desktop.UIAutomation;
 using System;
 using System.Drawing;
 
@@ -19,6 +20,11 @@ namespace Axe.Windows.Actions.Trackers
         internal int ProcessId;
 
         internal bool IsStarted;
+
+        /// <summary>
+        /// The ActionContext that owns this object
+        /// </summary>
+        protected IActionContext ActionContext { get; }
 
         /// <summary>
         /// keep track the Selected element RuntimeId
@@ -37,9 +43,10 @@ namespace Axe.Windows.Actions.Trackers
         /// Constructor
         /// </summary>
         /// <param name="action"></param>
-        protected BaseTracker(Action<A11yElement> action)
+        protected BaseTracker(Action<A11yElement> action, IActionContext actionContext)
         {
             this.SetElement = action;
+            ActionContext = actionContext ?? throw new ArgumentNullException(nameof(actionContext));
         }
 
 #pragma warning disable CA1716 // Identifiers should not match keywords
@@ -70,7 +77,7 @@ namespace Axe.Windows.Actions.Trackers
         {
             if (e != null && Scope == SelectionScope.App)
             {
-                var el = A11yAutomation.GetAppElement(e);
+                var el = ActionContext.TreeWalkerDataContext.A11yAutomation.GetAppElement(e, ActionContext.TreeWalkerDataContext);
 
                 // if the original selection is Top most element of the app, it should not be released.
                 if (e != el)

--- a/src/Actions/Trackers/FocusTracker.cs
+++ b/src/Actions/Trackers/FocusTracker.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Core.Bases;

--- a/src/Actions/Trackers/FocusTracker.cs
+++ b/src/Actions/Trackers/FocusTracker.cs
@@ -1,5 +1,7 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information
+
+using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.Types;
@@ -22,7 +24,7 @@ namespace Axe.Windows.Actions.Trackers
         /// Constructor
         /// </summary>
         /// <param name="action"></param>
-        public FocusTracker(Action<A11yElement> action) : base(action)
+        public FocusTracker(Action<A11yElement> action) : base(action, DefaultActionContext.GetDefaultInstance())
         {
             this.EventHandler = new EventListenerFactory(null); // listen for all element. it works only for FocusChangedEvent
         }

--- a/src/Actions/Trackers/MouseTracker.cs
+++ b/src/Actions/Trackers/MouseTracker.cs
@@ -1,8 +1,9 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
-using Axe.Windows.Desktop.UIAutomation;
 using Axe.Windows.Win32;
 using System;
 using System.Drawing;
@@ -64,7 +65,7 @@ namespace Axe.Windows.Actions.Trackers
         /// constructor
         /// </summary>
         /// <param name="action"></param>
-        public MouseTracker(Action<A11yElement> action) : base(action)
+        public MouseTracker(Action<A11yElement> action) : base(action, DefaultActionContext.GetDefaultInstance())
         {
             // set up mouse Timer
             this.timerMouse = new System.Timers.Timer(DefaultTimerInterval); // default but it will be set by config immediately.
@@ -113,7 +114,7 @@ namespace Axe.Windows.Actions.Trackers
 
                     if (LastMousePoint.Equals(p) && !this.POIPoint.Equals(p))
                     {
-                        var element = GetElementBasedOnScope(A11yAutomation.NormalizedElementFromPoint(p.X, p.Y, this.TreeViewMode));
+                        var element = GetElementBasedOnScope(ActionContext.TreeWalkerDataContext.A11yAutomation.NormalizedElementFromPoint(p.X, p.Y, this.TreeViewMode));
                         if (!SelectElementIfItIsEligible(element))
                         {
                             element?.Dispose();

--- a/src/Actions/Trackers/MouseTracker.cs
+++ b/src/Actions/Trackers/MouseTracker.cs
@@ -114,7 +114,7 @@ namespace Axe.Windows.Actions.Trackers
 
                     if (LastMousePoint.Equals(p) && !this.POIPoint.Equals(p))
                     {
-                        var element = GetElementBasedOnScope(ActionContext.TreeWalkerDataContext.A11yAutomation.NormalizedElementFromPoint(p.X, p.Y, this.TreeViewMode));
+                        var element = GetElementBasedOnScope(ActionContext.DesktopDataContext.A11yAutomation.NormalizedElementFromPoint(p.X, p.Y, this.TreeViewMode));
                         if (!SelectElementIfItIsEligible(element))
                         {
                             element?.Dispose();

--- a/src/Actions/Trackers/MouseTracker.cs
+++ b/src/Actions/Trackers/MouseTracker.cs
@@ -114,7 +114,7 @@ namespace Axe.Windows.Actions.Trackers
 
                     if (LastMousePoint.Equals(p) && !this.POIPoint.Equals(p))
                     {
-                        var element = GetElementBasedOnScope(ActionContext.DesktopDataContext.A11yAutomation.NormalizedElementFromPoint(p.X, p.Y, this.TreeViewMode));
+                        var element = GetElementBasedOnScope(ActionContext.DesktopDataContext.A11yAutomation.NormalizedElementFromPoint(p.X, p.Y, this.TreeViewMode, ActionContext.DesktopDataContext));
                         if (!SelectElementIfItIsEligible(element))
                         {
                             element?.Dispose();

--- a/src/Actions/Trackers/TreeTracker.cs
+++ b/src/Actions/Trackers/TreeTracker.cs
@@ -1,5 +1,7 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Exceptions;
@@ -25,7 +27,7 @@ namespace Axe.Windows.Actions.Trackers
         private readonly object _movementLock = new object();
 
         public TreeTracker(Action<A11yElement> action, SelectAction selectAction)
-            : base(action)
+            : base(action, DefaultActionContext.GetDefaultInstance())
         {
             this.SelectAction = selectAction;
         }
@@ -147,7 +149,7 @@ namespace Axe.Windows.Actions.Trackers
             var currentElement = GetCurrentElement();
             if (currentElement == null) return null;
 
-            var treeWalker = A11yAutomation.GetTreeWalker(this.TreeViewMode);
+            var treeWalker = ActionContext.TreeWalkerDataContext.A11yAutomation.GetTreeWalker(this.TreeViewMode);
 
             var nextElement = getNextElement?.Invoke(treeWalker, currentElement);
 

--- a/src/Actions/Trackers/TreeTracker.cs
+++ b/src/Actions/Trackers/TreeTracker.cs
@@ -149,7 +149,7 @@ namespace Axe.Windows.Actions.Trackers
             var currentElement = GetCurrentElement();
             if (currentElement == null) return null;
 
-            var treeWalker = ActionContext.TreeWalkerDataContext.A11yAutomation.GetTreeWalker(this.TreeViewMode);
+            var treeWalker = ActionContext.DesktopDataContext.A11yAutomation.GetTreeWalker(this.TreeViewMode);
 
             var nextElement = getNextElement?.Invoke(treeWalker, currentElement);
 

--- a/src/Actions/Trackers/TreeTracker.cs
+++ b/src/Actions/Trackers/TreeTracker.cs
@@ -130,7 +130,7 @@ namespace Axe.Windows.Actions.Trackers
             var desktopElement = new DesktopElement(element, true, false);
 #pragma warning restore CA2000
 
-            desktopElement.PopulateMinimumPropertiesForSelection();
+            desktopElement.PopulateMinimumPropertiesForSelection(ActionContext.DesktopDataContext);
             if (desktopElement.IsRootElement() == false)
             {
                 this.SelectAction?.SetCandidateElement(desktopElement);

--- a/src/ActionsTests/Actions/CaptureActionTests.cs
+++ b/src/ActionsTests/Actions/CaptureActionTests.cs
@@ -28,6 +28,7 @@ namespace Axe.Windows.ActionsTests.Actions
         int irrelevantMaxElements;
         ElementDataContext mockDataContext;
         TreeViewMode mockTreeViewMode;
+        DesktopDataContext mockDesktopDataContext;
 
         [TestInitialize]
         public void ResetMocks()
@@ -48,12 +49,12 @@ namespace Axe.Windows.ActionsTests.Actions
             mockDataManager.AddElementContext(mockElementContext);
 
             Registrar registrar = new Registrar();
-            DesktopDataContext treeWalkerDataContext = new DesktopDataContext(registrar, /*TODO*/ null, CancellationToken.None);
+            mockDesktopDataContext = new DesktopDataContext(registrar, /*TODO*/ null, CancellationToken.None);
 
             mockActionContext = new Mock<IActionContext>(MockBehavior.Strict);
             mockActionContext.Setup(m => m.DataManager).Returns(mockDataManager);
             mockActionContext.Setup(m => m.Registrar).Returns(registrar);
-            mockActionContext.Setup(m => m.DesktopDataContext).Returns(treeWalkerDataContext);
+            mockActionContext.Setup(m => m.DesktopDataContext).Returns(mockDesktopDataContext);
         }
 
         [TestMethod]
@@ -119,7 +120,7 @@ namespace Axe.Windows.ActionsTests.Actions
                 Assert.AreEqual(treeViewMode, result.TreeMode);
                 Assert.AreEqual(DataContextMode.Live, result.Mode);
                 Assert.AreEqual(mockTopMostElement, result.RootElment);
-                mockTreeWalkerForLive.Verify(w => w.GetTreeHierarchy(mockElement, treeViewMode, /* TODO */ null));
+                mockTreeWalkerForLive.Verify(w => w.GetTreeHierarchy(mockElement, treeViewMode, mockDesktopDataContext));
                 Assert.AreEqual(2, result.Elements.Count);
                 Assert.AreSame(mockElementsItem1, result.Elements[mockElementsItem1.UniqueId]);
                 Assert.AreSame(mockElementsItem2, result.Elements[mockElementsItem2.UniqueId]);

--- a/src/ActionsTests/Actions/CaptureActionTests.cs
+++ b/src/ActionsTests/Actions/CaptureActionTests.cs
@@ -7,6 +7,7 @@ using Axe.Windows.Actions.Enums;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;
+using Axe.Windows.Desktop.UIAutomation;
 using Axe.Windows.Desktop.UIAutomation.CustomObjects;
 using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -47,12 +48,12 @@ namespace Axe.Windows.ActionsTests.Actions
             mockDataManager.AddElementContext(mockElementContext);
 
             Registrar registrar = new Registrar();
-            TreeWalkerDataContext treeWalkerDataContext = new TreeWalkerDataContext(registrar, /*TODO*/ null, CancellationToken.None);
+            DesktopDataContext treeWalkerDataContext = new DesktopDataContext(registrar, /*TODO*/ null, CancellationToken.None);
 
             mockActionContext = new Mock<IActionContext>(MockBehavior.Strict);
             mockActionContext.Setup(m => m.DataManager).Returns(mockDataManager);
             mockActionContext.Setup(m => m.Registrar).Returns(registrar);
-            mockActionContext.Setup(m => m.TreeWalkerDataContext).Returns(treeWalkerDataContext);
+            mockActionContext.Setup(m => m.DesktopDataContext).Returns(treeWalkerDataContext);
         }
 
         [TestMethod]
@@ -197,7 +198,7 @@ namespace Axe.Windows.ActionsTests.Actions
                 Assert.AreEqual(treeViewMode, result.TreeMode);
                 Assert.AreEqual(DataContextMode.Test, result.Mode);
                 Assert.AreEqual(mockTopMostElement, result.RootElment);
-                mockTreeWalkerForTest.Verify(w => w.RefreshTreeData(treeViewMode, It.IsAny<TreeWalkerDataContext>()));
+                mockTreeWalkerForTest.Verify(w => w.RefreshTreeData(treeViewMode, It.IsAny<DesktopDataContext>()));
                 Assert.AreEqual(2, result.Elements.Count);
                 Assert.AreSame(mockElementsItem1, result.Elements[mockElementsItem1.UniqueId]);
                 Assert.AreSame(mockElementsItem2, result.Elements[mockElementsItem2.UniqueId]);

--- a/src/ActionsTests/Actions/CaptureActionTests.cs
+++ b/src/ActionsTests/Actions/CaptureActionTests.cs
@@ -49,7 +49,7 @@ namespace Axe.Windows.ActionsTests.Actions
             mockDataManager.AddElementContext(mockElementContext);
 
             Registrar registrar = new Registrar();
-            mockDesktopDataContext = new DesktopDataContext(registrar, /*TODO*/ null, CancellationToken.None);
+            mockDesktopDataContext = new DesktopDataContext(registrar, A11yAutomation.CreateInstance(), CancellationToken.None);
 
             mockActionContext = new Mock<IActionContext>(MockBehavior.Strict);
             mockActionContext.Setup(m => m.DataManager).Returns(mockDataManager);

--- a/src/ActionsTests/Actions/CaptureActionTests.cs
+++ b/src/ActionsTests/Actions/CaptureActionTests.cs
@@ -118,7 +118,7 @@ namespace Axe.Windows.ActionsTests.Actions
                 Assert.AreEqual(treeViewMode, result.TreeMode);
                 Assert.AreEqual(DataContextMode.Live, result.Mode);
                 Assert.AreEqual(mockTopMostElement, result.RootElment);
-                mockTreeWalkerForLive.Verify(w => w.GetTreeHierarchy(mockElement, treeViewMode));
+                mockTreeWalkerForLive.Verify(w => w.GetTreeHierarchy(mockElement, treeViewMode, /* TODO */ null));
                 Assert.AreEqual(2, result.Elements.Count);
                 Assert.AreSame(mockElementsItem1, result.Elements[mockElementsItem1.UniqueId]);
                 Assert.AreSame(mockElementsItem2, result.Elements[mockElementsItem2.UniqueId]);

--- a/src/ActionsTests/Actions/CaptureActionTests.cs
+++ b/src/ActionsTests/Actions/CaptureActionTests.cs
@@ -47,7 +47,7 @@ namespace Axe.Windows.ActionsTests.Actions
             mockDataManager.AddElementContext(mockElementContext);
 
             Registrar registrar = new Registrar();
-            TreeWalkerDataContext treeWalkerDataContext = new TreeWalkerDataContext(registrar, CancellationToken.None);
+            TreeWalkerDataContext treeWalkerDataContext = new TreeWalkerDataContext(registrar, /*TODO*/ null, CancellationToken.None);
 
             mockActionContext = new Mock<IActionContext>(MockBehavior.Strict);
             mockActionContext.Setup(m => m.DataManager).Returns(mockDataManager);

--- a/src/ActionsTests/Contexts/DefaultActionContextTests.cs
+++ b/src/ActionsTests/Contexts/DefaultActionContextTests.cs
@@ -3,8 +3,8 @@
 
 using Axe.Windows.Actions;
 using Axe.Windows.Actions.Contexts;
+using Axe.Windows.Desktop.UIAutomation;
 using Axe.Windows.Desktop.UIAutomation.CustomObjects;
-using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.ActionsTests.Contexts
@@ -43,9 +43,9 @@ namespace Axe.Windows.ActionsTests.Contexts
         [Timeout(1000)]
         public void TreeWalkerDataContext_IsDefaultTreeWalkerDataContext()
         {
-            var treeWalkerDataContext = DefaultActionContext.GetDefaultInstance().TreeWalkerDataContext;
+            var treeWalkerDataContext = DefaultActionContext.GetDefaultInstance().DesktopDataContext;
             Assert.IsNotNull(treeWalkerDataContext);
-            Assert.AreSame(TreeWalkerDataContext.DefaultContext, treeWalkerDataContext);
+            Assert.AreSame(DesktopDataContext.DefaultContext, treeWalkerDataContext);
         }
 
         [TestMethod]
@@ -56,7 +56,7 @@ namespace Axe.Windows.ActionsTests.Contexts
             var dataManager = DefaultActionContext.GetDefaultInstance().DataManager;
             var selectAction = DefaultActionContext.GetDefaultInstance().SelectAction;
             var registrar = DefaultActionContext.GetDefaultInstance().Registrar;
-            var treeWalkerDataContext = DefaultActionContext.GetDefaultInstance().TreeWalkerDataContext;
+            var treeWalkerDataContext = DefaultActionContext.GetDefaultInstance().DesktopDataContext;
 
             DefaultActionContext.GetDefaultInstance().Dispose();
 
@@ -64,7 +64,7 @@ namespace Axe.Windows.ActionsTests.Contexts
             Assert.AreSame(dataManager, DefaultActionContext.GetDefaultInstance().DataManager);
             Assert.AreSame(selectAction, DefaultActionContext.GetDefaultInstance().SelectAction);
             Assert.AreSame(registrar, DefaultActionContext.GetDefaultInstance().Registrar);
-            Assert.AreSame(treeWalkerDataContext, DefaultActionContext.GetDefaultInstance().TreeWalkerDataContext);
+            Assert.AreSame(treeWalkerDataContext, DefaultActionContext.GetDefaultInstance().DesktopDataContext);
         }
     }
 }

--- a/src/ActionsTests/Contexts/DefaultActionContextTests.cs
+++ b/src/ActionsTests/Contexts/DefaultActionContextTests.cs
@@ -41,11 +41,11 @@ namespace Axe.Windows.ActionsTests.Contexts
 
         [TestMethod]
         [Timeout(1000)]
-        public void TreeWalkerDataContext_IsDefaultTreeWalkerDataContext()
+        public void DesktopDataContext_IsDefaultDesktopDataContext()
         {
-            var treeWalkerDataContext = DefaultActionContext.GetDefaultInstance().DesktopDataContext;
-            Assert.IsNotNull(treeWalkerDataContext);
-            Assert.AreSame(DesktopDataContext.DefaultContext, treeWalkerDataContext);
+            var desktopDataContext = DefaultActionContext.GetDefaultInstance().DesktopDataContext;
+            Assert.IsNotNull(desktopDataContext);
+            Assert.AreSame(DesktopDataContext.DefaultContext, desktopDataContext);
         }
 
         [TestMethod]
@@ -56,7 +56,7 @@ namespace Axe.Windows.ActionsTests.Contexts
             var dataManager = DefaultActionContext.GetDefaultInstance().DataManager;
             var selectAction = DefaultActionContext.GetDefaultInstance().SelectAction;
             var registrar = DefaultActionContext.GetDefaultInstance().Registrar;
-            var treeWalkerDataContext = DefaultActionContext.GetDefaultInstance().DesktopDataContext;
+            var desktopDataContext = DefaultActionContext.GetDefaultInstance().DesktopDataContext;
 
             DefaultActionContext.GetDefaultInstance().Dispose();
 
@@ -64,7 +64,7 @@ namespace Axe.Windows.ActionsTests.Contexts
             Assert.AreSame(dataManager, DefaultActionContext.GetDefaultInstance().DataManager);
             Assert.AreSame(selectAction, DefaultActionContext.GetDefaultInstance().SelectAction);
             Assert.AreSame(registrar, DefaultActionContext.GetDefaultInstance().Registrar);
-            Assert.AreSame(treeWalkerDataContext, DefaultActionContext.GetDefaultInstance().DesktopDataContext);
+            Assert.AreSame(desktopDataContext, DefaultActionContext.GetDefaultInstance().DesktopDataContext);
         }
     }
 }

--- a/src/ActionsTests/Contexts/ScopedActionContextTests.cs
+++ b/src/ActionsTests/Contexts/ScopedActionContextTests.cs
@@ -48,7 +48,7 @@ namespace Axe.Windows.ActionsTests.Contexts
 
         [TestMethod]
         [Timeout(1000)]
-        public void TreeWalkerDataContext_IsNotDefaultTreeWalkerDataContext()
+        public void DesktopDataContext_IsNotDefaultDesktopDataContext()
         {
             using (var actionContext = ScopedActionContext.CreateInstance(CancellationToken.None))
             {
@@ -59,7 +59,7 @@ namespace Axe.Windows.ActionsTests.Contexts
 
         [TestMethod]
         [Timeout(1000)]
-        public void TreeWalkerDataContextRegistrar_IsSameAsRegistrar()
+        public void DesktopDataContextRegistrar_IsSameAsRegistrar()
         {
             using (var actionContext = ScopedActionContext.CreateInstance(CancellationToken.None))
             {
@@ -69,7 +69,7 @@ namespace Axe.Windows.ActionsTests.Contexts
 
         [TestMethod]
         [Timeout(1000)]
-        public void TreeWalkerDataContextCancellationToken_CancelSource_CancelsToken()
+        public void DesktopDataContextCancellationToken_CancelSource_CancelsToken()
         {
             var source = new CancellationTokenSource();
 

--- a/src/ActionsTests/Contexts/ScopedActionContextTests.cs
+++ b/src/ActionsTests/Contexts/ScopedActionContextTests.cs
@@ -3,8 +3,8 @@
 
 using Axe.Windows.Actions;
 using Axe.Windows.Actions.Contexts;
+using Axe.Windows.Desktop.UIAutomation;
 using Axe.Windows.Desktop.UIAutomation.CustomObjects;
-using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading;
 
@@ -52,8 +52,8 @@ namespace Axe.Windows.ActionsTests.Contexts
         {
             using (var actionContext = ScopedActionContext.CreateInstance(CancellationToken.None))
             {
-                Assert.IsNotNull(actionContext.TreeWalkerDataContext);
-                Assert.AreNotSame(actionContext.TreeWalkerDataContext, TreeWalkerDataContext.DefaultContext);
+                Assert.IsNotNull(actionContext.DesktopDataContext);
+                Assert.AreNotSame(actionContext.DesktopDataContext, DesktopDataContext.DefaultContext);
             }
         }
 
@@ -63,7 +63,7 @@ namespace Axe.Windows.ActionsTests.Contexts
         {
             using (var actionContext = ScopedActionContext.CreateInstance(CancellationToken.None))
             {
-                Assert.AreSame(actionContext.TreeWalkerDataContext.Registrar, actionContext.Registrar);
+                Assert.AreSame(actionContext.DesktopDataContext.Registrar, actionContext.Registrar);
             }
         }
 
@@ -75,9 +75,9 @@ namespace Axe.Windows.ActionsTests.Contexts
 
             using (var actionContext = ScopedActionContext.CreateInstance(source.Token))
             {
-                Assert.IsFalse(actionContext.TreeWalkerDataContext.CancellationToken.IsCancellationRequested);
+                Assert.IsFalse(actionContext.DesktopDataContext.CancellationToken.IsCancellationRequested);
                 source.Cancel();
-                Assert.IsTrue(actionContext.TreeWalkerDataContext.CancellationToken.IsCancellationRequested);
+                Assert.IsTrue(actionContext.DesktopDataContext.CancellationToken.IsCancellationRequested);
             }
         }
 
@@ -93,7 +93,7 @@ namespace Axe.Windows.ActionsTests.Contexts
                     AssertAreDifferentObjectsOfType<DataManager>(actionContext1.DataManager, actionContext2.DataManager);
                     AssertAreDifferentObjectsOfType<SelectAction>(actionContext1.SelectAction, actionContext2.SelectAction);
                     AssertAreDifferentObjectsOfType<Registrar>(actionContext1.Registrar, actionContext2.Registrar);
-                    AssertAreDifferentObjectsOfType<TreeWalkerDataContext>(actionContext1.TreeWalkerDataContext, actionContext2.TreeWalkerDataContext);
+                    AssertAreDifferentObjectsOfType<DesktopDataContext>(actionContext1.DesktopDataContext, actionContext2.DesktopDataContext);
                 }
             }
         }

--- a/src/Automation/TargetElementLocator.cs
+++ b/src/Automation/TargetElementLocator.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Automation
         {
             try
             {
-                var desktopElements = actionContext.TreeWalkerDataContext.A11yAutomation.ElementsFromProcessId(processId, actionContext.Registrar);
+                var desktopElements = actionContext.TreeWalkerDataContext.A11yAutomation.ElementsFromProcessId(processId, actionContext.TreeWalkerDataContext);
                 return GetA11YElementsFromDesktopElements(desktopElements);
             }
             catch (Exception ex)

--- a/src/Automation/TargetElementLocator.cs
+++ b/src/Automation/TargetElementLocator.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Automation
         {
             try
             {
-                var desktopElements = actionContext.TreeWalkerDataContext.A11yAutomation.ElementsFromProcessId(processId, actionContext.TreeWalkerDataContext);
+                var desktopElements = actionContext.DesktopDataContext.A11yAutomation.ElementsFromProcessId(processId, actionContext.DesktopDataContext);
                 return GetA11YElementsFromDesktopElements(desktopElements);
             }
             catch (Exception ex)

--- a/src/Automation/TargetElementLocator.cs
+++ b/src/Automation/TargetElementLocator.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Automation
         {
             try
             {
-                var desktopElements = A11yAutomation.ElementsFromProcessId(processId, actionContext.Registrar);
+                var desktopElements = actionContext.TreeWalkerDataContext.A11yAutomation.ElementsFromProcessId(processId, actionContext.Registrar);
                 return GetA11YElementsFromDesktopElements(desktopElements);
             }
             catch (Exception ex)

--- a/src/Core/Bases/A11yProperty.cs
+++ b/src/Core/Bases/A11yProperty.cs
@@ -47,6 +47,7 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        // TODO: This does not yet support different custom properties in concurrent scans
         static readonly Dictionary<int, ITypeConverter> TypeConverterMap = new Dictionary<int, ITypeConverter>();
 
         /// <summary>

--- a/src/Desktop/Resources/ErrorMessages.Designer.cs
+++ b/src/Desktop/Resources/ErrorMessages.Designer.cs
@@ -79,6 +79,15 @@ namespace Axe.Windows.Desktop.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The dataContext passed in does not match this A11yAutomation.
+        /// </summary>
+        internal static string InvalidContext {
+            get {
+                return ResourceManager.GetString("InvalidContext", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The pattern may no longer be valid.
         /// </summary>
         internal static string PatternNoLongerValid {

--- a/src/Desktop/Resources/ErrorMessages.resx
+++ b/src/Desktop/Resources/ErrorMessages.resx
@@ -125,7 +125,6 @@
   </data>
   <data name="InvalidContext" xml:space="preserve">
     <value>The dataContext passed in does not match this A11yAutomation</value>
-    <comment>Do not localize</comment>
   </data>
   <data name="PatternNoLongerValid" xml:space="preserve">
     <value>The pattern may no longer be valid</value>

--- a/src/Desktop/Resources/ErrorMessages.resx
+++ b/src/Desktop/Resources/ErrorMessages.resx
@@ -123,6 +123,10 @@
   <data name="InvalidColor" xml:space="preserve">
     <value>Color components are values between 0 and 255</value>
   </data>
+  <data name="InvalidContext" xml:space="preserve">
+    <value>The dataContext passed in does not match this A11yAutomation</value>
+    <comment>Do not localize</comment>
+  </data>
   <data name="PatternNoLongerValid" xml:space="preserve">
     <value>The pattern may no longer be valid</value>
     <comment>Pattern may not be valid any more.</comment>

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -260,9 +260,8 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// <returns></returns>
         internal A11yElement GetAppElement(A11yElement e, DesktopDataContext dataContext)
         {
-            if (!ReferenceEquals(dataContext.A11yAutomation, this)) throw new ArgumentException("Called on wrong context", nameof(dataContext));
+            EnsureContextConsistency(dataContext);
 
-            // TODOL Check for consistency
             var walker = GetTreeWalker(TreeViewMode.Control);
             var tree = new DesktopElementAncestry(TreeViewMode.Control, e, false, dataContext);
             Marshal.ReleaseComObject(walker);
@@ -431,7 +430,7 @@ namespace Axe.Windows.Desktop.UIAutomation
             if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
             if (!ReferenceEquals(dataContext.A11yAutomation, this))
             {
-                throw new ArgumentException("TODO: Resource string about consistency", nameof(dataContext));
+                throw new ArgumentException(Resources.ErrorMessages.InvalidContext, nameof(dataContext));
             }
         }
     }

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -110,7 +110,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// <param name="pid"></param>
         /// <param name="dataContext">The context we're workiing with</param>
         /// <returns>return null if we fail to get elements by process Id</returns>
-        public IEnumerable<DesktopElement> ElementsFromProcessId(int pid, TreeWalkerDataContext dataContext)
+        public IEnumerable<DesktopElement> ElementsFromProcessId(int pid, DesktopDataContext dataContext)
         {
             EnsureContextConsistency(dataContext);
 
@@ -150,7 +150,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// <summary>
         /// Get DesktopElement from UIAElement interface.
         /// </summary>
-        private DesktopElement ElementFromUIAElement(IUIAutomationElement uia, TreeWalkerDataContext dataContext)
+        private DesktopElement ElementFromUIAElement(IUIAutomationElement uia, DesktopDataContext dataContext)
         {
             EnsureContextConsistency(dataContext);
             if (uia != null)
@@ -176,7 +176,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// Get DesktopElements from UIAElements.
         /// </summary>
         /// <returns>An IEnumerable of <see cref="DesktopElement"/></returns>
-        private IEnumerable<DesktopElement> ElementsFromUIAElements(IList<IUIAutomationElement> elementList, TreeWalkerDataContext dataContext)
+        private IEnumerable<DesktopElement> ElementsFromUIAElements(IList<IUIAutomationElement> elementList, DesktopDataContext dataContext)
         {
             EnsureContextConsistency(dataContext);
 
@@ -258,7 +258,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// <param name="e">A11yElement</param>
         /// <param name="dataContext">This MUST be the context that contains thia A11yAutomation object</param>
         /// <returns></returns>
-        internal A11yElement GetAppElement(A11yElement e, TreeWalkerDataContext dataContext)
+        internal A11yElement GetAppElement(A11yElement e, DesktopDataContext dataContext)
         {
             if (!ReferenceEquals(dataContext.A11yAutomation, this)) throw new ArgumentException("Called on wrong context", nameof(dataContext));
 
@@ -426,7 +426,7 @@ namespace Axe.Windows.Desktop.UIAutomation
             return new DesktopElement(UIAutomation.GetRootElement());
         }
 
-        private void EnsureContextConsistency(TreeWalkerDataContext dataContext)
+        private void EnsureContextConsistency(DesktopDataContext dataContext)
         {
             if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
             if (!ReferenceEquals(dataContext.A11yAutomation, this))

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -20,9 +20,25 @@ namespace Axe.Windows.Desktop.UIAutomation
     /// <summary>
     /// Wrapper for CUIAutomation COM object
     /// </summary>
-    public static class A11yAutomation
+    public class A11yAutomation
     {
         static readonly IUIAutomation UIAutomation = GetUIAutomationInterface();
+
+        static readonly Lazy<A11yAutomation> Lazy = new Lazy<A11yAutomation>(() => CreateInstance());
+
+        internal static A11yAutomation GetDefaultInstance() => Lazy.Value;
+
+        internal static A11yAutomation CreateInstance()
+        {
+            return new A11yAutomation();
+        }
+
+        public long TempProperty { get; }
+
+        public A11yAutomation()
+        {
+            TempProperty = DateTime.UtcNow.Ticks;
+        }
 
         private static IUIAutomation GetUIAutomationInterface()
         {

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -258,11 +258,15 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// it is trace back to the top most ancestor with same process Id.
         /// </summary>
         /// <param name="e">A11yElement</param>
+        /// <param name="dataContext">This MUST be the context that contains thia A11yAutomation object</param>
         /// <returns></returns>
-        public A11yElement GetAppElement(A11yElement e)
+        internal A11yElement GetAppElement(A11yElement e, TreeWalkerDataContext dataContext)
         {
+            if (!ReferenceEquals(dataContext.A11yAutomation, this)) throw new ArgumentException("Called on wrong context", nameof(dataContext));
+
+            // TODOL Check for consistency
             var walker = GetTreeWalker(TreeViewMode.Control);
-            var tree = new DesktopElementAncestry(TreeViewMode.Control, e);
+            var tree = new DesktopElementAncestry(TreeViewMode.Control, e, false, dataContext);
             Marshal.ReleaseComObject(walker);
             A11yElement app = tree.First;
 
@@ -419,7 +423,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// Get DesktopElement from Desktop
         /// </summary>
         /// <returns></returns>
-        public DesktopElement ElementFromDesktop()
+        public  DesktopElement ElementFromDesktop()
         {
             return new DesktopElement(_uia.GetRootElement());
         }

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -336,7 +336,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// <param name="xPos"></param>
         /// <param name="yPos"></param>
         /// <returns></returns>
-        public DesktopElement ElementFromPoint(int xPos, int yPos)
+        internal DesktopElement ElementFromPoint(int xPos, int yPos, DesktopDataContext dataContext)
         {
             try
             {
@@ -347,7 +347,7 @@ namespace Axe.Windows.Desktop.UIAutomation
 #pragma warning disable CA2000 // Call IDisposable.Dispose()
                     var e = new DesktopElement(uia, true, false);
 #pragma warning restore CA2000
-                    e.PopulateMinimumPropertiesForSelection();
+                    e.PopulateMinimumPropertiesForSelection(dataContext);
 
                     return e;
                 }
@@ -373,11 +373,11 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// <param name="yPos"></param>
         /// <param name="treeViewMode">current TreeViewMode</param>
         /// <returns></returns>
-        public A11yElement NormalizedElementFromPoint(int xPos, int yPos, TreeViewMode treeViewMode)
+        public A11yElement NormalizedElementFromPoint(int xPos, int yPos, TreeViewMode treeViewMode, DesktopDataContext dataContext)
         {
             try
             {
-                A11yElement element = ElementFromPoint(xPos, yPos);
+                A11yElement element = ElementFromPoint(xPos, yPos, dataContext);
 
                 if (element == null)
                     return null;

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -153,6 +153,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         private DesktopElement ElementFromUIAElement(IUIAutomationElement uia, DesktopDataContext dataContext)
         {
             EnsureContextConsistency(dataContext);
+
             if (uia != null)
             {
                 if (!DesktopElement.IsFromCurrentProcess(uia))
@@ -200,26 +201,6 @@ namespace Axe.Windows.Desktop.UIAutomation
             } // for each element
 
             return elements;
-        }
-
-        /// <summary>
-        /// Get the top level IUIAutomationElement from Windows handle
-        /// </summary>
-        /// <param name="hWnd"></param>
-        /// <returns></returns>
-        public IUIAutomationElement UIAElementFromHandle(IntPtr hWnd)
-        {
-            try
-            {
-                return UIAutomation.ElementFromHandle(hWnd);
-            }
-#pragma warning disable CA1031 // Do not catch general exception types
-            catch (Exception e)
-            {
-                e.ReportException();
-                return null;
-            }
-#pragma warning restore CA1031 // Do not catch general exception types
         }
 
         /// <summary>
@@ -335,9 +316,12 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// </summary>
         /// <param name="xPos"></param>
         /// <param name="yPos"></param>
+        /// <param name="dataContext">The current data context</param>
         /// <returns></returns>
         internal DesktopElement ElementFromPoint(int xPos, int yPos, DesktopDataContext dataContext)
         {
+            EnsureContextConsistency(dataContext);
+
             try
             {
                 var uia = UIAutomation.ElementFromPoint(new tagPOINT() { x = xPos, y = yPos });
@@ -372,9 +356,12 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// <param name="xPos"></param>
         /// <param name="yPos"></param>
         /// <param name="treeViewMode">current TreeViewMode</param>
+        /// <param name="dataContext">The current data context</param>
         /// <returns></returns>
         public A11yElement NormalizedElementFromPoint(int xPos, int yPos, TreeViewMode treeViewMode, DesktopDataContext dataContext)
         {
+            EnsureContextConsistency(dataContext);
+
             try
             {
                 A11yElement element = ElementFromPoint(xPos, yPos, dataContext);
@@ -404,25 +391,6 @@ namespace Axe.Windows.Desktop.UIAutomation
 #pragma warning restore CA1031 // Do not catch general exception types
 
             return null;
-        }
-
-        /// <summary>
-        /// Get Property programmatic Name from UIA service.
-        /// </summary>
-        /// <param name="pid"></param>
-        /// <returns></returns>
-        public string GetPropertyProgrammaticName(int pid)
-        {
-            return UIAutomation.GetPropertyProgrammaticName(pid);
-        }
-
-        /// <summary>
-        /// Get DesktopElement from Desktop
-        /// </summary>
-        /// <returns></returns>
-        public  DesktopElement ElementFromDesktop()
-        {
-            return new DesktopElement(UIAutomation.GetRootElement());
         }
 
         private void EnsureContextConsistency(DesktopDataContext dataContext)

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -175,10 +175,8 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// Get DesktopElements from UIAElements.
         /// </summary>
         /// <returns>An IEnumerable of <see cref="DesktopElement"/></returns>
-        private IEnumerable<DesktopElement> ElementsFromUIAElements(IList<IUIAutomationElement> elementList, DesktopDataContext dataContext)
+        private static IEnumerable<DesktopElement> ElementsFromUIAElements(IList<IUIAutomationElement> elementList, DesktopDataContext dataContext)
         {
-            EnsureContextConsistency(dataContext);
-
             if (elementList == null) throw new ArgumentNullException(nameof(elementList));
 
             // Return an empty IEnumerable<DesktopElement> instead of null from ElementsFromUIAElements so that downstream calls to Linq extensions on the IEnumerable don't throw null reference exceptions.

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -242,7 +242,7 @@ namespace Axe.Windows.Desktop.UIAutomation
             EnsureContextConsistency(dataContext);
 
             var walker = GetTreeWalker(TreeViewMode.Control);
-            var tree = new DesktopElementAncestry(TreeViewMode.Control, e, false, dataContext);
+            var tree = new DesktopElementAncestry(TreeViewMode.Control, e, dataContext);
             Marshal.ReleaseComObject(walker);
             A11yElement app = tree.First;
 

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -150,10 +150,8 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// <summary>
         /// Get DesktopElement from UIAElement interface.
         /// </summary>
-        private DesktopElement ElementFromUIAElement(IUIAutomationElement uia, DesktopDataContext dataContext)
+        private static DesktopElement ElementFromUIAElement(IUIAutomationElement uia, DesktopDataContext dataContext)
         {
-            EnsureContextConsistency(dataContext);
-
             if (uia != null)
             {
                 if (!DesktopElement.IsFromCurrentProcess(uia))

--- a/src/Desktop/UIAutomation/DesktopDataContext.cs
+++ b/src/Desktop/UIAutomation/DesktopDataContext.cs
@@ -4,14 +4,14 @@
 using Axe.Windows.Desktop.UIAutomation.CustomObjects;
 using System.Threading;
 
-namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
+namespace Axe.Windows.Desktop.UIAutomation
 {
     /// <summary>
     /// Data context for refreshing tree data for test
     /// </summary>
-    public class TreeWalkerDataContext
+    public class DesktopDataContext
     {
-        public static readonly TreeWalkerDataContext DefaultContext = new TreeWalkerDataContext(Registrar.GetDefaultInstance(), A11yAutomation.GetDefaultInstance(), CancellationToken.None);
+        public static readonly DesktopDataContext DefaultContext = new DesktopDataContext(Registrar.GetDefaultInstance(), A11yAutomation.GetDefaultInstance(), CancellationToken.None);
 
         public Registrar Registrar { get; }
 
@@ -19,7 +19,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 
         public CancellationToken CancellationToken { get; }
 
-        public TreeWalkerDataContext(Registrar registrar, A11yAutomation a11yAutomation, CancellationToken cancellationToken)
+        public DesktopDataContext(Registrar registrar, A11yAutomation a11yAutomation, CancellationToken cancellationToken)
         {
             Registrar = registrar;
             A11yAutomation = a11yAutomation;

--- a/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
+++ b/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
@@ -4,7 +4,7 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;
-using Axe.Windows.Desktop.UIAutomation.CustomObjects;
+using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using Axe.Windows.Telemetry;
 using Axe.Windows.Win32;
 using System;
@@ -40,7 +40,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// it would make Ux and Runtime separation easier since all communication is done via Actions.
         /// </summary>
         /// <param name="element"></param>
-        public static void PopulateAllPropertiesWithLiveData(this A11yElement element, Registrar registrar = null)
+        public static void PopulateAllPropertiesWithLiveData(this A11yElement element, TreeWalkerDataContext dataContext = null) // TODO Check default here!
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
 
@@ -48,7 +48,7 @@ namespace Axe.Windows.Desktop.UIAutomation
 
             if (element.IsSafeToRefresh())
             {
-                element.PopulatePropertiesAndPatternsFromCache(registrar);
+                element.PopulatePropertiesAndPatternsFromCache(dataContext);
                 element.PopulatePlatformProperties();
             }
         }
@@ -60,11 +60,11 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// - BoundingRectangle
         /// </summary>
         /// <param name="element"></param>
-        public static void PopulateMinimumPropertiesForSelection(this A11yElement element, Registrar registrar = null)
+        public static void PopulateMinimumPropertiesForSelection(this A11yElement element, TreeWalkerDataContext dataContext = null) // TODO
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
 
-            element.PopulateWithIndicatedProperties(MiniumProperties, registrar);
+            element.PopulateWithIndicatedProperties(MiniumProperties, dataContext);
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// </summary>
         /// <param name="element"></param>
         /// <param name="list"></param>
-        private static void PopulateWithIndicatedProperties(this A11yElement element, List<int> list, Registrar registrar)
+        private static void PopulateWithIndicatedProperties(this A11yElement element, List<int> list, TreeWalkerDataContext dataContext)
         {
             element.Clear();
             if (element.IsSafeToRefresh())
@@ -105,7 +105,7 @@ namespace Axe.Windows.Desktop.UIAutomation
                 A11yAutomation.UIAutomationObject.PollForPotentialSupportedProperties((IUIAutomationElement)element.PlatformObject, out int[] ppids, out string[] ppns);
 
                 // build a cache based on the lists
-                var cache = DesktopElementHelper.BuildCacheRequest(list, null, registrar);
+                var cache = DesktopElementHelper.BuildCacheRequest(list, null, dataContext);
 
                 // buildupdate cached element
                 var uia = ((IUIAutomationElement)element.PlatformObject).BuildUpdatedCache(cache);
@@ -128,14 +128,16 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// </summary>
         /// <param name="e"></param>
         /// <returns>if element is not live, don't allow clone</returns>
-        public static A11yElement CloneForSelection(this A11yElement e)
+        public static A11yElement CloneForSelection(this A11yElement e, TreeWalkerDataContext dataContext)
         {
+            if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
+
             if (e == null) return null;
             if (e.PlatformObject == null) return null;
 
             try
             {
-                var cache = DesktopElementHelper.BuildCacheRequest(MiniumProperties, null);
+                var cache = DesktopElementHelper.BuildCacheRequest(MiniumProperties, null, dataContext);
 
                 var uia = ((IUIAutomationElement)e.PlatformObject).BuildUpdatedCache(cache);
                 Marshal.ReleaseComObject(cache);
@@ -236,7 +238,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// the update is done via caching to improve performance.
         /// </summary>
         /// <param name="useProperties">default is false to refresh it from UIElement directly</param>
-        private static void PopulatePropertiesAndPatternsFromCache(this A11yElement element, Registrar registrar)
+        private static void PopulatePropertiesAndPatternsFromCache(this A11yElement element, TreeWalkerDataContext dataContext)
         {
             try
             {
@@ -270,7 +272,7 @@ namespace Axe.Windows.Desktop.UIAutomation
                               select pt.Item1).ToList();
 
                 // build a cache based on the lists
-                var cache = DesktopElementHelper.BuildCacheRequest(pplist, ptlist, registrar);
+                var cache = DesktopElementHelper.BuildCacheRequest(pplist, ptlist, dataContext);
 
                 // buildupdate cached element
                 var uia = ((IUIAutomationElement)element.PlatformObject).BuildUpdatedCache(cache);

--- a/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
+++ b/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
@@ -4,7 +4,6 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;
-using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using Axe.Windows.Telemetry;
 using Axe.Windows.Win32;
 using System;
@@ -40,8 +39,9 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// it would make Ux and Runtime separation easier since all communication is done via Actions.
         /// </summary>
         /// <param name="element"></param>
-        public static void PopulateAllPropertiesWithLiveData(this A11yElement element, TreeWalkerDataContext dataContext = null) // TODO Check default here!
+        public static void PopulateAllPropertiesWithLiveData(this A11yElement element, DesktopDataContext dataContext = null) // TODO DHT Check default here!
         {
+            dataContext = dataContext ?? DesktopDataContext.DefaultContext; // TODO DHT: Review!
             if (element == null) throw new ArgumentNullException(nameof(element));
 
             element.Clear();
@@ -60,8 +60,9 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// - BoundingRectangle
         /// </summary>
         /// <param name="element"></param>
-        public static void PopulateMinimumPropertiesForSelection(this A11yElement element, TreeWalkerDataContext dataContext = null) // TODO
+        public static void PopulateMinimumPropertiesForSelection(this A11yElement element, DesktopDataContext dataContext = null) // TODO DHT: Remove default?
         {
+            dataContext = dataContext ?? DesktopDataContext.DefaultContext; // TODO DHT: Review!
             if (element == null) throw new ArgumentNullException(nameof(element));
 
             element.PopulateWithIndicatedProperties(MiniumProperties, dataContext);
@@ -97,7 +98,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// </summary>
         /// <param name="element"></param>
         /// <param name="list"></param>
-        private static void PopulateWithIndicatedProperties(this A11yElement element, List<int> list, TreeWalkerDataContext dataContext)
+        private static void PopulateWithIndicatedProperties(this A11yElement element, List<int> list, DesktopDataContext dataContext)
         {
             element.Clear();
             if (element.IsSafeToRefresh())
@@ -128,7 +129,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// </summary>
         /// <param name="e"></param>
         /// <returns>if element is not live, don't allow clone</returns>
-        public static A11yElement CloneForSelection(this A11yElement e, TreeWalkerDataContext dataContext)
+        public static A11yElement CloneForSelection(this A11yElement e, DesktopDataContext dataContext)
         {
             if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 
@@ -238,7 +239,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// the update is done via caching to improve performance.
         /// </summary>
         /// <param name="useProperties">default is false to refresh it from UIElement directly</param>
-        private static void PopulatePropertiesAndPatternsFromCache(this A11yElement element, TreeWalkerDataContext dataContext)
+        private static void PopulatePropertiesAndPatternsFromCache(this A11yElement element, DesktopDataContext dataContext)
         {
             try
             {
@@ -519,7 +520,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// Requesting the clickable point property in Edge can cause a crash,
         /// so the clickable point property is not initially populated by <see cref="DesktopElementExtensionMethods.PopulatePropertiesAndPatternsFromCache(A11yElement)"/>.
         /// </remarks>
-        private static void InitClickablePointProperty(this A11yElement a11yElement, IUIAutomationElement uiaElement, TreeWalkerDataContext dataContext)
+        private static void InitClickablePointProperty(this A11yElement a11yElement, IUIAutomationElement uiaElement, DesktopDataContext dataContext)
         {
             if (a11yElement.IsEdgeElement()) return;
 

--- a/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
+++ b/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
@@ -102,7 +102,7 @@ namespace Axe.Windows.Desktop.UIAutomation
             element.Clear();
             if (element.IsSafeToRefresh())
             {
-                A11yAutomation.UIAutomationObject.PollForPotentialSupportedProperties((IUIAutomationElement)element.PlatformObject, out int[] ppids, out string[] ppns);
+                dataContext.A11yAutomation.UIAutomation.PollForPotentialSupportedProperties((IUIAutomationElement)element.PlatformObject, out int[] ppids, out string[] ppns);
 
                 // build a cache based on the lists
                 var cache = DesktopElementHelper.BuildCacheRequest(list, null, dataContext);
@@ -243,7 +243,7 @@ namespace Axe.Windows.Desktop.UIAutomation
             try
             {
                 // Get the list of properties to retrieve
-                A11yAutomation.UIAutomationObject.PollForPotentialSupportedProperties((IUIAutomationElement)element.PlatformObject, out int[] ppids, out string[] ppns);
+                dataContext.A11yAutomation.UIAutomation.PollForPotentialSupportedProperties((IUIAutomationElement)element.PlatformObject, out int[] ppids, out string[] ppns);
 
                 var ppl = new List<Tuple<int, string>>();
 
@@ -258,7 +258,7 @@ namespace Axe.Windows.Desktop.UIAutomation
                     }
                 }
 
-                A11yAutomation.UIAutomationObject.PollForPotentialSupportedPatterns((IUIAutomationElement)element.PlatformObject, out int[] ptids, out string[] ptns);
+                dataContext.A11yAutomation.UIAutomation.PollForPotentialSupportedPatterns((IUIAutomationElement)element.PlatformObject, out int[] ptids, out string[] ptns);
                 var ptl = new List<Tuple<int, string>>();
 
                 for (int i = 0; i < ptids.Length; i++)
@@ -287,7 +287,7 @@ namespace Axe.Windows.Desktop.UIAutomation
 
                 element.UpdateGlimpse();
 
-                element.InitClickablePointProperty(uia);
+                element.InitClickablePointProperty(uia, dataContext);
 
                 // retrieve patterns from cache
                 var ptlst = from pt in ptl
@@ -519,7 +519,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// Requesting the clickable point property in Edge can cause a crash,
         /// so the clickable point property is not initially populated by <see cref="DesktopElementExtensionMethods.PopulatePropertiesAndPatternsFromCache(A11yElement)"/>.
         /// </remarks>
-        private static void InitClickablePointProperty(this A11yElement a11yElement, IUIAutomationElement uiaElement)
+        private static void InitClickablePointProperty(this A11yElement a11yElement, IUIAutomationElement uiaElement, TreeWalkerDataContext dataContext)
         {
             if (a11yElement.IsEdgeElement()) return;
 
@@ -528,7 +528,7 @@ namespace Axe.Windows.Desktop.UIAutomation
             double[] clickablePoint = uiaElement.GetCurrentPropertyValue(id);
             if (clickablePoint == null) return;
 
-            string name = A11yAutomation.UIAutomationObject.GetPropertyProgrammaticName(id);
+            string name = dataContext.A11yAutomation.UIAutomation.GetPropertyProgrammaticName(id);
 
             var prop = new A11yProperty
             {

--- a/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
+++ b/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
@@ -39,9 +39,13 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// it would make Ux and Runtime separation easier since all communication is done via Actions.
         /// </summary>
         /// <param name="element"></param>
-        public static void PopulateAllPropertiesWithLiveData(this A11yElement element, DesktopDataContext dataContext = null) // TODO DHT Check default here!
+        public static void PopulateAllPropertiesWithLiveData(this A11yElement element)
         {
-            dataContext = dataContext ?? DesktopDataContext.DefaultContext; // TODO DHT: Review!
+            element.PopulateAllPropertiesWithLiveData(DesktopDataContext.DefaultContext);
+        }
+
+        internal static void PopulateAllPropertiesWithLiveData(this A11yElement element, DesktopDataContext dataContext)
+        {
             if (element == null) throw new ArgumentNullException(nameof(element));
 
             element.Clear();
@@ -60,9 +64,8 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// - BoundingRectangle
         /// </summary>
         /// <param name="element"></param>
-        public static void PopulateMinimumPropertiesForSelection(this A11yElement element, DesktopDataContext dataContext = null) // TODO DHT: Remove default?
+        internal static void PopulateMinimumPropertiesForSelection(this A11yElement element, DesktopDataContext dataContext)
         {
-            dataContext = dataContext ?? DesktopDataContext.DefaultContext; // TODO DHT: Review!
             if (element == null) throw new ArgumentNullException(nameof(element));
 
             element.PopulateWithIndicatedProperties(MiniumProperties, dataContext);
@@ -144,7 +147,7 @@ namespace Axe.Windows.Desktop.UIAutomation
                 Marshal.ReleaseComObject(cache);
 
                 var ne = new DesktopElement(uia, true, false);
-                ne.PopulateMinimumPropertiesForSelection();
+                ne.PopulateMinimumPropertiesForSelection(dataContext);
 
                 return ne;
             }

--- a/src/Desktop/UIAutomation/DesktopElementHelper.cs
+++ b/src/Desktop/UIAutomation/DesktopElementHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Desktop.UIAutomation.CustomObjects;
+using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using System;
 using System.Collections.Generic;
 using UIAutomationClient;
@@ -18,9 +19,9 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// </summary>
         /// <param name="pps">Property ids</param>
         /// <param name="pts">Pattern ids</param>
-        public static IUIAutomationCacheRequest BuildCacheRequest(IEnumerable<int> pps, IEnumerable<int> pts, Registrar registrar = null)
+        public static IUIAutomationCacheRequest BuildCacheRequest(IEnumerable<int> pps, IEnumerable<int> pts, TreeWalkerDataContext dataContext)
         {
-            return GetPropertiesCache(A11yAutomation.UIAutomationObject, pps, pts, registrar);
+            return GetPropertiesCache(A11yAutomation.UIAutomationObject, pps, pts, dataContext.Registrar);
         }
 
         /// <summary>

--- a/src/Desktop/UIAutomation/DesktopElementHelper.cs
+++ b/src/Desktop/UIAutomation/DesktopElementHelper.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Desktop.UIAutomation.CustomObjects;
-using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using System;
 using System.Collections.Generic;
 using UIAutomationClient;
@@ -19,7 +18,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// </summary>
         /// <param name="pps">Property ids</param>
         /// <param name="pts">Pattern ids</param>
-        public static IUIAutomationCacheRequest BuildCacheRequest(IEnumerable<int> pps, IEnumerable<int> pts, TreeWalkerDataContext dataContext)
+        public static IUIAutomationCacheRequest BuildCacheRequest(IEnumerable<int> pps, IEnumerable<int> pts, DesktopDataContext dataContext)
         {
             return GetPropertiesCache(dataContext.A11yAutomation.UIAutomation, pps, pts, dataContext.Registrar);
         }

--- a/src/Desktop/UIAutomation/DesktopElementHelper.cs
+++ b/src/Desktop/UIAutomation/DesktopElementHelper.cs
@@ -21,7 +21,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// <param name="pts">Pattern ids</param>
         public static IUIAutomationCacheRequest BuildCacheRequest(IEnumerable<int> pps, IEnumerable<int> pts, TreeWalkerDataContext dataContext)
         {
-            return GetPropertiesCache(A11yAutomation.UIAutomationObject, pps, pts, dataContext.Registrar);
+            return GetPropertiesCache(dataContext.A11yAutomation.UIAutomation, pps, pts, dataContext.Registrar);
         }
 
         /// <summary>

--- a/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
@@ -74,7 +74,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
                 if (this.Last.IsRootElement() == false)
                 {
                     this.Last.Children.Clear();
-                    this.NextId = PopulateSiblingTreeNodes(this.Last, e);
+                    this.NextId = PopulateSiblingTreeNodes(this.Last, e, dataContext);
                 }
                 else
                 {
@@ -133,7 +133,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// <param name="parentNode"></param>
         /// <param name="poiNode"></param>
         /// <param name="startId"></param>
-        private int PopulateSiblingTreeNodes(A11yElement parentNode, A11yElement poiNode)
+        private int PopulateSiblingTreeNodes(A11yElement parentNode, A11yElement poiNode, DesktopDataContext dataContext)
         {
             int childId = 1;
 
@@ -159,7 +159,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 #pragma warning disable CA2000 // Use recommended dispose patterns
                     var childNode = new DesktopElement(child, true, false);
 #pragma warning restore CA2000 // Use recommended dispose patterns
-                    childNode.PopulateMinimumPropertiesForSelection();
+                    childNode.PopulateMinimumPropertiesForSelection(dataContext);
 
                     if (childNode.IsSameUIElement(poiNode) == false)
                     {

--- a/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
@@ -36,11 +36,6 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         public TreeViewMode TreeWalkerMode { get; }
 
         /// <summary>
-        /// Parent elements' SetMembers value
-        /// </summary>
-        bool SetMembers { get; set; }
-
-        /// <summary>
         /// Id for next element
         /// it will be used in Tree Walker.
         /// </summary>
@@ -53,18 +48,17 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// <param name="walker"></param>
         /// <param name="e"></param>
         public DesktopElementAncestry(TreeViewMode mode, A11yElement e)
-            : this (mode, e, false, DesktopDataContext.DefaultContext)
+            : this (mode, e, DesktopDataContext.DefaultContext)
         {
         }
 
-        internal DesktopElementAncestry(TreeViewMode mode, A11yElement e, bool setMem, DesktopDataContext dataContext)
+        internal DesktopElementAncestry(TreeViewMode mode, A11yElement e, DesktopDataContext dataContext)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             this.TreeWalker = dataContext.A11yAutomation.GetTreeWalker(mode);
             this.TreeWalkerMode = mode;
             this.Items = new List<A11yElement>();
-            this.SetMembers = setMem;
             SetParent(e, -1, dataContext);
 
             if (Items.Count != 0)
@@ -100,7 +94,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
                 if (puia == null) return;
 
 #pragma warning disable CA2000 // Call IDisposable.Dispose()
-                var parent = new DesktopElement(puia, true, SetMembers);
+                var parent = new DesktopElement(puia, true, false);
                 parent.PopulateMinimumPropertiesForSelection(dataContext);
 
                 // we need to avoid infinite loop of self reference as parent.

--- a/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
@@ -52,15 +52,20 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// </summary>
         /// <param name="walker"></param>
         /// <param name="e"></param>
-        public DesktopElementAncestry(TreeViewMode mode, A11yElement e, bool setMem = false, Registrar registrar = null)
+        public DesktopElementAncestry(TreeViewMode mode, A11yElement e)
+            : this (mode, e, false, TreeWalkerDataContext.DefaultContext)
+        {
+        }
+
+        internal DesktopElementAncestry(TreeViewMode mode, A11yElement e, bool setMem, TreeWalkerDataContext dataContext)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            this.TreeWalker = A11yAutomation.GetTreeWalker(mode);
+            this.TreeWalker = dataContext.A11yAutomation.GetTreeWalker(mode);
             this.TreeWalkerMode = mode;
             this.Items = new List<A11yElement>();
             this.SetMembers = setMem;
-            SetParent(e, -1, registrar: registrar);
+            SetParent(e, -1, registrar: dataContext.Registrar);
 
             if (Items.Count != 0)
             {

--- a/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
@@ -65,7 +65,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             this.TreeWalkerMode = mode;
             this.Items = new List<A11yElement>();
             this.SetMembers = setMem;
-            SetParent(e, -1, registrar: dataContext.Registrar);
+            SetParent(e, -1, dataContext);
 
             if (Items.Count != 0)
             {
@@ -90,7 +90,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// </summary>
         /// <param name="e"></param>
         /// <param name="uniqueId"></param>
-        private void SetParent(A11yElement e, int uniqueId, Registrar registrar)
+        private void SetParent(A11yElement e, int uniqueId, TreeWalkerDataContext dataContext)
         {
             if (e == null || e.PlatformObject == null || e.IsRootElement()) return;
 
@@ -101,7 +101,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 
 #pragma warning disable CA2000 // Call IDisposable.Dispose()
                 var parent = new DesktopElement(puia, true, SetMembers);
-                parent.PopulateMinimumPropertiesForSelection(registrar);
+                parent.PopulateMinimumPropertiesForSelection(dataContext);
 
                 // we need to avoid infinite loop of self reference as parent.
                 // it is a probably a bug in UIA or the target app.
@@ -113,7 +113,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
                     this.Items.Add(parent);
                     parent.UniqueId = uniqueId;
 
-                    SetParent(parent, uniqueId - 1, registrar);
+                    SetParent(parent, uniqueId - 1, dataContext);
                 }
 #pragma warning restore CA2000
             }

--- a/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
@@ -53,11 +53,11 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// <param name="walker"></param>
         /// <param name="e"></param>
         public DesktopElementAncestry(TreeViewMode mode, A11yElement e)
-            : this (mode, e, false, TreeWalkerDataContext.DefaultContext)
+            : this (mode, e, false, DesktopDataContext.DefaultContext)
         {
         }
 
-        internal DesktopElementAncestry(TreeViewMode mode, A11yElement e, bool setMem, TreeWalkerDataContext dataContext)
+        internal DesktopElementAncestry(TreeViewMode mode, A11yElement e, bool setMem, DesktopDataContext dataContext)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
@@ -90,7 +90,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// </summary>
         /// <param name="e"></param>
         /// <param name="uniqueId"></param>
-        private void SetParent(A11yElement e, int uniqueId, TreeWalkerDataContext dataContext)
+        private void SetParent(A11yElement e, int uniqueId, DesktopDataContext dataContext)
         {
             if (e == null || e.PlatformObject == null || e.IsRootElement()) return;
 

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerDataContext.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerDataContext.cs
@@ -11,15 +11,18 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
     /// </summary>
     public class TreeWalkerDataContext
     {
-        public static readonly TreeWalkerDataContext DefaultContext = new TreeWalkerDataContext(Registrar.GetDefaultInstance(), CancellationToken.None);
+        public static readonly TreeWalkerDataContext DefaultContext = new TreeWalkerDataContext(Registrar.GetDefaultInstance(), A11yAutomation.GetDefaultInstance(), CancellationToken.None);
 
         public Registrar Registrar { get; }
 
+        public A11yAutomation A11yAutomation { get; }
+
         public CancellationToken CancellationToken { get; }
 
-        public TreeWalkerDataContext(Registrar registrar, CancellationToken cancellationToken)
+        public TreeWalkerDataContext(Registrar registrar, A11yAutomation a11yAutomation, CancellationToken cancellationToken)
         {
             Registrar = registrar;
+            A11yAutomation = a11yAutomation;
             CancellationToken = cancellationToken;
         }
     }

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
@@ -68,7 +68,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 
             //Set parent of Root explicitly for testing.
             A11yElement parent = null;
-            var ancestry = new DesktopElementAncestry(this.WalkerMode, e, false, dataContext);
+            var ancestry = new DesktopElementAncestry(this.WalkerMode, e, dataContext);
             parent = ancestry.Last;
 
             this.RootElement = ancestry.First;

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
@@ -87,7 +87,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             // populate descendant Elements first in parallel
             this.Elements.AsParallel().ForAll(el =>
             {
-                el.PopulateMinimumPropertiesForSelection();
+                el.PopulateMinimumPropertiesForSelection(dataContext);
             });
 
             // Add ancestry into Elements list.

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
@@ -16,7 +16,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
     {
         IList<A11yElement> Elements { get; }
         A11yElement RootElement { get; }
-        void GetTreeHierarchy(A11yElement e, TreeViewMode mode);
+        void GetTreeHierarchy(A11yElement e, TreeViewMode mode, TreeWalkerDataContext dataContext);
     }
 
     /// <summary>
@@ -58,8 +58,8 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// </summary>
         /// <param name="e"></param>
         /// <param name="mode"></param>
-        /// <param name="showAncestry"></param>
-        public void GetTreeHierarchy(A11yElement e, TreeViewMode mode)
+        /// <param name="dataContext"></param>
+        public void GetTreeHierarchy(A11yElement e, TreeViewMode mode, TreeWalkerDataContext dataContext)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
@@ -68,7 +68,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 
             //Set parent of Root explicitly for testing.
             A11yElement parent = null;
-            var ancestry = new DesktopElementAncestry(this.WalkerMode, e);
+            var ancestry = new DesktopElementAncestry(this.WalkerMode, e, false, dataContext);
             parent = ancestry.Last;
 
             this.RootElement = ancestry.First;
@@ -82,7 +82,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             e.UniqueId = 0; // it is the selected element which should be id 0.
             this.Elements.Add(e);
 
-            PopulateChildrenTreeNode(e, ancestry.NextId);
+            PopulateChildrenTreeNode(e, ancestry.NextId, dataContext);
 
             // populate descendant Elements first in parallel
             this.Elements.AsParallel().ForAll(el =>
@@ -103,11 +103,11 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// Populate tree by retrieving all children at once.
         /// </summary>
         /// <param name="rootNode"></param>
-        private void PopulateChildrenTreeNode(A11yElement rootNode, int startId)
+        private void PopulateChildrenTreeNode(A11yElement rootNode, int startId, TreeWalkerDataContext dataContext)
         {
             int childId = startId;
 
-            IUIAutomationTreeWalker walker = A11yAutomation.GetTreeWalker(this.WalkerMode);
+            IUIAutomationTreeWalker walker = dataContext.A11yAutomation.GetTreeWalker(this.WalkerMode);
             IUIAutomationElement child = (IUIAutomationElement)rootNode.PlatformObject;
 
             if (child != null)

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
@@ -16,7 +16,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
     {
         IList<A11yElement> Elements { get; }
         A11yElement RootElement { get; }
-        void GetTreeHierarchy(A11yElement e, TreeViewMode mode, TreeWalkerDataContext dataContext);
+        void GetTreeHierarchy(A11yElement e, TreeViewMode mode, DesktopDataContext dataContext);
     }
 
     /// <summary>
@@ -59,7 +59,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// <param name="e"></param>
         /// <param name="mode"></param>
         /// <param name="dataContext"></param>
-        public void GetTreeHierarchy(A11yElement e, TreeViewMode mode, TreeWalkerDataContext dataContext)
+        public void GetTreeHierarchy(A11yElement e, TreeViewMode mode, DesktopDataContext dataContext)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
@@ -103,7 +103,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// Populate tree by retrieving all children at once.
         /// </summary>
         /// <param name="rootNode"></param>
-        private void PopulateChildrenTreeNode(A11yElement rootNode, int startId, TreeWalkerDataContext dataContext)
+        private void PopulateChildrenTreeNode(A11yElement rootNode, int startId, DesktopDataContext dataContext)
         {
             int childId = startId;
 

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -71,7 +71,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             }
 
             //Set parent of Root explicitly for testing.
-            var ancestry = new DesktopElementAncestry(this.WalkerMode, this.SelectedElement, false, dataContext);
+            var ancestry = new DesktopElementAncestry(this.WalkerMode, this.SelectedElement, dataContext);
 
             // Pre-count the ancestors in our bounded count, so that our count is accurate
             _elementCounter.TryAdd(ancestry.Items.Count);

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -20,7 +20,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
     {
         IList<A11yElement> Elements { get; }
         A11yElement TopMostElement { get; }
-        void RefreshTreeData(TreeViewMode mode, TreeWalkerDataContext dataContext);
+        void RefreshTreeData(TreeViewMode mode, DesktopDataContext dataContext);
     }
 
     /// <summary>
@@ -60,7 +60,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// Refresh tree node data with all children at once.
         /// <param name="mode">indicate the mode</param>
         /// </summary>
-        public void RefreshTreeData(TreeViewMode mode, TreeWalkerDataContext dataContext)
+        public void RefreshTreeData(TreeViewMode mode, DesktopDataContext dataContext)
         {
             dataContext.CancellationToken.ThrowIfCancellationRequested();
 
@@ -126,7 +126,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// <param name="rootNode"></param>
         /// <param name="parentNode"></param>
         /// <param name="startChildId"></param>
-        private int PopulateChildrenTreeNode(A11yElement rootNode, A11yElement parentNode, int startChildId, TreeWalkerDataContext dataContext)
+        private int PopulateChildrenTreeNode(A11yElement rootNode, A11yElement parentNode, int startChildId, DesktopDataContext dataContext)
         {
             this.Elements.Add(rootNode);
 

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -71,7 +71,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             }
 
             //Set parent of Root explicitly for testing.
-            var ancestry = new DesktopElementAncestry(this.WalkerMode, this.SelectedElement, registrar: dataContext.Registrar);
+            var ancestry = new DesktopElementAncestry(this.WalkerMode, this.SelectedElement, false, dataContext);
 
             // Pre-count the ancestors in our bounded count, so that our count is accurate
             _elementCounter.TryAdd(ancestry.Items.Count);
@@ -82,7 +82,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             ListHelper.DisposeAllItemsAndClearList(this.SelectedElement.Children);
             this.SelectedElement.UniqueId = 0;
 
-            PopulateChildrenTreeNode(this.SelectedElement, ancestry.Last, ancestry.NextId);
+            PopulateChildrenTreeNode(this.SelectedElement, ancestry.Last, ancestry.NextId, dataContext);
 
             // do population of ancestors all together with children
             var list = new List<A11yElement>(this.Elements);
@@ -126,14 +126,14 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// <param name="rootNode"></param>
         /// <param name="parentNode"></param>
         /// <param name="startChildId"></param>
-        private int PopulateChildrenTreeNode(A11yElement rootNode, A11yElement parentNode, int startChildId)
+        private int PopulateChildrenTreeNode(A11yElement rootNode, A11yElement parentNode, int startChildId, TreeWalkerDataContext dataContext)
         {
             this.Elements.Add(rootNode);
 
             rootNode.Parent = parentNode;
             rootNode.TreeWalkerMode = this.WalkerMode; // set tree walker mode.
 
-            IUIAutomationTreeWalker walker = A11yAutomation.GetTreeWalker(this.WalkerMode);
+            IUIAutomationTreeWalker walker = dataContext.A11yAutomation.GetTreeWalker(this.WalkerMode);
             IUIAutomationElement child = (IUIAutomationElement)rootNode.PlatformObject;
 
             if (child != null)
@@ -161,7 +161,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
                     rootNode.Children.Add(childNode);
                     childNode.Parent = rootNode;
                     childNode.UniqueId = startChildId++;
-                    startChildId = PopulateChildrenTreeNode(childNode, rootNode, startChildId);
+                    startChildId = PopulateChildrenTreeNode(childNode, rootNode, startChildId, dataContext);
                     try
                     {
                         child = walker.GetNextSiblingElement(child);

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -92,14 +92,14 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             }
 
             // populate Elements first
-            this.Elements.AsParallel().ForAll(e => e.PopulateAllPropertiesWithLiveData(dataContext.Registrar));
+            this.Elements.AsParallel().ForAll(e => e.PopulateAllPropertiesWithLiveData(dataContext));
 
             // check whether there is any elements which couldn't be updated in parallel, if so, update it in sequence.
             var nuel = this.Elements.Where(e => e.Properties == null);
 
             if (nuel.Any())
             {
-                nuel.ToList().ForEach(e => e.PopulateAllPropertiesWithLiveData(dataContext.Registrar));
+                nuel.ToList().ForEach(e => e.PopulateAllPropertiesWithLiveData(dataContext));
             }
 
             // run tests

--- a/src/DesktopTests/UIAutomation/DesktopDataContextTests.cs
+++ b/src/DesktopTests/UIAutomation/DesktopDataContextTests.cs
@@ -1,21 +1,21 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Axe.Windows.Desktop.UIAutomation;
 using Axe.Windows.Desktop.UIAutomation.CustomObjects;
-using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading;
 
-namespace Axe.Windows.DesktopTests.UIAutomation.TreeWalkers
+namespace Axe.Windows.DesktopTests.UIAutomation
 {
     [TestClass]
-    public class TreeWalkerDataContextTests
+    public class DesktopDataContextTests
     {
         [TestMethod]
         [Timeout(1000)]
         public void DefaultContext_Registrar_IsDefaultRegistrar()
         {
-            var registrar = TreeWalkerDataContext.DefaultContext.Registrar;
+            var registrar = DesktopDataContext.DefaultContext.Registrar;
 
             Assert.IsNotNull(registrar);
             Assert.AreSame(Registrar.GetDefaultInstance(), registrar);

--- a/src/DesktopTests/UIAutomation/DesktopDataContextTests.cs
+++ b/src/DesktopTests/UIAutomation/DesktopDataContextTests.cs
@@ -20,5 +20,37 @@ namespace Axe.Windows.DesktopTests.UIAutomation
             Assert.IsNotNull(registrar);
             Assert.AreSame(Registrar.GetDefaultInstance(), registrar);
         }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void DefaultContext_A11yAutomation_IsDefaultRegistrar()
+        {
+            var a11yAutomation = DesktopDataContext.DefaultContext.A11yAutomation;
+
+            Assert.IsNotNull(a11yAutomation);
+            Assert.AreSame(A11yAutomation.GetDefaultInstance(), a11yAutomation);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void DefaultContext_CancellationToken_IsCancellationTokenNone()
+        {
+            var cancellationToken = DesktopDataContext.DefaultContext.CancellationToken;
+
+            Assert.AreEqual(CancellationToken.None, cancellationToken);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void CancellationToken_CancelSource_CancelsToken()
+        {
+            var source = new CancellationTokenSource();
+
+            DesktopDataContext dataContext = new DesktopDataContext(null, null, source.Token);
+
+            Assert.IsFalse(dataContext.CancellationToken.IsCancellationRequested);
+            source.Cancel();
+            Assert.IsTrue(dataContext.CancellationToken.IsCancellationRequested);
+        }
     }
 }

--- a/src/DesktopTests/UIAutomation/TreeWalkers/TreeWalkerForTestTests.cs
+++ b/src/DesktopTests/UIAutomation/TreeWalkers/TreeWalkerForTestTests.cs
@@ -4,6 +4,7 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;
+using Axe.Windows.Desktop.UIAutomation;
 using Axe.Windows.Desktop.UIAutomation.CustomObjects;
 using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -35,7 +36,7 @@ namespace Axe.Windows.DesktopTests.UIAutomation.TreeWalkers
         {
             var cancellationToken = new CancellationTokenSource();
             cancellationToken.Cancel();
-            var dataContext = new TreeWalkerDataContext(Registrar.GetDefaultInstance(), cancellationToken.Token);
+            var dataContext = new TreeWalkerDataContext(Registrar.GetDefaultInstance(), A11yAutomation.GetDefaultInstance(), cancellationToken.Token);
             Assert.ThrowsException<OperationCanceledException>(() => _treeWalker.RefreshTreeData(TreeViewMode.Raw, dataContext));
         }
     }

--- a/src/DesktopTests/UIAutomation/TreeWalkers/TreeWalkerForTestTests.cs
+++ b/src/DesktopTests/UIAutomation/TreeWalkers/TreeWalkerForTestTests.cs
@@ -36,7 +36,7 @@ namespace Axe.Windows.DesktopTests.UIAutomation.TreeWalkers
         {
             var cancellationToken = new CancellationTokenSource();
             cancellationToken.Cancel();
-            var dataContext = new TreeWalkerDataContext(Registrar.GetDefaultInstance(), A11yAutomation.GetDefaultInstance(), cancellationToken.Token);
+            var dataContext = new DesktopDataContext(Registrar.GetDefaultInstance(), A11yAutomation.GetDefaultInstance(), cancellationToken.Token);
             Assert.ThrowsException<OperationCanceledException>(() => _treeWalker.RefreshTreeData(TreeViewMode.Raw, dataContext));
         }
     }


### PR DESCRIPTION
#### Details

#757 set up separate data contexts, but it didn't go far enough. When testing, we realized that the `A11yAutomation` static class was still being shared across all of those data contexts, so the `IUIAutomation` object held within that class was also being shared between contextx. These changes break down as follows:
1. Update `A11yAutomation` to support multiple instances, with each instance having its own `IUIAutomation`.
2. Add an `A11yAutomation` object to `TreeWalkerDataContext`
3. Rename `TreeWalkerDataContext` to `DesktopDataContext`, move it one level up the directory structure
4. Add an `IActionContext` member in the `BaseTracker` class, so each tracker is bound to a context. In practice, these will always be the default contexts (they're not used while scanning), but it puts that decision into a single place in the code
5. Update the plumbing to make sure that we have the `DesktopDataContext` or `A11yAutomation`, as appropriate
6. In methods that are called from AIWin, add a shim that passes in the default context
7. Some methods in `A11yAutomation` also need the `DesktopDataContext`. Add a check to ensure data consistency.
8. Update unit tests where feasible
9. Remove some unused methods from the A11yAutomation` class


##### Motivation

Part of async feature

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
There are some places where classes or methods could have more restricted visibility. I left those out for this PR

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
