### PR TITLE
feat(localization): Add translator comments for Rules namespace

### DIFF
--- a/src/Rules/Resources/ConditionDescriptions.resx
+++ b/src/Rules/Resources/ConditionDescriptions.resx
@@ -119,27 +119,34 @@
   </resheader>
   <data name="AllChildren" xml:space="preserve">
     <value>AllChildren({0})</value>
+    <comment>The description of a relationship between multiple elements.</comment>
   </data>
   <data name="And" xml:space="preserve">
     <value>{0} and {1}</value>
+    <comment>The description of a relationship between multiple elements.</comment>
   </data>
   <data name="AnyChild" xml:space="preserve">
     <value>AnyChild({0})</value>
+    <comment>The description of a relationship between multiple elements.</comment>
   </data>
   <data name="BoundingRectangleCompletelyObscuresContainer" xml:space="preserve">
     <value>BoundingRectangle completely obscures container</value>
+    <comment>The name of a rule used by the automated accessibility scanner.</comment>
   </data>
   <data name="ChildrenExist" xml:space="preserve">
     <value>children exist</value>
+    <comment>The description of a relationship between multiple elements.</comment>
   </data>
   <data name="ChildCount" xml:space="preserve">
     <value>CountChildren({0})</value>
+    <comment>The description of a relationship between multiple elements.</comment>
   </data>
   <data name="CustomLandmark" xml:space="preserve">
     <value>custom landmark</value>
   </data>
   <data name="DescendantCount" xml:space="preserve">
     <value>DescendantCount({0})</value>
+    <comment>The description of a relationship between multiple elements.</comment>
   </data>
   <data name="False" xml:space="preserve">
     <value>False</value>
@@ -152,9 +159,11 @@
   </data>
   <data name="IsContentElement" xml:space="preserve">
     <value>IsContentElement</value>
+    <comment>The name of a UI Automation property that should not be translated.</comment>
   </data>
   <data name="IsControlElement" xml:space="preserve">
     <value>IsControlElement</value>
+    <comment>The name of a UI Automation property that should not be translated.</comment>
   </data>
   <data name="MainLandmark" xml:space="preserve">
     <value>main landmark</value>
@@ -168,21 +177,27 @@
   </data>
   <data name="NoChild" xml:space="preserve">
     <value>NoChild({0})</value>
+    <comment>The description of a relationship between multiple elements.</comment>
   </data>
   <data name="NoChildrenExist" xml:space="preserve">
     <value>no children exist</value>
+    <comment>The description of a relationship between multiple elements.</comment>
   </data>
   <data name="Not" xml:space="preserve">
     <value>not({0})</value>
+    <comment>The description of a relationship between multiple elements.</comment>
   </data>
   <data name="Or" xml:space="preserve">
     <value>{0} or {1}</value>
+    <comment>The description of a relationship between multiple elements.</comment>
   </data>
   <data name="Orientation" xml:space="preserve">
     <value>Orientation</value>
+    <comment>The name of a UI Automation property that should not be translated.</comment>
   </data>
   <data name="Parentheses" xml:space="preserve">
     <value>({0})</value>
+    <comment>Delimiting round brackets that should not be translated.</comment>
   </data>
   <data name="SearchLandmark" xml:space="preserve">
     <value>search landmark</value>
@@ -192,18 +207,23 @@
   </data>
   <data name="TreeItemChildrenExist" xml:space="preserve">
     <value>treeitem children exist </value>
+    <comment>The description of a relationship between multiple elements.</comment>
   </data>
   <data name="SiblingCount" xml:space="preserve">
     <value>CountSiblings({0})</value>
+    <comment>The description of a relationship between multiple elements.</comment>
   </data>
   <data name="ExactlyOne" xml:space="preserve">
     <value>ExactlyOne({0})</value>
+    <comment>The description of a relationship between multiple elements.</comment>
   </data>
   <data name="All" xml:space="preserve">
     <value>AllOf({0})</value>
+    <comment>The description of a relationship between multiple elements.</comment>
   </data>
   <data name="Any" xml:space="preserve">
     <value>AnyOf({0})</value>
+    <comment>The description of a relationship between multiple elements.</comment>
   </data>
   <data name="IntPropertyNotSet" xml:space="preserve">
     <value>[IntProperty not set]</value>
@@ -224,14 +244,15 @@
   </data>
   <data name="Name" xml:space="preserve">
     <value>Name</value>
-    <comment>Name</comment>
+    <comment>The name of a UI Automation property that should not be translated.</comment>
   </data>
   <data name="LocalizedControlType" xml:space="preserve">
     <value>LocalizedControlType</value>
-    <comment>LocalizedControlType</comment>
+    <comment>The name of a UI Automation property that should not be translated.</comment>
   </data>
   <data name="HelpText" xml:space="preserve">
     <value>HelpText</value>
+    <comment>The name of a UI Automation property that should not be translated.</comment>
   </data>
   <data name="IncludesPrivateUnicodeCharacters" xml:space="preserve">
     <value>{0}.IncludesPrivateUnicodeCharacters</value>
@@ -244,5 +265,6 @@
   </data>
   <data name="IsDialog" xml:space="preserve">
     <value>IsDialog</value>
+    <comment>The name of a UI Automation property that should not be translated.</comment>
   </data>
 </root>

--- a/src/Rules/Resources/ConditionDescriptions.resx
+++ b/src/Rules/Resources/ConditionDescriptions.resx
@@ -163,11 +163,11 @@
   </data>
   <data name="IsContentElement" xml:space="preserve">
     <value>IsContentElement</value>
-    <comment>The name of a UI Automation property that should not be translated.</comment>
+    <comment>Do not translate: the name of a UI Automation property.</comment>
   </data>
   <data name="IsControlElement" xml:space="preserve">
     <value>IsControlElement</value>
-    <comment>The name of a UI Automation property that should not be translated.</comment>
+    <comment>Do not translate: the name of a UI Automation property.</comment>
   </data>
   <data name="MainLandmark" xml:space="preserve">
     <value>main landmark</value>
@@ -200,7 +200,7 @@
   </data>
   <data name="Orientation" xml:space="preserve">
     <value>Orientation</value>
-    <comment>The name of a UI Automation property that should not be translated.</comment>
+    <comment>Do not translate: the name of a UI Automation property.</comment>
   </data>
   <data name="Parentheses" xml:space="preserve">
     <value>({0})</value>
@@ -256,15 +256,15 @@
   </data>
   <data name="Name" xml:space="preserve">
     <value>Name</value>
-    <comment>The name of a UI Automation property that should not be translated.</comment>
+    <comment>Do not translate: the name of a UI Automation property.</comment>
   </data>
   <data name="LocalizedControlType" xml:space="preserve">
     <value>LocalizedControlType</value>
-    <comment>The name of a UI Automation property that should not be translated.</comment>
+    <comment>Do not translate: the name of a UI Automation property.</comment>
   </data>
   <data name="HelpText" xml:space="preserve">
     <value>HelpText</value>
-    <comment>The name of a UI Automation property that should not be translated.</comment>
+    <comment>Do not translate: the name of a UI Automation property.</comment>
   </data>
   <data name="IncludesPrivateUnicodeCharacters" xml:space="preserve">
     <value>{0}.IncludesPrivateUnicodeCharacters</value>
@@ -280,6 +280,6 @@
   </data>
   <data name="IsDialog" xml:space="preserve">
     <value>IsDialog</value>
-    <comment>The name of a UI Automation property that should not be translated.</comment>
+    <comment>Do not translate: the name of a UI Automation property.</comment>
   </data>
 </root>

--- a/src/Rules/Resources/ConditionDescriptions.resx
+++ b/src/Rules/Resources/ConditionDescriptions.resx
@@ -119,15 +119,15 @@
   </resheader>
   <data name="AllChildren" xml:space="preserve">
     <value>AllChildren({0})</value>
-    <comment>The description of a relationship between multiple elements.</comment>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="And" xml:space="preserve">
     <value>{0} and {1}</value>
-    <comment>The description of a relationship between multiple elements.</comment>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="AnyChild" xml:space="preserve">
     <value>AnyChild({0})</value>
-    <comment>The description of a relationship between multiple elements.</comment>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="BoundingRectangleCompletelyObscuresContainer" xml:space="preserve">
     <value>BoundingRectangle completely obscures container</value>
@@ -135,27 +135,31 @@
   </data>
   <data name="ChildrenExist" xml:space="preserve">
     <value>children exist</value>
-    <comment>The description of a relationship between multiple elements.</comment>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="ChildCount" xml:space="preserve">
     <value>CountChildren({0})</value>
-    <comment>The description of a relationship between multiple elements.</comment>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="CustomLandmark" xml:space="preserve">
     <value>custom landmark</value>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="DescendantCount" xml:space="preserve">
     <value>DescendantCount({0})</value>
-    <comment>The description of a relationship between multiple elements.</comment>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="False" xml:space="preserve">
     <value>False</value>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="FormLandmark" xml:space="preserve">
     <value>form landmark</value>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="HeadingLevel" xml:space="preserve">
     <value>heading level</value>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="IsContentElement" xml:space="preserve">
     <value>IsContentElement</value>
@@ -167,29 +171,32 @@
   </data>
   <data name="MainLandmark" xml:space="preserve">
     <value>main landmark</value>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="NavigationLandmark" xml:space="preserve">
     <value>navigation landmark</value>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="NewLine" xml:space="preserve">
     <value>{0}
 </value>
+    <comment>Do not translate: a whitespace character.</comment>
   </data>
   <data name="NoChild" xml:space="preserve">
     <value>NoChild({0})</value>
-    <comment>The description of a relationship between multiple elements.</comment>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="NoChildrenExist" xml:space="preserve">
     <value>no children exist</value>
-    <comment>The description of a relationship between multiple elements.</comment>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="Not" xml:space="preserve">
     <value>not({0})</value>
-    <comment>The description of a relationship between multiple elements.</comment>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="Or" xml:space="preserve">
     <value>{0} or {1}</value>
-    <comment>The description of a relationship between multiple elements.</comment>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="Orientation" xml:space="preserve">
     <value>Orientation</value>
@@ -197,50 +204,55 @@
   </data>
   <data name="Parentheses" xml:space="preserve">
     <value>({0})</value>
-    <comment>Delimiting round brackets that should not be translated.</comment>
+    <comment>Do not translate: delimiting round brackets.</comment>
   </data>
   <data name="SearchLandmark" xml:space="preserve">
     <value>search landmark</value>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="True" xml:space="preserve">
     <value>True</value>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="TreeItemChildrenExist" xml:space="preserve">
     <value>treeitem children exist </value>
-    <comment>The description of a relationship between multiple elements.</comment>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="SiblingCount" xml:space="preserve">
     <value>CountSiblings({0})</value>
-    <comment>The description of a relationship between multiple elements.</comment>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="ExactlyOne" xml:space="preserve">
     <value>ExactlyOne({0})</value>
-    <comment>The description of a relationship between multiple elements.</comment>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="All" xml:space="preserve">
     <value>AllOf({0})</value>
-    <comment>The description of a relationship between multiple elements.</comment>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="Any" xml:space="preserve">
     <value>AnyOf({0})</value>
-    <comment>The description of a relationship between multiple elements.</comment>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="IntPropertyNotSet" xml:space="preserve">
     <value>[IntProperty not set]</value>
+    <comment>Do not translate: an internal error message.</comment>
   </data>
   <data name="MatchesRegEx" xml:space="preserve">
     <value>{0} matches regular expression "{1}"</value>
-    <comment>{0} = string property, {1} = regular expression</comment>
+    <comment>A description of an accessibility property.</comment>
   </data>
   <data name="MatchesRegExWithOptions" xml:space="preserve">
     <value>{0} matches regular expression "{1}" with options {2}</value>
-    <comment>{0} = string property, {1} = regular expression, {2} = options</comment>
+    <comment>A description of an accessibility property.</comment>
   </data>
   <data name="NativeWindowHandle" xml:space="preserve">
     <value>NativeWindowHandle</value>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="StringPropertyNotSet" xml:space="preserve">
     <value>[StringProperty not set]</value>
+    <comment>Do not translate: an internal error message.</comment>
   </data>
   <data name="Name" xml:space="preserve">
     <value>Name</value>
@@ -256,12 +268,15 @@
   </data>
   <data name="IncludesPrivateUnicodeCharacters" xml:space="preserve">
     <value>{0}.IncludesPrivateUnicodeCharacters</value>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="ClickablePointOnScreen" xml:space="preserve">
     <value>ClickablePointOnScreen</value>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="ClickablePointOffScreen" xml:space="preserve">
     <value>ClickablePointOffScreen</value>
+    <comment>Do not translate: a token used by the Axe.Windows domain-specific language for accessibility descriptions.</comment>
   </data>
   <data name="IsDialog" xml:space="preserve">
     <value>IsDialog</value>

--- a/src/Rules/Resources/ConditionDescriptions.resx
+++ b/src/Rules/Resources/ConditionDescriptions.resx
@@ -131,7 +131,7 @@
   </data>
   <data name="BoundingRectangleCompletelyObscuresContainer" xml:space="preserve">
     <value>BoundingRectangle completely obscures container</value>
-    <comment>The name of a rule used by the automated accessibility scanner.</comment>
+    <comment>The name of a condition used by the automated accessibility scanner. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ChildrenExist" xml:space="preserve">
     <value>children exist</value>

--- a/src/Rules/Resources/Descriptions.Designer.cs
+++ b/src/Rules/Resources/Descriptions.Designer.cs
@@ -160,7 +160,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A button element should only support one of Invoke, Toggle, or ExpandCollapse patterns when a splitbutton is the parent. .
+        ///   Looks up a localized string similar to A button element should only support one of the Invoke, Toggle, or ExpandCollapse patterns when a splitbutton is the parent. .
         /// </summary>
         internal static string ButtonWithSplitButtonParentPattern {
             get {
@@ -196,7 +196,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes that support the Scroll pattern by default which app developers can&apos;t easily fix..
+        ///   Looks up a localized string similar to A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes that support the Scroll pattern by default, which app developers can&apos;t easily fix..
         /// </summary>
         internal static string ComboBoxShouldNotSupportScrollPattern {
             get {
@@ -394,7 +394,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The framework used to build this application does not support UI Automation..
+        ///   Looks up a localized string similar to The framework used to build this application does not support..
         /// </summary>
         internal static string FrameworkDoesNotSupportUIAutomation {
             get {
@@ -736,7 +736,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The UI Automation Name property for the given element is empty, but the element isn&apos;t focusable. Please consider whether or not the element should have a name..
+        ///   Looks up a localized string similar to The Name property for the given element is empty, but the element isn&apos;t focusable. Please consider whether or not the element should have a name..
         /// </summary>
         internal static string NameEmptyButElementNotKeyboardFocusable {
             get {
@@ -772,7 +772,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The UI Automation Name property of the given element may be null or empty if the element has no siblings of the same type..
+        ///   Looks up a localized string similar to The Name property of the given element may be null or empty if the element has no siblings of the same type..
         /// </summary>
         internal static string NameNoSiblingsOfSameType {
             get {
@@ -826,7 +826,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The UI Automation Name property for the given element type is optional..
+        ///   Looks up a localized string similar to The Name property for the given element type is optional..
         /// </summary>
         internal static string NameOnOptionalType {
             get {
@@ -844,7 +844,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An interactive element with a valid UI Automation Name property is usually expected to have a valid BoundingRectangle that is not null and has area..
+        ///   Looks up a localized string similar to An interactive element with a valid Name property is usually expected to have a valid BoundingRectangle that is not null and has area..
         /// </summary>
         internal static string NameWithValidBoundingRectangle {
             get {

--- a/src/Rules/Resources/Descriptions.Designer.cs
+++ b/src/Rules/Resources/Descriptions.Designer.cs
@@ -178,7 +178,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An element&apos;s IsOffScreen property must be true when its clickable point is off screen..
+        ///   Looks up a localized string similar to An element&apos;s IsOffScreen property must be true when its clickable point is off-screen..
         /// </summary>
         internal static string ClickablePointOffScreen {
             get {
@@ -187,7 +187,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An element&apos;s IsOffScreen property must be false when its clickable point is on screen..
+        ///   Looks up a localized string similar to An element&apos;s IsOffScreen property must be false when its clickable point is on-screen..
         /// </summary>
         internal static string ClickablePointOnScreen {
             get {
@@ -196,7 +196,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes support the scroll pattern by default, which app developers can&apos;t easily fix..
+        ///   Looks up a localized string similar to A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes that support the Scroll pattern by default which app developers can&apos;t easily fix..
         /// </summary>
         internal static string ComboBoxShouldNotSupportScrollPattern {
             get {
@@ -484,7 +484,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The IsKeyboardFocusable property may be false when the given element supports the text pattern and is the descendant of an element that also supports the text pattern. Please consider if the given element should or should not be focusable..
+        ///   Looks up a localized string similar to The IsKeyboardFocusable property may be false when the given element supports the Text pattern and is the descendant of an element that also supports the Text pattern. Please consider if the given element should or should not be focusable..
         /// </summary>
         internal static string IsKeyboardFocusableDescendantTextPattern {
             get {
@@ -529,7 +529,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The IsKeyboardFocusable property should be true when you want an empty container to be discoverable by assistive technology users. IsKeyboardFocusable may be false when you want an empty container not to be discoverable by AT users..
+        ///   Looks up a localized string similar to The IsKeyboardFocusable property should be true when you want an empty container to be discoverable by assistive technology users. IsKeyboardFocusable may be false when you want an empty container not to be discoverable by assistive technology users..
         /// </summary>
         internal static string IsKeyboardFocusableOnEmptyContainer {
             get {
@@ -556,7 +556,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The IsKeyboardFocusable property should be true for an element that supports the text pattern, is not a descendant of an element that supports the text pattern, and which supports text selection..
+        ///   Looks up a localized string similar to The IsKeyboardFocusable property should be true for an element that supports the Text pattern, is not a descendant of an element that supports the Text pattern, and which supports text selection..
         /// </summary>
         internal static string IsKeyboardFocusableTopLevelTextPattern {
             get {
@@ -574,7 +574,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The ItemType property for the given element has no content, and the element has a child image. Please consider including an item type so that assistive technology users can obtain the information provided by the image. If this information is already provided in another way, the item type may not be necessary..
+        ///   Looks up a localized string similar to The ItemType property for the given element has no content, and the element has a child image. Please consider including an ItemType so that assistive technology users can obtain the information provided by the image. If this information is already provided in another way, the ItemType may not be necessary..
         /// </summary>
         internal static string ItemTypeRecommended {
             get {
@@ -619,7 +619,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A page must not have multiple elements with LocalizedLandmarkType &quot;banner.&quot;.
+        ///   Looks up a localized string similar to A page must not have multiple elements with LocalizedLandmarkType &quot;banner&quot;..
         /// </summary>
         internal static string LandmarkNoDuplicateBanner {
             get {
@@ -628,7 +628,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A page must not have multiple elements with LocalizedLandmarkType &quot;contentinfo.&quot;.
+        ///   Looks up a localized string similar to A page must not have multiple elements with LocalizedLandmarkType &quot;contentinfo&quot;..
         /// </summary>
         internal static string LandmarkNoDuplicateContentInfo {
             get {
@@ -682,7 +682,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The localized control type should be reasonable based on ControlTypeId..
+        ///   Looks up a localized string similar to The LocalizedControlType should be reasonable based on the element&apos;s ControlTypeId..
         /// </summary>
         internal static string LocalizedControlTypeReasonable {
             get {
@@ -700,7 +700,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The LandmarkType and LocalizedLandmarkType must not both be set to &quot;custom.&quot;.
+        ///   Looks up a localized string similar to The LandmarkType and LocalizedLandmarkType must not both be set to &quot;custom&quot;..
         /// </summary>
         internal static string LocalizedLandmarkTypeNotCustom {
             get {
@@ -736,7 +736,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Name property for the given element is empty, but the element isn&apos;t focusable. Please consider whether or not the element should have a name..
+        ///   Looks up a localized string similar to The UI Automation Name property for the given element is empty, but the element isn&apos;t focusable. Please consider whether or not the element should have a name..
         /// </summary>
         internal static string NameEmptyButElementNotKeyboardFocusable {
             get {
@@ -763,7 +763,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The name property of an element should not contain class names like &apos;Microsoft.*.*&apos; or &apos;Windows.*.*&apos; as these are not usually informative..
+        ///   Looks up a localized string similar to The Name property of an element should not contain class names like &apos;Microsoft.*.*&apos; or &apos;Windows.*.*&apos; as these are not usually informative..
         /// </summary>
         internal static string NameIsInformative {
             get {
@@ -772,7 +772,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The name property of the given element may be null or empty if the element has no siblings of the same type..
+        ///   Looks up a localized string similar to The UI Automation Name property of the given element may be null or empty if the element has no siblings of the same type..
         /// </summary>
         internal static string NameNoSiblingsOfSameType {
             get {
@@ -817,7 +817,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The name property of a custom control may be empty if the parent is a wpf dataitem..
+        ///   Looks up a localized string similar to The Name property of a custom control may be empty if the parent is a WPF dataitem..
         /// </summary>
         internal static string NameOnCustomWithParentWPFDataItem {
             get {
@@ -826,7 +826,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The name property for the given element type is optional..
+        ///   Looks up a localized string similar to The UI Automation Name property for the given element type is optional..
         /// </summary>
         internal static string NameOnOptionalType {
             get {
@@ -844,7 +844,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An interactive element with a valid name property is usually expected to have a valid bounding rectangle that is not null and has area..
+        ///   Looks up a localized string similar to An interactive element with a valid UI Automation Name property is usually expected to have a valid BoundingRectangle that is not null and has area..
         /// </summary>
         internal static string NameWithValidBoundingRectangle {
             get {

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -135,99 +135,99 @@
   </data>
   <data name="ControlShouldNotSupportValuePattern" xml:space="preserve">
     <value>An element of the given type should not support the Value pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Value" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Value" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldNotSupportWindowPattern" xml:space="preserve">
     <value>An element of the given type should not support the Window pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Window" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Window" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="HelpTextNotEqualToName" xml:space="preserve">
     <value>The HelpText property of an element must not be the same as the element's Name property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "HelpText" and "Name" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "HelpText" and "Name" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsContentElementFalseOptional" xml:space="preserve">
     <value>The recommended value of the IsContentElement property for the given control type is false. Please consider if this is an element that should be reported to an assistive technology user as content.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsContentElement" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsContentElementTrueOptional" xml:space="preserve">
     <value>The recommended value of the IsContentElement property for the given control type is true. Please consider if this is an element that should be reported to an assistive technology user as content.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsContentElement" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsControlElementTrueOptional" xml:space="preserve">
     <value>The recommended value of the IsControlElement property for the given control type is true. Please consider if this is an element that should be reported to an assistive technology user as a control. Note that almost all controls are required to have the IsControl Property set to true.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsControlElement" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsControlElement" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element should be true based on its control type.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButDisabled" xml:space="preserve">
     <value>The IsKeyboardFocusable property is false for an element where it would normally be true. However, the IsEnabled property on the element is also false, so the value of IsKeyboardFocusable may be acceptable.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsEnabled" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsEnabled" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsKeyboardFocusableForListItemShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given list item is false, but the element has children that are focusable. The element should probably be focusable instead of its children.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButOffscreen" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element is false for an element where it would normally be true. However, the IsOffscreen property on the element is true, so the value of IsKeyboardFocusable may be acceptable.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsOffscreen" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsOffscreen" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsKeyboardFocusableForCustomShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for a custom element should be true when the element supports actionable patterns.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableDescendantTextPattern" xml:space="preserve">
     <value>The IsKeyboardFocusable property may be false when the given element supports the Text pattern and is the descendant of an element that also supports the Text pattern. Please consider if the given element should or should not be focusable.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsKeyboardFocusableOnEmptyContainer" xml:space="preserve">
     <value>The IsKeyboardFocusable property should be true when you want an empty container to be discoverable by assistive technology users. IsKeyboardFocusable may be false when you want an empty container not to be discoverable by assistive technology users.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeFalse" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element is expected to be false because of the element's control type.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableTopLevelTextPattern" xml:space="preserve">
     <value>The IsKeyboardFocusable property should be true for an element that supports the Text pattern, is not a descendant of an element that supports the Text pattern, and which supports text selection.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ItemStatusExists" xml:space="preserve">
     <value>The ItemStatus property for the given element should exist.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "ItemStatus" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "ItemStatus" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeReasonable" xml:space="preserve">
     <value>The LocalizedControlType should be reasonable based on the element's ControlTypeId.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LocalizedControlType" and "ControlTypeId" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LocalizedControlType" and "ControlTypeId" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ItemTypeRecommended" xml:space="preserve">
     <value>The ItemType property for the given element has no content, and the element has a child image. Please consider including an ItemType so that assistive technology users can obtain the information provided by the image. If this information is already provided in another way, the ItemType may not be necessary.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "ItemType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "ItemType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameEmptyButElementNotKeyboardFocusable" xml:space="preserve">
     <value>The UI Automation Name property for the given element is empty, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNoSiblingsOfSameType" xml:space="preserve">
     <value>The UI Automation Name property of the given element may be null or empty if the element has no siblings of the same type.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNullButElementNotKeyboardFocusable" xml:space="preserve">
     <value>The Name property for the given element is null, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameOnCustomWithParentWPFDataItem" xml:space="preserve">
     <value>The Name property of a custom control may be empty if the parent is a WPF dataitem.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "dataitem" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "dataitem" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="NameOnOptionalType" xml:space="preserve">
     <value>The UI Automation Name property for the given element type is optional.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameWithValidBoundingRectangle" xml:space="preserve">
     <value>An interactive element with a valid UI Automation Name property is usually expected to have a valid BoundingRectangle that is not null and has area.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "BoundingRectangle" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "BoundingRectangle" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="Structure" xml:space="preserve">
     <value>The given element is expected to have the following structure: {0}.</value>
@@ -235,106 +235,106 @@
   </data>
   <data name="ButtonInvokeAndExpandCollapsePatterns" xml:space="preserve">
     <value>A button may have the Invoke and ExpandCollapse patterns together, but it is not recommended. If possible, please have only one of them. </value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ButtonShouldHavePatterns" xml:space="preserve">
     <value>A button must support one of these patterns: Invoke, Toggle, or ExpandCollapse.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>A button must not support both the Invoke and Toggle patterns.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "Toggle" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "Toggle" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ButtonToggleAndExpandCollapsePatterns" xml:space="preserve">
     <value>A button must not support both the Toggle and ExpandCollapse patterns.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Toggle" and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Toggle" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ProgressBarRangeValue" xml:space="preserve">
     <value>The RangeValue pattern of a progress bar must have specific Minimum, Maximum, and IsReadOnly values.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "RangeValue", "Minimum", "Maximum", and "IsReadOnly" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "RangeValue", "Minimum", "Maximum", and "IsReadOnly" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="EditSupportsIncorrectRangeValuePattern" xml:space="preserve">
     <value>The RangeValue pattern of an edit control must have a null LargeChange property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "RangeValue" and "LargeChange" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "RangeValue" and "LargeChange" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="SplitButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>A split button must support exactly one of the Invoke or Toggle patterns.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "Toggle" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "Toggle" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldNotSupportInvokePattern" xml:space="preserve">
     <value>An element of the given ControlType must not support the Invoke pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Invoke" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Invoke" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldNotSupportScrollPattern" xml:space="preserve">
     <value>An element of the given ControlType must not support the Scroll pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Scroll" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Scroll" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldNotSupportTogglePattern" xml:space="preserve">
     <value>An element of the given ControlType must not support the Toggle pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Toggle" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Toggle" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportExpandCollapsePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the ExpandCollapse pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportGridItemPattern" xml:space="preserve">
     <value>An element whose parent supports the Grid pattern must support the GridItem pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Grid" and "GridItem" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Grid" and "GridItem" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportGridPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Grid pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Grid" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Grid" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportInvokePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Invoke pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Invoke" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Invoke" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportScrollItemPattern" xml:space="preserve">
     <value>An element whose parent supports the Scroll pattern must support the ScrollItem pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Scroll" and "ScrollItem" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Scroll" and "ScrollItem" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportSelectionItemPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the SelectionItem pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "SelectionItem" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "SelectionItem" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportSelectionPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Selection pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Selection" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Selection" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportSpreadsheetItemPattern" xml:space="preserve">
     <value>An element whose parent supports the Spreadsheet pattern must support the SpreadsheetItem pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Spreadsheet" and "SpreadsheetItem" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Spreadsheet" and "SpreadsheetItem" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportTableItemPattern" xml:space="preserve">
     <value>An element whose parent supports the Table pattern must support the TableItem pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Table" and "TableItem" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Table" and "TableItem" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportTablePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Table pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Table" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Table" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportTextPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Text pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Table" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Table" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportTogglePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Toggle pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Toggle" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Toggle" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportTransformPattern" xml:space="preserve">
     <value>An element that can be resized must support the Transform pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Transform" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Transform" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ChildrenNotAllowedInContentView" xml:space="preserve">
     <value>A separator must not have any children with IsContentElement set to TRUE.</value>
   </data>
   <data name="SelectionPatternSelectionRequired" xml:space="preserve">
     <value>An element of the given ControlType must have the IsSelectionRequired property set to TRUE.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsSelectionRequired" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsSelectionRequired" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="SelectionPatternSingleSelection" xml:space="preserve">
     <value>An element of the given ControlType must not support multiple selection.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "ControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "ControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="SelectionItemPatternSingleSelection" xml:space="preserve">
     <value>An element whose parent supports single selection must not have selected siblings.</value>
@@ -342,7 +342,7 @@
   </data>
   <data name="ParentChildShouldNotHaveSameNameAndLocalizedControlType" xml:space="preserve">
     <value>An element must not have the same Name and LocalizedControlType as its parent.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "LocalizedControlType" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="SiblingUniqueAndFocusable" xml:space="preserve">
     <value>Focusable sibling elements must not have the same Name and LocalizedControlType.</value>
@@ -350,31 +350,31 @@
   </data>
   <data name="ControlShouldSupportSetInfo" xml:space="preserve">
     <value>The element's ControlType requires valid values for SizeOfSet and PositionInSet.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType", "SizeOfSet", and "PositionInSet" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType", "SizeOfSet", and "PositionInSet" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="BoundingRectangleCompletelyObscuresContainer" xml:space="preserve">
     <value>An element's BoundingRectangle must not obscure its container element.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="BoundingRectangleContainedInParent" xml:space="preserve">
     <value>An element's BoundingRectangle must be contained within its parent element.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="BoundingRectangleDataFormatCorrect" xml:space="preserve">
     <value>The BoundingRectangle property must return a valid rectangle.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="BoundingRectangleNotAllZeros" xml:space="preserve">
     <value>The BoundingRectangle property must not be defined as [0,0,0,0]</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="BoundingRectangleNotNull" xml:space="preserve">
     <value>An on-screen element must not have a null BoundingRectangle property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="BoundingRectangleSizeReasonable" xml:space="preserve">
     <value>The BoundingRectangle property must represent an area of at least 25 pixels.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="HeadingLevelDescendsWhenNested" xml:space="preserve">
     <value>An element's HeadingLevel must be greater than or equal to that of its ancestors.</value>
@@ -382,111 +382,111 @@
   </data>
   <data name="IsContentElementPropertyExists" xml:space="preserve">
     <value>The given ControlType must have a non-null IsContentElement property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsContentElement" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsContentElement" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsControlElementPropertyExists" xml:space="preserve">
     <value>The given ControlType must have a non-null IsControlElement property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsControlElement" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsControlElement" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsControlElementTrueRequired" xml:space="preserve">
     <value>The given ControlType must have the IsControlElement property set to TRUE.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsControlElement" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsControlElement" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="LandmarkBannerIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "banner" must not descend from another landmark.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LandmarkComplementaryIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "complementary" must not descend from another landmark.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LandmarkContentInfoIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "contentinfo" must not descend from another landmark.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LandmarkMainIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "main" must not descend from another landmark.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LandmarkNoDuplicateBanner" xml:space="preserve">
     <value>A page must not have multiple elements with LocalizedLandmarkType "banner".</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LandmarkNoDuplicateContentInfo" xml:space="preserve">
     <value>A page must not have multiple elements with LocalizedLandmarkType "contentinfo".</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedLandmarkTypeIsReasonableLength" xml:space="preserve">
     <value>The LocalizedLandmarkType property must not be longer than 64 characters.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotCustom" xml:space="preserve">
     <value>The LandmarkType and LocalizedLandmarkType must not both be set to "custom".</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotEmpty" xml:space="preserve">
     <value>An element with LandmarkType set must not have an empty LocalizedLandmarkType.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotNull" xml:space="preserve">
     <value>An element with LandmarkType set must not have a null LocalizedLandmarkType.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotWhiteSpace" xml:space="preserve">
     <value>The LocalizedLandmarkType property must not contain only white space.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeNotCustom" xml:space="preserve">
     <value>The ControlType and LocalizedControlType must not both be set to "custom."</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "LocalizedControlType" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="LocalizedControlTypeNotEmpty" xml:space="preserve">
     <value>The LocalizedControlType property must not be an empty string.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeNotNull" xml:space="preserve">
     <value>The LocalizedControlType property must not be null.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeNotWhiteSpace" xml:space="preserve">
     <value>The LocalizedControlType property must not contain only white space.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="OrientationPropertyExists" xml:space="preserve">
     <value>Controls that can be horizontal or vertical must support the Orientation property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Orientation" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Orientation" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameExcludesControlType" xml:space="preserve">
     <value>The Name property must not include the element's control type.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameExcludesLocalizedControlType" xml:space="preserve">
     <value>The Name must not include the same text as the LocalizedControlType.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "LocalizedControlType" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="NameIsInformative" xml:space="preserve">
     <value>The Name property of an element should not contain class names like 'Microsoft.*.*' or 'Windows.*.*' as these are not usually informative.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">
     <value>The Name property of a focusable element must not be an empty string.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotNull" xml:space="preserve">
     <value>The Name property of a focusable element must not be null.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotWhiteSpace" xml:space="preserve">
     <value>The Name property must not contain only space characters.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameReasonableLength" xml:space="preserve">
     <value>The Name property must not be longer than 512 characters.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ListItemSiblingsUnique" xml:space="preserve">
     <value>The Name property of sibling list items should be unique.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="HyperlinkNameShouldBeUnique" xml:space="preserve">
     <value>Links with different purposes and destinations should have different names.</value>
@@ -498,11 +498,11 @@
   </data>
   <data name="ClickablePointOnScreen" xml:space="preserve">
     <value>An element's IsOffScreen property must be false when its clickable point is on-screen.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsOffScreen" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsOffScreen" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ClickablePointOffScreen" xml:space="preserve">
     <value>An element's IsOffScreen property must be true when its clickable point is off-screen.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsOffScreen" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsOffScreen" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
     <value>The framework used to build this application does not support UI Automation.</value>

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -119,299 +119,397 @@
   </resheader>
   <data name="BoundingRectangleNotValidButOffScreen" xml:space="preserve">
     <value>The BoundingRectangle property is not valid, but the element is off-screen.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ButtonWithSplitButtonParentPattern" xml:space="preserve">
     <value>A button element should only support one of Invoke, Toggle, or ExpandCollapse patterns when a splitbutton is the parent. </value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="SiblingUniqueAndNotFocusable" xml:space="preserve">
     <value>The given element has siblings with the same Name and LocalizedControlType.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ComboBoxShouldNotSupportScrollPattern" xml:space="preserve">
-    <value>A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes support the scroll pattern by default, which app developers can't easily fix.</value>
+    <value>A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes that support the Scroll pattern by default which app developers can't easily fix.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Scroll" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldNotSupportValuePattern" xml:space="preserve">
     <value>An element of the given type should not support the Value pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Value" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldNotSupportWindowPattern" xml:space="preserve">
     <value>An element of the given type should not support the Window pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Window" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="HelpTextNotEqualToName" xml:space="preserve">
     <value>The HelpText property of an element must not be the same as the element's Name property.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "HelpText" and "Name" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsContentElementFalseOptional" xml:space="preserve">
     <value>The recommended value of the IsContentElement property for the given control type is false. Please consider if this is an element that should be reported to an assistive technology user as content.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsContentElement" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsContentElementTrueOptional" xml:space="preserve">
     <value>The recommended value of the IsContentElement property for the given control type is true. Please consider if this is an element that should be reported to an assistive technology user as content.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsContentElement" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsControlElementTrueOptional" xml:space="preserve">
     <value>The recommended value of the IsControlElement property for the given control type is true. Please consider if this is an element that should be reported to an assistive technology user as a control. Note that almost all controls are required to have the IsControl Property set to true.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsControlElement" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element should be true based on its control type.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButDisabled" xml:space="preserve">
     <value>The IsKeyboardFocusable property is false for an element where it would normally be true. However, the IsEnabled property on the element is also false, so the value of IsKeyboardFocusable may be acceptable.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsEnabled" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsKeyboardFocusableForListItemShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given list item is false, but the element has children that are focusable. The element should probably be focusable instead of its children.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButOffscreen" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element is false for an element where it would normally be true. However, the IsOffscreen property on the element is true, so the value of IsKeyboardFocusable may be acceptable.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsOffscreen" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsKeyboardFocusableForCustomShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for a custom element should be true when the element supports actionable patterns.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableDescendantTextPattern" xml:space="preserve">
-    <value>The IsKeyboardFocusable property may be false when the given element supports the text pattern and is the descendant of an element that also supports the text pattern. Please consider if the given element should or should not be focusable.</value>
+    <value>The IsKeyboardFocusable property may be false when the given element supports the Text pattern and is the descendant of an element that also supports the Text pattern. Please consider if the given element should or should not be focusable.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsKeyboardFocusableOnEmptyContainer" xml:space="preserve">
-    <value>The IsKeyboardFocusable property should be true when you want an empty container to be discoverable by assistive technology users. IsKeyboardFocusable may be false when you want an empty container not to be discoverable by AT users.</value>
+    <value>The IsKeyboardFocusable property should be true when you want an empty container to be discoverable by assistive technology users. IsKeyboardFocusable may be false when you want an empty container not to be discoverable by assistive technology users.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeFalse" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element is expected to be false because of the element's control type.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableTopLevelTextPattern" xml:space="preserve">
-    <value>The IsKeyboardFocusable property should be true for an element that supports the text pattern, is not a descendant of an element that supports the text pattern, and which supports text selection.</value>
+    <value>The IsKeyboardFocusable property should be true for an element that supports the Text pattern, is not a descendant of an element that supports the Text pattern, and which supports text selection.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ItemStatusExists" xml:space="preserve">
     <value>The ItemStatus property for the given element should exist.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "ItemStatus" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeReasonable" xml:space="preserve">
-    <value>The localized control type should be reasonable based on ControlTypeId.</value>
+    <value>The LocalizedControlType should be reasonable based on the element's ControlTypeId.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LocalizedControlType" and "ControlTypeId" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ItemTypeRecommended" xml:space="preserve">
-    <value>The ItemType property for the given element has no content, and the element has a child image. Please consider including an item type so that assistive technology users can obtain the information provided by the image. If this information is already provided in another way, the item type may not be necessary.</value>
+    <value>The ItemType property for the given element has no content, and the element has a child image. Please consider including an ItemType so that assistive technology users can obtain the information provided by the image. If this information is already provided in another way, the ItemType may not be necessary.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "ItemType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameEmptyButElementNotKeyboardFocusable" xml:space="preserve">
-    <value>The Name property for the given element is empty, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
+    <value>The UI Automation Name property for the given element is empty, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNoSiblingsOfSameType" xml:space="preserve">
-    <value>The name property of the given element may be null or empty if the element has no siblings of the same type.</value>
+    <value>The UI Automation Name property of the given element may be null or empty if the element has no siblings of the same type.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNullButElementNotKeyboardFocusable" xml:space="preserve">
     <value>The Name property for the given element is null, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameOnCustomWithParentWPFDataItem" xml:space="preserve">
-    <value>The name property of a custom control may be empty if the parent is a wpf dataitem.</value>
+    <value>The Name property of a custom control may be empty if the parent is a WPF dataitem.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "dataitem" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="NameOnOptionalType" xml:space="preserve">
-    <value>The name property for the given element type is optional.</value>
+    <value>The UI Automation Name property for the given element type is optional.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameWithValidBoundingRectangle" xml:space="preserve">
-    <value>An interactive element with a valid name property is usually expected to have a valid bounding rectangle that is not null and has area.</value>
+    <value>An interactive element with a valid UI Automation Name property is usually expected to have a valid BoundingRectangle that is not null and has area.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "BoundingRectangle" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="Structure" xml:space="preserve">
     <value>The given element is expected to have the following structure: {0}.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection.</comment>
   </data>
   <data name="ButtonInvokeAndExpandCollapsePatterns" xml:space="preserve">
     <value>A button may have the Invoke and ExpandCollapse patterns together, but it is not recommended. If possible, please have only one of them. </value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ButtonShouldHavePatterns" xml:space="preserve">
     <value>A button must support one of these patterns: Invoke, Toggle, or ExpandCollapse.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>A button must not support both the Invoke and Toggle patterns.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "Toggle" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ButtonToggleAndExpandCollapsePatterns" xml:space="preserve">
     <value>A button must not support both the Toggle and ExpandCollapse patterns.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Toggle" and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ProgressBarRangeValue" xml:space="preserve">
     <value>The RangeValue pattern of a progress bar must have specific Minimum, Maximum, and IsReadOnly values.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "RangeValue", "Minimum", "Maximum", and "IsReadOnly" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="EditSupportsIncorrectRangeValuePattern" xml:space="preserve">
     <value>The RangeValue pattern of an edit control must have a null LargeChange property.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "RangeValue" and "LargeChange" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="SplitButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>A split button must support exactly one of the Invoke or Toggle patterns.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "Toggle" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldNotSupportInvokePattern" xml:space="preserve">
     <value>An element of the given ControlType must not support the Invoke pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Invoke" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldNotSupportScrollPattern" xml:space="preserve">
     <value>An element of the given ControlType must not support the Scroll pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Scroll" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldNotSupportTogglePattern" xml:space="preserve">
     <value>An element of the given ControlType must not support the Toggle pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Toggle" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportExpandCollapsePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the ExpandCollapse pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportGridItemPattern" xml:space="preserve">
     <value>An element whose parent supports the Grid pattern must support the GridItem pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Grid" and "GridItem" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportGridPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Grid pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Grid" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportInvokePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Invoke pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Invoke" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportScrollItemPattern" xml:space="preserve">
     <value>An element whose parent supports the Scroll pattern must support the ScrollItem pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Scroll" and "ScrollItem" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportSelectionItemPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the SelectionItem pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "SelectionItem" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportSelectionPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Selection pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Selection" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportSpreadsheetItemPattern" xml:space="preserve">
     <value>An element whose parent supports the Spreadsheet pattern must support the SpreadsheetItem pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Spreadsheet" and "SpreadsheetItem" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportTableItemPattern" xml:space="preserve">
     <value>An element whose parent supports the Table pattern must support the TableItem pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Table" and "TableItem" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportTablePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Table pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Table" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportTextPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Text pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Table" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportTogglePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Toggle pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Toggle" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportTransformPattern" xml:space="preserve">
     <value>An element that can be resized must support the Transform pattern.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Transform" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ChildrenNotAllowedInContentView" xml:space="preserve">
     <value>A separator must not have any children with IsContentElement set to TRUE.</value>
   </data>
   <data name="SelectionPatternSelectionRequired" xml:space="preserve">
     <value>An element of the given ControlType must have the IsSelectionRequired property set to TRUE.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsSelectionRequired" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="SelectionPatternSingleSelection" xml:space="preserve">
     <value>An element of the given ControlType must not support multiple selection.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "ControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="SelectionItemPatternSingleSelection" xml:space="preserve">
     <value>An element whose parent supports single selection must not have selected siblings.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection.</comment>
   </data>
   <data name="ParentChildShouldNotHaveSameNameAndLocalizedControlType" xml:space="preserve">
     <value>An element must not have the same Name and LocalizedControlType as its parent.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "LocalizedControlType" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="SiblingUniqueAndFocusable" xml:space="preserve">
     <value>Focusable sibling elements must not have the same Name and LocalizedControlType.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection.</comment>
   </data>
   <data name="ControlShouldSupportSetInfo" xml:space="preserve">
     <value>The element's ControlType requires valid values for SizeOfSet and PositionInSet.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType", "SizeOfSet", and "PositionInSet" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="BoundingRectangleCompletelyObscuresContainer" xml:space="preserve">
     <value>An element's BoundingRectangle must not obscure its container element.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="BoundingRectangleContainedInParent" xml:space="preserve">
     <value>An element's BoundingRectangle must be contained within its parent element.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="BoundingRectangleDataFormatCorrect" xml:space="preserve">
     <value>The BoundingRectangle property must return a valid rectangle.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="BoundingRectangleNotAllZeros" xml:space="preserve">
     <value>The BoundingRectangle property must not be defined as [0,0,0,0]</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="BoundingRectangleNotNull" xml:space="preserve">
     <value>An on-screen element must not have a null BoundingRectangle property.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="BoundingRectangleSizeReasonable" xml:space="preserve">
     <value>The BoundingRectangle property must represent an area of at least 25 pixels.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="HeadingLevelDescendsWhenNested" xml:space="preserve">
     <value>An element's HeadingLevel must be greater than or equal to that of its ancestors.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection.</comment>
   </data>
   <data name="IsContentElementPropertyExists" xml:space="preserve">
     <value>The given ControlType must have a non-null IsContentElement property.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsContentElement" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsControlElementPropertyExists" xml:space="preserve">
     <value>The given ControlType must have a non-null IsControlElement property.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsControlElement" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsControlElementTrueRequired" xml:space="preserve">
     <value>The given ControlType must have the IsControlElement property set to TRUE.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsControlElement" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="LandmarkBannerIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "banner" must not descend from another landmark.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LandmarkComplementaryIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "complementary" must not descend from another landmark.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LandmarkContentInfoIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "contentinfo" must not descend from another landmark.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LandmarkMainIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "main" must not descend from another landmark.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LandmarkNoDuplicateBanner" xml:space="preserve">
-    <value>A page must not have multiple elements with LocalizedLandmarkType "banner."</value>
+    <value>A page must not have multiple elements with LocalizedLandmarkType "banner".</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LandmarkNoDuplicateContentInfo" xml:space="preserve">
-    <value>A page must not have multiple elements with LocalizedLandmarkType "contentinfo."</value>
+    <value>A page must not have multiple elements with LocalizedLandmarkType "contentinfo".</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedLandmarkTypeIsReasonableLength" xml:space="preserve">
     <value>The LocalizedLandmarkType property must not be longer than 64 characters.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotCustom" xml:space="preserve">
-    <value>The LandmarkType and LocalizedLandmarkType must not both be set to "custom."</value>
+    <value>The LandmarkType and LocalizedLandmarkType must not both be set to "custom".</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotEmpty" xml:space="preserve">
     <value>An element with LandmarkType set must not have an empty LocalizedLandmarkType.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotNull" xml:space="preserve">
     <value>An element with LandmarkType set must not have a null LocalizedLandmarkType.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotWhiteSpace" xml:space="preserve">
     <value>The LocalizedLandmarkType property must not contain only white space.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeNotCustom" xml:space="preserve">
     <value>The ControlType and LocalizedControlType must not both be set to "custom."</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "LocalizedControlType" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="LocalizedControlTypeNotEmpty" xml:space="preserve">
     <value>The LocalizedControlType property must not be an empty string.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeNotNull" xml:space="preserve">
     <value>The LocalizedControlType property must not be null.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeNotWhiteSpace" xml:space="preserve">
     <value>The LocalizedControlType property must not contain only white space.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="OrientationPropertyExists" xml:space="preserve">
     <value>Controls that can be horizontal or vertical must support the Orientation property.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Orientation" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameExcludesControlType" xml:space="preserve">
     <value>The Name property must not include the element's control type.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameExcludesLocalizedControlType" xml:space="preserve">
     <value>The Name must not include the same text as the LocalizedControlType.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "LocalizedControlType" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="NameIsInformative" xml:space="preserve">
-    <value>The name property of an element should not contain class names like 'Microsoft.*.*' or 'Windows.*.*' as these are not usually informative.</value>
+    <value>The Name property of an element should not contain class names like 'Microsoft.*.*' or 'Windows.*.*' as these are not usually informative.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">
     <value>The Name property of a focusable element must not be an empty string.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotNull" xml:space="preserve">
     <value>The Name property of a focusable element must not be null.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotWhiteSpace" xml:space="preserve">
     <value>The Name property must not contain only space characters.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameReasonableLength" xml:space="preserve">
     <value>The Name property must not be longer than 512 characters.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ListItemSiblingsUnique" xml:space="preserve">
     <value>The Name property of sibling list items should be unique.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="HyperlinkNameShouldBeUnique" xml:space="preserve">
     <value>Links with different purposes and destinations should have different names.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection.</comment>
   </data>
   <data name="PropertyExcludesPrivateUnicodeCharacters" xml:space="preserve">
     <value>The {0} property must not contain any characters in the private Unicode range.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection.</comment>
   </data>
   <data name="ClickablePointOnScreen" xml:space="preserve">
-    <value>An element's IsOffScreen property must be false when its clickable point is on screen.</value>
+    <value>An element's IsOffScreen property must be false when its clickable point is on-screen.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsOffScreen" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ClickablePointOffScreen" xml:space="preserve">
-    <value>An element's IsOffScreen property must be true when its clickable point is off screen.</value>
+    <value>An element's IsOffScreen property must be true when its clickable point is off-screen.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsOffScreen" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
     <value>The framework used to build this application does not support UI Automation.</value>
+    <comment>The description of an accessibility problem with an application currently under inspection.</comment>
   </data>
   <data name="EdgeBrowserHasBeenDeprecated" xml:space="preserve">
     <value>The non-Chromium version of Microsoft Edge has been deprecated.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection.</comment>
   </data>
 </root>

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -122,7 +122,7 @@
     <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ButtonWithSplitButtonParentPattern" xml:space="preserve">
-    <value>A button element should only support one of Invoke, Toggle, or ExpandCollapse patterns when a splitbutton is the parent. </value>
+    <value>A button element should only support one of the Invoke, Toggle, or ExpandCollapse patterns when a splitbutton is the parent. </value>
     <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="SiblingUniqueAndNotFocusable" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ComboBoxShouldNotSupportScrollPattern" xml:space="preserve">
-    <value>A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes that support the Scroll pattern by default which app developers can't easily fix.</value>
+    <value>A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes that support the Scroll pattern by default, which app developers can't easily fix.</value>
     <comment>The description of an accessibility problem with an element currently under inspection. The term "Scroll" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldNotSupportValuePattern" xml:space="preserve">
@@ -206,11 +206,11 @@
     <comment>The description of an accessibility problem with an element currently under inspection. The term "ItemType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameEmptyButElementNotKeyboardFocusable" xml:space="preserve">
-    <value>The UI Automation Name property for the given element is empty, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
+    <value>The Name property for the given element is empty, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
     <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNoSiblingsOfSameType" xml:space="preserve">
-    <value>The UI Automation Name property of the given element may be null or empty if the element has no siblings of the same type.</value>
+    <value>The Name property of the given element may be null or empty if the element has no siblings of the same type.</value>
     <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNullButElementNotKeyboardFocusable" xml:space="preserve">
@@ -222,11 +222,11 @@
     <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "dataitem" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="NameOnOptionalType" xml:space="preserve">
-    <value>The UI Automation Name property for the given element type is optional.</value>
+    <value>The Name property for the given element type is optional.</value>
     <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameWithValidBoundingRectangle" xml:space="preserve">
-    <value>An interactive element with a valid UI Automation Name property is usually expected to have a valid BoundingRectangle that is not null and has area.</value>
+    <value>An interactive element with a valid Name property is usually expected to have a valid BoundingRectangle that is not null and has area.</value>
     <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "BoundingRectangle" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="Structure" xml:space="preserve">
@@ -505,7 +505,7 @@
     <comment>The description of an accessibility problem with an element currently under inspection. The term "IsOffScreen" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
-    <value>The framework used to build this application does not support UI Automation.</value>
+    <value>The framework used to build this application does not support.</value>
     <comment>The description of an accessibility problem with an application currently under inspection.</comment>
   </data>
   <data name="EdgeBrowserHasBeenDeprecated" xml:space="preserve">

--- a/src/Rules/Resources/ErrorMessages.resx
+++ b/src/Rules/Resources/ErrorMessages.resx
@@ -119,54 +119,54 @@
   </resheader>
   <data name="ElementHelpTextNullOrWhiteSpace" xml:space="preserve">
     <value>The element's HelpText property must not be null or white space</value>
-    <comment>The text of an internal error that should not be translated.</comment>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="ElementLocalizedControlTypeNullOrWhiteSpace" xml:space="preserve">
     <value>The element's LocalizedControlType property must not be null or white space</value>
-    <comment>The text of an internal error that should not be translated.</comment>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="ElementNameNullOrWhiteSpace" xml:space="preserve">
     <value>The element's Name property must not be null or white space</value>
-    <comment>The text of an internal error that should not be translated.</comment>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="ElementParentNull" xml:space="preserve">
     <value>The element's Parent property must not be null</value>
-    <comment>The text of an internal error that should not be translated.</comment>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="ExpectedEnumType" xml:space="preserve">
     <value>Expected T to be an enumeration type</value>
-    <comment>The text of an internal error that should not be translated.</comment>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="ExpectedValidAncestor" xml:space="preserve">
     <value>Expected to find a valid ancestor element</value>
-    <comment>The text of an internal error that should not be translated.</comment>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="ExpectedValidConditionContext" xml:space="preserve">
     <value>Expected Condition.Context to be valid</value>
-    <comment>The text of an internal error that should not be translated.</comment>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="IntParameterEqualsZero" xml:space="preserve">
     <value>The given int parameter must not be zero</value>
-    <comment>The text of an internal error that should not be translated.</comment>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="IntParameterLessThanZero" xml:space="preserve">
     <value>Int parameter must not be less than zero</value>
-    <comment>The text of an internal error that should not be translated.</comment>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="NoControlTypeEntryFound" xml:space="preserve">
     <value>No control type entry was found in dictionary. Key value = {0}</value>
-    <comment>The text of an internal error that should not be translated.</comment>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="NoElementFound" xml:space="preserve">
     <value>Based on the Rule.Condition match, there should have been at least one element found in the PassesTest method of {0}</value>
-    <comment>The text of an internal error that should not be translated.</comment>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="NoLocalizedControlTypeStringFound" xml:space="preserve">
     <value>Could not find potential LocalizedControlType string(s) for the given control type</value>
-    <comment>The text of an internal error that should not be translated.</comment>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="StringNullOrWhiteSpace" xml:space="preserve">
     <value>Expected the given string not to be null and not to be white space</value>
-    <comment>The text of an internal error that should not be translated.</comment>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
 </root>

--- a/src/Rules/Resources/ErrorMessages.resx
+++ b/src/Rules/Resources/ErrorMessages.resx
@@ -119,42 +119,54 @@
   </resheader>
   <data name="ElementHelpTextNullOrWhiteSpace" xml:space="preserve">
     <value>The element's HelpText property must not be null or white space</value>
+    <comment>The text of an internal error that should not be translated.</comment>
   </data>
   <data name="ElementLocalizedControlTypeNullOrWhiteSpace" xml:space="preserve">
     <value>The element's LocalizedControlType property must not be null or white space</value>
+    <comment>The text of an internal error that should not be translated.</comment>
   </data>
   <data name="ElementNameNullOrWhiteSpace" xml:space="preserve">
     <value>The element's Name property must not be null or white space</value>
+    <comment>The text of an internal error that should not be translated.</comment>
   </data>
   <data name="ElementParentNull" xml:space="preserve">
     <value>The element's Parent property must not be null</value>
+    <comment>The text of an internal error that should not be translated.</comment>
   </data>
   <data name="ExpectedEnumType" xml:space="preserve">
     <value>Expected T to be an enumeration type</value>
+    <comment>The text of an internal error that should not be translated.</comment>
   </data>
   <data name="ExpectedValidAncestor" xml:space="preserve">
     <value>Expected to find a valid ancestor element</value>
+    <comment>The text of an internal error that should not be translated.</comment>
   </data>
   <data name="ExpectedValidConditionContext" xml:space="preserve">
     <value>Expected Condition.Context to be valid</value>
+    <comment>The text of an internal error that should not be translated.</comment>
   </data>
   <data name="IntParameterEqualsZero" xml:space="preserve">
     <value>The given int parameter must not be zero</value>
+    <comment>The text of an internal error that should not be translated.</comment>
   </data>
   <data name="IntParameterLessThanZero" xml:space="preserve">
     <value>Int parameter must not be less than zero</value>
+    <comment>The text of an internal error that should not be translated.</comment>
   </data>
   <data name="NoControlTypeEntryFound" xml:space="preserve">
     <value>No control type entry was found in dictionary. Key value = {0}</value>
-    <comment>{0} is the numeric key</comment>
+    <comment>The text of an internal error that should not be translated.</comment>
   </data>
   <data name="NoElementFound" xml:space="preserve">
     <value>Based on the Rule.Condition match, there should have been at least one element found in the PassesTest method of {0}</value>
+    <comment>The text of an internal error that should not be translated.</comment>
   </data>
   <data name="NoLocalizedControlTypeStringFound" xml:space="preserve">
     <value>Could not find potential LocalizedControlType string(s) for the given control type</value>
+    <comment>The text of an internal error that should not be translated.</comment>
   </data>
   <data name="StringNullOrWhiteSpace" xml:space="preserve">
     <value>Expected the given string not to be null and not to be white space</value>
+    <comment>The text of an internal error that should not be translated.</comment>
   </data>
 </root>

--- a/src/Rules/Resources/HowToFix.Designer.cs
+++ b/src/Rules/Resources/HowToFix.Designer.cs
@@ -218,7 +218,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes that support the Scroll pattern by default which app developers can&apos;t easily fix..
+        ///   Looks up a localized string similar to A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes that support the Scroll pattern by default, which app developers can&apos;t easily fix..
         /// </summary>
         internal static string ComboBoxShouldNotSupportScrollPattern {
             get {

--- a/src/Rules/Resources/HowToFix.Designer.cs
+++ b/src/Rules/Resources/HowToFix.Designer.cs
@@ -135,7 +135,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A button may have invoke and expandcollapse patterns together. but it is not recommended. if possible, please have only one of them. .
+        ///   Looks up a localized string similar to A button may have the Invoke and ExpandCollapse patterns together, but it is not recommended. If possible, please have only one of them. .
         /// </summary>
         internal static string ButtonInvokeAndExpandCollapsePatterns {
             get {
@@ -180,7 +180,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A button element should only support the one of Invoke, Toggle, or ExpandCollapse patterns when a splitbutton is the parent. .
+        ///   Looks up a localized string similar to A button element should only support one of Invoke, Toggle, or ExpandCollapse patterns when a splitbutton is the parent. .
         /// </summary>
         internal static string ButtonWithSplitButtonParentPattern {
             get {
@@ -218,7 +218,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes support the scroll pattern by default, which app developers can&apos;t easily fix..
+        ///   Looks up a localized string similar to A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes that support the Scroll pattern by default which app developers can&apos;t easily fix..
         /// </summary>
         internal static string ComboBoxShouldNotSupportScrollPattern {
             get {
@@ -523,7 +523,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The IsKeyboardFocusable property may be false when the given element supports the text pattern and is the descendant of an element that also supports the text pattern. Please consider if the given element should or should not be focusable..
+        ///   Looks up a localized string similar to The IsKeyboardFocusable property may be false when the given element supports the Text pattern and is the descendant of an element that also supports the Text pattern. Please consider if the given element should or should not be focusable..
         /// </summary>
         internal static string IsKeyboardFocusableDescendantTextPattern {
             get {
@@ -568,7 +568,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The IsKeyboardFocusable property should be true when you want an empty container to be discoverable by assistive technology users. IsKeyboardFocusable may be false when you want an empty container not to be discoverable by AT users..
+        ///   Looks up a localized string similar to The IsKeyboardFocusable property should be true when you want an empty container to be discoverable by assistive technology users. IsKeyboardFocusable may be false when you want an empty container not to be discoverable by assistive technology users..
         /// </summary>
         internal static string IsKeyboardFocusableOnEmptyContainer {
             get {
@@ -595,7 +595,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The IsKeyboardFocusable property should be true for an element that supports the text pattern, is not a descendant of an element that supports the text pattern, and which supports text selection..
+        ///   Looks up a localized string similar to The IsKeyboardFocusable property should be true for an element that supports the Text pattern, is not a descendant of an element that supports the Text pattern, and which supports text selection..
         /// </summary>
         internal static string IsKeyboardFocusableTopLevelTextPattern {
             get {
@@ -613,7 +613,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The ItemType property for the given element has no content, and the element has a child image. Please consider including an item type so that assistive technology users can obtain the information provided by the image. If this information is already provided in another way, the item type may not be necessary..
+        ///   Looks up a localized string similar to The ItemType property for the given element has no content, and the element has a child image. Please consider including an ItemType so that assistive technology users can obtain the information provided by the image. If this information is already provided in another way, the ItemType may not be necessary..
         /// </summary>
         internal static string ItemTypeRecommended {
             get {
@@ -741,7 +741,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The localized control type should be reasonable based on ControlTypeId..
+        ///   Looks up a localized string similar to The LocalizedControlType should be reasonable based on the element&apos;s ControlTypeId..
         /// </summary>
         internal static string LocalizedControlTypeReasonable {
             get {
@@ -820,7 +820,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The UIAutomation Name property for the given element is empty, but the element isn&apos;t focusable. Please consider whether or not the element should have a name..
+        ///   Looks up a localized string similar to The UI Automation Name property for the given element is empty, but the element isn&apos;t focusable. Please consider whether or not the element should have a name..
         /// </summary>
         internal static string NameEmptyButElementNotKeyboardFocusable {
             get {
@@ -907,7 +907,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The UI Automation Name property of a custom control may be empty if the parent is a wpf dataitem..
+        ///   Looks up a localized string similar to The UI Automation Name property of a custom control may be empty if the parent is a WPF dataitem..
         /// </summary>
         internal static string NameOnCustomWithParentWPFDataItem {
             get {
@@ -936,7 +936,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An interactive element with a valid UI Automation Name property is usually expected to have a valid bounding rectangle that is not null and has area..
+        ///   Looks up a localized string similar to An interactive element with a valid UI Automation Name property is usually expected to have a valid BoundingRectangle that is not null and has area..
         /// </summary>
         internal static string NameWithValidBoundingRectangle {
             get {

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -135,99 +135,99 @@
   </data>
   <data name="ControlShouldNotSupportValuePattern" xml:space="preserve">
     <value>An element of the given type should not support the Value pattern.</value>
-    <comment>The description of a problem with an element currently under inspection. The term "Value" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of a problem with an element currently under inspection. The term "Value" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldNotSupportWindowPattern" xml:space="preserve">
     <value>An element of the given type should not support the Window pattern.</value>
-    <comment>The description of a problem with an element currently under inspection. The term "Window" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of a problem with an element currently under inspection. The term "Window" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="HelpTextNotEqualToName" xml:space="preserve">
     <value>The HelpText property of an element must not be the same as the element's Name property.</value>
-    <comment>The description of a problem with an element currently under inspection. The terms "HelpText" and "Name" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of a problem with an element currently under inspection. The terms "HelpText" and "Name" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsContentElementFalseOptional" xml:space="preserve">
     <value>The recommended value of the IsContentElement property for the given control type is false. Please consider if this is an element that should be reported to an assistive technology user as content.</value>
-    <comment>The description of a problem with an element currently under inspection. The term "IsContentElement" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of a problem with an element currently under inspection. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsContentElementTrueOptional" xml:space="preserve">
     <value>The recommended value of the IsContentElement property for the given control type is true. Please consider if this is an element that should be reported to an assistive technology user as content.</value>
-    <comment>The description of a problem with an element currently under inspection. The term "IsContentElement" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of a problem with an element currently under inspection. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsControlElementTrueOptional" xml:space="preserve">
     <value>The recommended value of the IsControlElement property for the given control type is true. Please consider if this is an element that should be reported to an assistive technology user as a control. Note that almost all controls are required to have the IsControl Property set to true.</value>
-    <comment>The description of a problem with an element currently under inspection. The term "IsControlElement" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of a problem with an element currently under inspection. The term "IsControlElement" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element should be true based on its control type.</value>
-    <comment>The description of a problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of a problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButDisabled" xml:space="preserve">
     <value>The IsKeyboardFocusable property is false for an element where it would normally be true. However, the IsEnabled property on the element is also false, so the value of IsKeyboardFocusable may be acceptable.</value>
-    <comment>The description of a problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsEnabled" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of a problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsEnabled" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsKeyboardFocusableForListItemShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given list item is false, but the element has children that are focusable. The element should probably be focusable instead of its children.</value>
-    <comment>The description of a problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of a problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButOffscreen" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element is false for an element where it would normally be true. However, the IsOffscreen property on the element is true, so the value of IsKeyboardFocusable may be acceptable.</value>
-    <comment>The description of a problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsOffscreen" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of a problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsOffscreen" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsKeyboardFocusableForCustomShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for a custom element should be true when the element supports actionable patterns.</value>
-    <comment>The description of a problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of a problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableDescendantTextPattern" xml:space="preserve">
     <value>The IsKeyboardFocusable property may be false when the given element supports the Text pattern and is the descendant of an element that also supports the Text pattern. Please consider if the given element should or should not be focusable.</value>
-    <comment>The description of a problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of a problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsKeyboardFocusableOnEmptyContainer" xml:space="preserve">
     <value>The IsKeyboardFocusable property should be true when you want an empty container to be discoverable by assistive technology users. IsKeyboardFocusable may be false when you want an empty container not to be discoverable by assistive technology users.</value>
-    <comment>The description of a problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of a problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeFalse" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element is expected to be false because of the element's control type.</value>
-    <comment>The description of a problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of a problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableTopLevelTextPattern" xml:space="preserve">
     <value>The IsKeyboardFocusable property should be true for an element that supports the Text pattern, is not a descendant of an element that supports the Text pattern, and which supports text selection.</value>
-    <comment>The description of a problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of a problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ItemStatusExists" xml:space="preserve">
     <value>The ItemStatus property for the given element should exist.</value>
-    <comment>The description of a problem with an element currently under inspection. The term "ItemStatus" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of a problem with an element currently under inspection. The term "ItemStatus" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeReasonable" xml:space="preserve">
     <value>The LocalizedControlType should be reasonable based on the element's ControlTypeId.</value>
-    <comment>The description of a problem with an element currently under inspection. The terms "LocalizedControlType" and "ControlTypeId" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of a problem with an element currently under inspection. The terms "LocalizedControlType" and "ControlTypeId" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ItemTypeRecommended" xml:space="preserve">
     <value>The ItemType property for the given element has no content, and the element has a child image. Please consider including an ItemType so that assistive technology users can obtain the information provided by the image. If this information is already provided in another way, the ItemType may not be necessary.</value>
-    <comment>The description of a problem with an element currently under inspection. The term "ItemType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of a problem with an element currently under inspection. The term "ItemType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameEmptyButElementNotKeyboardFocusable" xml:space="preserve">
     <value>The UI Automation Name property for the given element is empty, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
-    <comment>The description of a problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of a problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNoSiblingsOfSameType" xml:space="preserve">
     <value>The UI Automation Name property of the given element may be null or empty if the element has no siblings of the same type.</value>
-    <comment>The description of a problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of a problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNullButElementNotKeyboardFocusable" xml:space="preserve">
     <value>The UI Automation Name property for the given element is null, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
-    <comment>The description of a problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of a problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameOnCustomWithParentWPFDataItem" xml:space="preserve">
     <value>The UI Automation Name property of a custom control may be empty if the parent is a WPF dataitem.</value>
-    <comment>The description of a problem with an element currently under inspection. The terms "Name" and "dataitem" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of a problem with an element currently under inspection. The terms "Name" and "dataitem" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="NameOnOptionalType" xml:space="preserve">
     <value>The UI Automation Name property for the given element type is optional.</value>
-    <comment>The description of a problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>The description of a problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameWithValidBoundingRectangle" xml:space="preserve">
     <value>An interactive element with a valid UI Automation Name property is usually expected to have a valid BoundingRectangle that is not null and has area.</value>
-    <comment>The description of a problem with an element currently under inspection. The terms "Name" and "BoundingRectangle" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of a problem with an element currently under inspection. The terms "Name" and "BoundingRectangle" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="Structure" xml:space="preserve">
     <value>The given element is expected to have the following structure: {0}.</value>
@@ -235,153 +235,153 @@
   </data>
   <data name="SelectionPatternSelectionRequired" xml:space="preserve">
     <value>Set the element's IsSelectionRequired property of the SelectionPattern to TRUE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "IsSelectionRequired" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "IsSelectionRequired" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ButtonInvokeAndExpandCollapsePatterns" xml:space="preserve">
     <value>A button may have the Invoke and ExpandCollapse patterns together, but it is not recommended. If possible, please have only one of them. </value>
-    <comment>The description of a problem with an element currently under inspection. The terms "Invoke" and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>The description of a problem with an element currently under inspection. The terms "Invoke" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ButtonShouldHavePatterns" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ButtonToggleAndExpandCollapsePatterns" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ProgressBarRangeValue" xml:space="preserve">
     <value>Implement the progress bar's RangeValue pattern using the following properties and values:
  · Minimum: 0.0
  · Maximum: 100.0
  · IsReadOnly: TRUE</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "RangeValue", "Minimum", "Maximum", and "IsReadOnly" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "RangeValue", "Minimum", "Maximum", and "IsReadOnly" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
     <data name="EditSupportsIncorrectRangeValuePattern" xml:space="preserve">
     <value>Implement the edit control's RangeValue pattern with a null LargeChange property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "RangeValue" and "LargeChange" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "RangeValue" and "LargeChange" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="SplitButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>Modify the split button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke" and "Toggle" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke" and "Toggle" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldNotSupportInvokePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Modify the element to support only its allowed patterns.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldNotSupportScrollPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Modify the element to support only its allowed patterns.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldNotSupportTogglePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Modify the element to support only its allowed patterns.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldSupportExpandCollapsePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the ExpandCollapse pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportGridItemPattern" xml:space="preserve">
     <value>Modify the element (or one of its children) to support the GridItem pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "GridItem" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "GridItem" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldSupportGridPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Grid pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Grid" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Grid" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportInvokePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Invoke pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Invoke" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Invoke" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportScrollItemPattern" xml:space="preserve">
     <value>Modify the element (or one of its children) to support the ScrollItem pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ScrollItem" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ScrollItem" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldSupportSelectionItemPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the SelectionItem pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "SelectionItem" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "SelectionItem" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportSelectionPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Selection pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Selection" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Selection" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportSpreadsheetItemPattern" xml:space="preserve">
     <value>Modify the element (or one of its children) to support the SpreadsheetItem pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "SpreadsheetItem" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "SpreadsheetItem" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldSupportTableItemPattern" xml:space="preserve">
     <value>Modify the element (or one of its children) to support the TableItem pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "TableItem" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "TableItem" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldSupportTablePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Table pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Table" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Table" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportTextPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Text pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Text" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Text" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportTogglePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Toggle pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Toggle" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Toggle" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportTransformPattern" xml:space="preserve">
     <value>If the element can be resized, implement the Transform pattern.
 If the element can't be resized, ensure the TransformPattern_CanResize property is FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Transform" and "TransformPattern_CanResize" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Transform" and "TransformPattern_CanResize" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ChildrenNotAllowedInContentView" xml:space="preserve">
     <value>Make sure all of the element's children have the IsContentElement property set to FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="SelectionPatternSingleSelection" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Make sure Selection is the correct pattern.
 3. Set the element's CanSelectMultiple property to FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType", "Selection", and "CanSelectMultiple" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType", "Selection", and "CanSelectMultiple" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="SelectionItemPatternSingleSelection" xml:space="preserve">
     <value>Do one of the following:
  1. Modify the element and/or its siblings so that only one of them is selected at any given time, OR
  2. Modify the parent element so its CanSelectMultiple property is TRUE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "CanSelectMultiple" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "CanSelectMultiple" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ParentChildShouldNotHaveSameNameAndLocalizedControlType" xml:space="preserve">
     <value>Provide unique names for controls that have a parent/child relationship and the same ControlType property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="SiblingUniqueAndFocusable" xml:space="preserve">
     <value>Provide unique names for sibling controls that have the same ControlType property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldSupportSetInfo" xml:space="preserve">
     <value>Provide valid values for the SizeOfSet and PositionInSet properties.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "SizeOfSet" and "PositionInSet" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "SizeOfSet" and "PositionInSet" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="BoundingRectangleCompletelyObscuresContainer" xml:space="preserve">
     <value>Modify one or both bounding rectangles to ensure that the bounding rectangle of the container element is not completely obscured.</value>
@@ -412,11 +412,11 @@ If the element can't be resized, ensure the TransformPattern_CanResize property 
   <data name="BoundingRectangleNotNull" xml:space="preserve">
     <value>If the element is off-screen, set its IsOffscreen property to TRUE.
 If the element is on-screen, provide a BoundingRectangle property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "IsOffscreen" and "BoundingRectangle" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "IsOffscreen" and "BoundingRectangle" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="BoundingRectangleSizeReasonable" xml:space="preserve">
     <value>Modify the BoundingRectangle property so that its width and height define an area of at least 25 pixels.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "BoundingRectangle" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="HeadingLevelDescendsWhenNested" xml:space="preserve">
     <value>Modify the heading levels and/or nesting structure of the element and/or its ancestors.
@@ -427,17 +427,17 @@ For example, if an element has a level-5 heading, its descendants can have only 
     <value>Provide a value for the element's IsContentElement property:
  · If the element should be included in the content view, set the property to TRUE.
  · If the element should not be included in the content view, set the property to FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsControlElementPropertyExists" xml:space="preserve">
     <value>Provide a value for the element's IsControlElement property:
  · If the element should be included in the control view, set the property to TRUE.
  · If the element should not be included in the control view, set the property to FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsControlElement" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsControlElement" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsControlElementTrueRequired" xml:space="preserve">
     <value>Set the element's IsControlElement property to TRUE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsControlElement" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsControlElement" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LandmarkBannerIsTopLevel" xml:space="preserve">
     <value>Modify the banner element so it does not descend from any other landmark.
@@ -479,7 +479,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotCustom" xml:space="preserve">
     <value>Provide string for the LocalizedLandmarkType property that does not include "custom."
@@ -492,7 +492,7 @@ Where appropriate, use a standard localized landmark type:
     ·         Use "navigation" for an area containing links for page or site navigation.
     ·         Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotEmpty" xml:space="preserve">
     <value>Provide a string for the LocalizedLandmarkType property.
@@ -505,7 +505,7 @@ Where appropriate, use a standard localized landmark type:
     ·         Use "navigation" for an area containing links for page or site navigation.
     ·         Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotNull" xml:space="preserve">
     <value>Provide a LocalizedLandmarkType property for the element.
@@ -518,7 +518,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotWhiteSpace" xml:space="preserve">
     <value>Provide a string for the LocalizedLandmarkType property.
@@ -531,7 +531,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeNotCustom" xml:space="preserve">
     <value>Sufficient:
@@ -539,7 +539,7 @@ Provide a string for the LocalizedControlType property that concisely describes 
 
 Better:
 If possible, use a predefined (non-custom) control type and the default localized control type. The UIA framework will provide the correct localized control type automatically.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeNotCustomWPFGridCell" xml:space="preserve">
     <value>{0}
@@ -549,55 +549,55 @@ If your application targets a version of .NET Framework before 4.7.1, but is run
   </data>
   <data name="LocalizedControlTypeNotEmpty" xml:space="preserve">
     <value>Provide a string for the LocalizedControlType property that concisely describes the control's type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeNotNull" xml:space="preserve">
     <value>Provide a string for the LocalizedControlType property that concisely describes the control's type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeNotWhiteSpace" xml:space="preserve">
     <value>Provide a string for the LocalizedControlType property that concisely describes the control's type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="OrientationPropertyExists" xml:space="preserve">
     <value>Provide an Orientation property for the element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Orientation" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Orientation" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameExcludesControlType" xml:space="preserve">
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the control type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameExcludesLocalizedControlType" xml:space="preserve">
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the same text as the element's LocalizedControlType property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "name" and "LocalizedControlType" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "name" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="NameIsInformative" xml:space="preserve">
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the element's class name (such as Microsoft.*.* or Windows.*.*).</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">
     <value>Provide a UI Automation Name property that concisely identifies the element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotNull" xml:space="preserve">
     <value>Provide a UI Automation Name property that concisely identifies the element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotWhiteSpace" xml:space="preserve">
     <value>Provide a UI Automation Name property that concisely identifies the element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameReasonableLength" xml:space="preserve">
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Contains at most 512 characters.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ListItemSiblingsUnique" xml:space="preserve">
     <value>Provide unique names for sibling list items.</value>
@@ -614,12 +614,12 @@ If your application targets a version of .NET Framework before 4.7.1, but is run
   <data name="ClickablePointOnScreen" xml:space="preserve">
     <value>If the element's ClickablePoint property is correct, set the element's IsOffScreen property to false.
 If the element's ClickablePoint property is incorrect, please ensure it returns the correct value.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ClickablePoint" and "IsOffscreen" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ClickablePoint" and "IsOffscreen" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ClickablePointOffScreen" xml:space="preserve">
     <value>If the element's ClickablePoint property is correct, set the element's IsOffScreen property to true.
 If the element's ClickablePoint property is incorrect, please ensure it returns the correct value.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ClickablePoint" and "IsOffscreen" should not be translated(i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ClickablePoint" and "IsOffscreen" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
     <value>Switch your application to a framework that supports UI Automation.</value>

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -130,7 +130,7 @@
     <comment>The description of a problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ComboBoxShouldNotSupportScrollPattern" xml:space="preserve">
-    <value>A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes that support the Scroll pattern by default which app developers can't easily fix.</value>
+    <value>A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes that support the Scroll pattern by default, which app developers can't easily fix.</value>
     <comment>The description of a problem with an element currently under inspection. The term "Scroll" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldNotSupportValuePattern" xml:space="preserve">
@@ -269,7 +269,7 @@
  · IsReadOnly: TRUE</value>
     <comment>Brief guidance on how to fix an accessibility problem. The terms "RangeValue", "Minimum", "Maximum", and "IsReadOnly" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
-    <data name="EditSupportsIncorrectRangeValuePattern" xml:space="preserve">
+  <data name="EditSupportsIncorrectRangeValuePattern" xml:space="preserve">
     <value>Implement the edit control's RangeValue pattern with a null LargeChange property.</value>
     <comment>Brief guidance on how to fix an accessibility problem. The terms "RangeValue" and "LargeChange" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -119,216 +119,277 @@
   </resheader>
   <data name="BoundingRectangleNotValidButOffScreen" xml:space="preserve">
     <value>The BoundingRectangle property is not valid, but the element is off-screen.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ButtonWithSplitButtonParentPattern" xml:space="preserve">
-    <value>A button element should only support the one of Invoke, Toggle, or ExpandCollapse patterns when a splitbutton is the parent. </value>
+    <value>A button element should only support one of Invoke, Toggle, or ExpandCollapse patterns when a splitbutton is the parent. </value>
+    <comment>The description of a problem with an element currently under inspection. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="SiblingUniqueAndNotFocusable" xml:space="preserve">
     <value>The given element has siblings with the same Name and LocalizedControlType.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ComboBoxShouldNotSupportScrollPattern" xml:space="preserve">
-    <value>A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes support the scroll pattern by default, which app developers can't easily fix.</value>
+    <value>A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes that support the Scroll pattern by default which app developers can't easily fix.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "Scroll" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldNotSupportValuePattern" xml:space="preserve">
     <value>An element of the given type should not support the Value pattern.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "Value" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldNotSupportWindowPattern" xml:space="preserve">
     <value>An element of the given type should not support the Window pattern.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "Window" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="HelpTextNotEqualToName" xml:space="preserve">
     <value>The HelpText property of an element must not be the same as the element's Name property.</value>
+    <comment>The description of a problem with an element currently under inspection. The terms "HelpText" and "Name" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsContentElementFalseOptional" xml:space="preserve">
     <value>The recommended value of the IsContentElement property for the given control type is false. Please consider if this is an element that should be reported to an assistive technology user as content.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "IsContentElement" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsContentElementTrueOptional" xml:space="preserve">
     <value>The recommended value of the IsContentElement property for the given control type is true. Please consider if this is an element that should be reported to an assistive technology user as content.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "IsContentElement" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsControlElementTrueOptional" xml:space="preserve">
     <value>The recommended value of the IsControlElement property for the given control type is true. Please consider if this is an element that should be reported to an assistive technology user as a control. Note that almost all controls are required to have the IsControl Property set to true.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "IsControlElement" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element should be true based on its control type.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButDisabled" xml:space="preserve">
     <value>The IsKeyboardFocusable property is false for an element where it would normally be true. However, the IsEnabled property on the element is also false, so the value of IsKeyboardFocusable may be acceptable.</value>
+    <comment>The description of a problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsEnabled" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsKeyboardFocusableForListItemShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given list item is false, but the element has children that are focusable. The element should probably be focusable instead of its children.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButOffscreen" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element is false for an element where it would normally be true. However, the IsOffscreen property on the element is true, so the value of IsKeyboardFocusable may be acceptable.</value>
+    <comment>The description of a problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsOffscreen" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsKeyboardFocusableForCustomShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for a custom element should be true when the element supports actionable patterns.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableDescendantTextPattern" xml:space="preserve">
-    <value>The IsKeyboardFocusable property may be false when the given element supports the text pattern and is the descendant of an element that also supports the text pattern. Please consider if the given element should or should not be focusable.</value>
+    <value>The IsKeyboardFocusable property may be false when the given element supports the Text pattern and is the descendant of an element that also supports the Text pattern. Please consider if the given element should or should not be focusable.</value>
+    <comment>The description of a problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="IsKeyboardFocusableOnEmptyContainer" xml:space="preserve">
-    <value>The IsKeyboardFocusable property should be true when you want an empty container to be discoverable by assistive technology users. IsKeyboardFocusable may be false when you want an empty container not to be discoverable by AT users.</value>
+    <value>The IsKeyboardFocusable property should be true when you want an empty container to be discoverable by assistive technology users. IsKeyboardFocusable may be false when you want an empty container not to be discoverable by assistive technology users.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeFalse" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element is expected to be false because of the element's control type.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsKeyboardFocusableTopLevelTextPattern" xml:space="preserve">
-    <value>The IsKeyboardFocusable property should be true for an element that supports the text pattern, is not a descendant of an element that supports the text pattern, and which supports text selection.</value>
+    <value>The IsKeyboardFocusable property should be true for an element that supports the Text pattern, is not a descendant of an element that supports the Text pattern, and which supports text selection.</value>
+    <comment>The description of a problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ItemStatusExists" xml:space="preserve">
     <value>The ItemStatus property for the given element should exist.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "ItemStatus" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeReasonable" xml:space="preserve">
-    <value>The localized control type should be reasonable based on ControlTypeId.</value>
+    <value>The LocalizedControlType should be reasonable based on the element's ControlTypeId.</value>
+    <comment>The description of a problem with an element currently under inspection. The terms "LocalizedControlType" and "ControlTypeId" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ItemTypeRecommended" xml:space="preserve">
-    <value>The ItemType property for the given element has no content, and the element has a child image. Please consider including an item type so that assistive technology users can obtain the information provided by the image. If this information is already provided in another way, the item type may not be necessary.</value>
+    <value>The ItemType property for the given element has no content, and the element has a child image. Please consider including an ItemType so that assistive technology users can obtain the information provided by the image. If this information is already provided in another way, the ItemType may not be necessary.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "ItemType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameEmptyButElementNotKeyboardFocusable" xml:space="preserve">
-    <value>The UIAutomation Name property for the given element is empty, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
+    <value>The UI Automation Name property for the given element is empty, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNoSiblingsOfSameType" xml:space="preserve">
     <value>The UI Automation Name property of the given element may be null or empty if the element has no siblings of the same type.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNullButElementNotKeyboardFocusable" xml:space="preserve">
     <value>The UI Automation Name property for the given element is null, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameOnCustomWithParentWPFDataItem" xml:space="preserve">
-    <value>The UI Automation Name property of a custom control may be empty if the parent is a wpf dataitem.</value>
+    <value>The UI Automation Name property of a custom control may be empty if the parent is a WPF dataitem.</value>
+    <comment>The description of a problem with an element currently under inspection. The terms "Name" and "dataitem" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="NameOnOptionalType" xml:space="preserve">
     <value>The UI Automation Name property for the given element type is optional.</value>
+    <comment>The description of a problem with an element currently under inspection. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameWithValidBoundingRectangle" xml:space="preserve">
-    <value>An interactive element with a valid UI Automation Name property is usually expected to have a valid bounding rectangle that is not null and has area.</value>
+    <value>An interactive element with a valid UI Automation Name property is usually expected to have a valid BoundingRectangle that is not null and has area.</value>
+    <comment>The description of a problem with an element currently under inspection. The terms "Name" and "BoundingRectangle" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="Structure" xml:space="preserve">
     <value>The given element is expected to have the following structure: {0}.</value>
+    <comment>The description of a problem with an element currently under inspection.</comment>
   </data>
   <data name="SelectionPatternSelectionRequired" xml:space="preserve">
     <value>Set the element's IsSelectionRequired property of the SelectionPattern to TRUE.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "IsSelectionRequired" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ButtonInvokeAndExpandCollapsePatterns" xml:space="preserve">
-    <value>A button may have invoke and expandcollapse patterns together. but it is not recommended. if possible, please have only one of them. </value>
+    <value>A button may have the Invoke and ExpandCollapse patterns together, but it is not recommended. If possible, please have only one of them. </value>
+    <comment>The description of a problem with an element currently under inspection. The terms "Invoke" and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ButtonShouldHavePatterns" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ButtonToggleAndExpandCollapsePatterns" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ProgressBarRangeValue" xml:space="preserve">
     <value>Implement the progress bar's RangeValue pattern using the following properties and values:
  · Minimum: 0.0
  · Maximum: 100.0
  · IsReadOnly: TRUE</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "RangeValue", "Minimum", "Maximum", and "IsReadOnly" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
-  <data name="EditSupportsIncorrectRangeValuePattern" xml:space="preserve">
+    <data name="EditSupportsIncorrectRangeValuePattern" xml:space="preserve">
     <value>Implement the edit control's RangeValue pattern with a null LargeChange property.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "RangeValue" and "LargeChange" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="SplitButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>Modify the split button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke" and "Toggle" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldNotSupportInvokePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Modify the element to support only its allowed patterns.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldNotSupportScrollPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Modify the element to support only its allowed patterns.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldNotSupportTogglePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Modify the element to support only its allowed patterns.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldSupportExpandCollapsePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the ExpandCollapse pattern.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "ExpandCollapse" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportGridItemPattern" xml:space="preserve">
     <value>Modify the element (or one of its children) to support the GridItem pattern.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "GridItem" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldSupportGridPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Grid pattern.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Grid" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportInvokePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Invoke pattern.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Invoke" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportScrollItemPattern" xml:space="preserve">
     <value>Modify the element (or one of its children) to support the ScrollItem pattern.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ScrollItem" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldSupportSelectionItemPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the SelectionItem pattern.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "SelectionItem" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportSelectionPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Selection pattern.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Selection" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportSpreadsheetItemPattern" xml:space="preserve">
     <value>Modify the element (or one of its children) to support the SpreadsheetItem pattern.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "SpreadsheetItem" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldSupportTableItemPattern" xml:space="preserve">
     <value>Modify the element (or one of its children) to support the TableItem pattern.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "TableItem" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldSupportTablePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Table pattern.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Table" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportTextPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Text pattern.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Text" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportTogglePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Toggle pattern.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Toggle" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ControlShouldSupportTransformPattern" xml:space="preserve">
     <value>If the element can be resized, implement the Transform pattern.
 If the element can't be resized, ensure the TransformPattern_CanResize property is FALSE.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Transform" and "TransformPattern_CanResize" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ChildrenNotAllowedInContentView" xml:space="preserve">
     <value>Make sure all of the element's children have the IsContentElement property set to FALSE.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="SelectionPatternSingleSelection" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Make sure Selection is the correct pattern.
 3. Set the element's CanSelectMultiple property to FALSE.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType", "Selection", and "CanSelectMultiple" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="SelectionItemPatternSingleSelection" xml:space="preserve">
     <value>Do one of the following:
  1. Modify the element and/or its siblings so that only one of them is selected at any given time, OR
  2. Modify the parent element so its CanSelectMultiple property is TRUE.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "CanSelectMultiple" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ParentChildShouldNotHaveSameNameAndLocalizedControlType" xml:space="preserve">
     <value>Provide unique names for controls that have a parent/child relationship and the same ControlType property.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="SiblingUniqueAndFocusable" xml:space="preserve">
     <value>Provide unique names for sibling controls that have the same ControlType property.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ControlShouldSupportSetInfo" xml:space="preserve">
     <value>Provide valid values for the SizeOfSet and PositionInSet properties.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "SizeOfSet" and "PositionInSet" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="BoundingRectangleCompletelyObscuresContainer" xml:space="preserve">
     <value>Modify one or both bounding rectangles to ensure that the bounding rectangle of the container element is not completely obscured.</value>
+    <comment>Brief guidance on how to fix an accessibility problem.</comment>
   </data>
   <data name="BoundingRectangleContainedInParent" xml:space="preserve">
     <value>Modify one or both bounding rectangles to ensure that the element's bounding rectangle is contained within the bounding rectangle of its parent.</value>
+    <comment>Brief guidance on how to fix an accessibility problem.</comment>
   </data>
   <data name="BoundingRectangleDataFormatCorrect" xml:space="preserve">
     <value>Make sure the BoundingRectangle property returns data in the expected format:
@@ -338,6 +399,7 @@ If the element can't be resized, ensure the TransformPattern_CanResize property 
     b. Left edge
     c. Width
     d. Height</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="BoundingRectangleNotAllZeros" xml:space="preserve">
     <value>Specify the rectangle's position and size (in pixels) by providing array values in the following order:
@@ -345,53 +407,66 @@ If the element can't be resized, ensure the TransformPattern_CanResize property 
  2. Left edge
  3. Width
  4. Height</value>
+    <comment>Brief guidance on how to fix an accessibility problem.</comment>
   </data>
   <data name="BoundingRectangleNotNull" xml:space="preserve">
     <value>If the element is off-screen, set its IsOffscreen property to TRUE.
 If the element is on-screen, provide a BoundingRectangle property.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "IsOffscreen" and "BoundingRectangle" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="BoundingRectangleSizeReasonable" xml:space="preserve">
     <value>Modify the BoundingRectangle property so that its width and height define an area of at least 25 pixels.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "BoundingRectangle" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="HeadingLevelDescendsWhenNested" xml:space="preserve">
     <value>Modify the heading levels and/or nesting structure of the element and/or its ancestors.
 For example, if an element has a level-5 heading, its descendants can have only level-5 or level-6 headings.</value>
+    <comment>Brief guidance on how to fix an accessibility problem.</comment>
   </data>
   <data name="IsContentElementPropertyExists" xml:space="preserve">
     <value>Provide a value for the element's IsContentElement property:
  · If the element should be included in the content view, set the property to TRUE.
  · If the element should not be included in the content view, set the property to FALSE.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsControlElementPropertyExists" xml:space="preserve">
     <value>Provide a value for the element's IsControlElement property:
  · If the element should be included in the control view, set the property to TRUE.
  · If the element should not be included in the control view, set the property to FALSE.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsControlElement" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="IsControlElementTrueRequired" xml:space="preserve">
     <value>Set the element's IsControlElement property to TRUE.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsControlElement" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LandmarkBannerIsTopLevel" xml:space="preserve">
     <value>Modify the banner element so it does not descend from any other landmark.
       Exception: If a page has nested document or application roles, each nested document or application may have one banner landmark.</value>
+    <comment>Brief guidance on how to fix an accessibility problem.</comment>
   </data>
   <data name="LandmarkComplementaryIsTopLevel" xml:space="preserve">
     <value>Modify the complementary landmark so it does not descend from any other landmark.
       Exception: If a page has nested document or application roles, each nested document or application may have one complementary landmark.</value>
+    <comment>Brief guidance on how to fix an accessibility problem.</comment>
   </data>
   <data name="LandmarkContentInfoIsTopLevel" xml:space="preserve">
     <value>Modify the contentinfo landmark so it does not descend from any other landmark.
       Exception: If a page has nested document or application roles, each nested document or application may have one contentinfo landmark.</value>
+    <comment>Brief guidance on how to fix an accessibility problem.</comment>
   </data>
   <data name="LandmarkMainIsTopLevel" xml:space="preserve">
     <value>Modify the main landmark so it does not descend from any other landmark.
       Exception: If a page has nested document or application roles, each nested document or application may have one main landmark.</value>
+    <comment>Brief guidance on how to fix an accessibility problem.</comment>
   </data>
   <data name="LandmarkNoDuplicateBanner" xml:space="preserve">
     <value>Use the banner landmark only once per page.
       Exception: If a page has nested document or application roles, each nested document or application may have a banner landmark.</value>
+    <comment>Brief guidance on how to fix an accessibility problem.</comment>
   </data>
   <data name="LandmarkNoDuplicateContentInfo" xml:space="preserve">
     <value>Use the contentinfo landmark only once per page.</value>
+    <comment>Brief guidance on how to fix an accessibility problem.</comment>
   </data>
   <data name="LocalizedLandmarkTypeIsReasonableLength" xml:space="preserve">
     <value>Provide a string for the LocalizedLandmarkType property that contains at most 64 characters.
@@ -404,6 +479,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotCustom" xml:space="preserve">
     <value>Provide string for the LocalizedLandmarkType property that does not include "custom."
@@ -416,6 +492,7 @@ Where appropriate, use a standard localized landmark type:
     ·         Use "navigation" for an area containing links for page or site navigation.
     ·         Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotEmpty" xml:space="preserve">
     <value>Provide a string for the LocalizedLandmarkType property.
@@ -428,6 +505,7 @@ Where appropriate, use a standard localized landmark type:
     ·         Use "navigation" for an area containing links for page or site navigation.
     ·         Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotNull" xml:space="preserve">
     <value>Provide a LocalizedLandmarkType property for the element.
@@ -440,6 +518,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotWhiteSpace" xml:space="preserve">
     <value>Provide a string for the LocalizedLandmarkType property.
@@ -452,6 +531,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeNotCustom" xml:space="preserve">
     <value>Sufficient:
@@ -459,74 +539,94 @@ Provide a string for the LocalizedControlType property that concisely describes 
 
 Better:
 If possible, use a predefined (non-custom) control type and the default localized control type. The UIA framework will provide the correct localized control type automatically.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeNotCustomWPFGridCell" xml:space="preserve">
     <value>{0}
     
 If your application targets a version of .NET Framework before 4.7.1, but is running on a system where .NET version 4.7.1 or higher is installed, you may be able to address this issue by taking advantage of accessibility enhancements in .NET 4.7.1. To do this, you will need to enable accessibility switches as described on the following page: https://docs.microsoft.com/en-us/dotnet/framework/whats-new/whats-new-in-accessibility#accessibility-switches</value>
+    <comment>Brief guidance on how to fix an accessibility problem. If you know it, replace en-us in the URL with the IETF language code of the target language (es-es for Spanish, de-de for German, etc.), but otherwise do not localize the URL.</comment>
   </data>
   <data name="LocalizedControlTypeNotEmpty" xml:space="preserve">
     <value>Provide a string for the LocalizedControlType property that concisely describes the control's type.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeNotNull" xml:space="preserve">
     <value>Provide a string for the LocalizedControlType property that concisely describes the control's type.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="LocalizedControlTypeNotWhiteSpace" xml:space="preserve">
     <value>Provide a string for the LocalizedControlType property that concisely describes the control's type.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="OrientationPropertyExists" xml:space="preserve">
     <value>Provide an Orientation property for the element.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Orientation" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameExcludesControlType" xml:space="preserve">
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the control type.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameExcludesLocalizedControlType" xml:space="preserve">
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the same text as the element's LocalizedControlType property.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "name" and "LocalizedControlType" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="NameIsInformative" xml:space="preserve">
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the element's class name (such as Microsoft.*.* or Windows.*.*).</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">
     <value>Provide a UI Automation Name property that concisely identifies the element.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotNull" xml:space="preserve">
     <value>Provide a UI Automation Name property that concisely identifies the element.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotWhiteSpace" xml:space="preserve">
     <value>Provide a UI Automation Name property that concisely identifies the element.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameReasonableLength" xml:space="preserve">
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Contains at most 512 characters.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated(i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="ListItemSiblingsUnique" xml:space="preserve">
     <value>Provide unique names for sibling list items.</value>
+    <comment>Brief guidance on how to fix an accessibility problem.</comment>
   </data>
   <data name="HyperlinkNameShouldBeUnique" xml:space="preserve">
     <value>If the sibling hyperlink with the same Name navigates to a different destination, change the Name of either hyperlink.</value>
+    <comment>Brief guidance on how to fix an accessibility problem.</comment>
   </data>
   <data name="PropertyExcludesPrivateUnicodeCharacters" xml:space="preserve">
     <value>Modify the {0} property, removing all characters in the range U+E000 to U+F8FF and replace them with meaningful, standard text content.</value>
+    <comment>Brief guidance on how to fix an accessibility problem.</comment>
   </data>
   <data name="ClickablePointOnScreen" xml:space="preserve">
     <value>If the element's ClickablePoint property is correct, set the element's IsOffScreen property to false.
 If the element's ClickablePoint property is incorrect, please ensure it returns the correct value.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ClickablePoint" and "IsOffscreen" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="ClickablePointOffScreen" xml:space="preserve">
     <value>If the element's ClickablePoint property is correct, set the element's IsOffScreen property to true.
 If the element's ClickablePoint property is incorrect, please ensure it returns the correct value.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ClickablePoint" and "IsOffscreen" should not be translated(i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
     <value>Switch your application to a framework that supports UI Automation.</value>
+    <comment>Brief guidance on how to fix an accessibility problem.</comment>
   </data>
   <data name="EdgeBrowserHasBeenDeprecated" xml:space="preserve">
     <value>The non-Chromium version of Edge has reached its end of life and should not be used for current product development. Please migrate your application to a supported browser.</value>
+    <comment>Brief guidance on how to fix an accessibility problem.</comment>
   </data>
 </root>

--- a/src/Rules/Resources/LocalizedControlTypeNames.resx
+++ b/src/Rules/Resources/LocalizedControlTypeNames.resx
@@ -119,125 +119,166 @@
   </resheader>
   <data name="AppBar" xml:space="preserve">
     <value>app bar</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Button" xml:space="preserve">
     <value>button</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Calendar" xml:space="preserve">
     <value>calendar</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="CheckBox" xml:space="preserve">
     <value>check box</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="ComboBox" xml:space="preserve">
     <value>combo box</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Custom" xml:space="preserve">
     <value>custom</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="DataGrid" xml:space="preserve">
     <value>data grid,datagrid</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="DataItem" xml:space="preserve">
     <value>data item</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Document" xml:space="preserve">
     <value>document</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Edit" xml:space="preserve">
     <value>edit</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Group" xml:space="preserve">
     <value>group</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Header" xml:space="preserve">
     <value>header</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="HeaderItem" xml:space="preserve">
     <value>header item</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Hyperlink" xml:space="preserve">
     <value>hyperlink,link</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Image" xml:space="preserve">
     <value>image</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="List" xml:space="preserve">
     <value>list,list view</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="ListItem" xml:space="preserve">
     <value>list item</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Menu" xml:space="preserve">
     <value>menu</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="MenuBar" xml:space="preserve">
     <value>menu bar</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="MenuItem" xml:space="preserve">
     <value>menu item</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Pane" xml:space="preserve">
     <value>pane</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="ProgressBar" xml:space="preserve">
     <value>progress bar</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="RadioButton" xml:space="preserve">
     <value>radio button</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="ScrollBar" xml:space="preserve">
     <value>scroll bar</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="SemanticZoom" xml:space="preserve">
     <value>semantic zoom,semanticzoom</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Separator" xml:space="preserve">
     <value>separator</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Slider" xml:space="preserve">
     <value>slider</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Spinner" xml:space="preserve">
     <value>spinner</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="SplitButton" xml:space="preserve">
     <value>split button</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="StatusBar" xml:space="preserve">
     <value>status bar</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Tab" xml:space="preserve">
     <value>tab</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="TabItem" xml:space="preserve">
     <value>tab item</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Table" xml:space="preserve">
     <value>table</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Text" xml:space="preserve">
     <value>text</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Thumb" xml:space="preserve">
     <value>thumb</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="TitleBar" xml:space="preserve">
     <value>title bar</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="ToolBar" xml:space="preserve">
     <value>toolbar</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="ToolTip" xml:space="preserve">
     <value>tooltip</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Tree" xml:space="preserve">
     <value>tree</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="TreeItem" xml:space="preserve">
     <value>tree item</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
   <data name="Window" xml:space="preserve">
     <value>window</value>
+    <comment>The localized type (role) of a UI Automation control, as provided by the system. If you know it, the localized name used by the UI Automation accessibility framework in the target language should be used.</comment>
   </data>
 </root>


### PR DESCRIPTION
#### Details
This PR adds translator comments for each string in the resource files under the `Rules` directory. While at it, I also cleaned up and standardized a couple of messages.

##### Motivation
Part of localization feature (internal access required to view).

##### Context
Other namespaces to follow in subsequent PRs.

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
