### PR TITLE
feat(async-api): Use ConcurrentDictionary for custom TypeConverter mapping

### DIFF
--- a/src/Core/Bases/A11yProperty.cs
+++ b/src/Core/Bases/A11yProperty.cs
@@ -7,7 +7,7 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.Win32;
 using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Globalization;
 
 namespace Axe.Windows.Core.Bases
@@ -47,8 +47,7 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
-        // TODO: This does not yet support different custom properties in concurrent scans
-        static readonly Dictionary<int, ITypeConverter> TypeConverterMap = new Dictionary<int, ITypeConverter>();
+        static readonly ConcurrentDictionary<int, ITypeConverter> TypeConverterMap = new ConcurrentDictionary<int, ITypeConverter>();
 
         /// <summary>
         /// Constructor with normal case


### PR DESCRIPTION
#### Details

#770 calls out a potential isolation problem with the mix of CustomUIA and async scans. Upon further analysis, each scan registers its own set of CustomUIA properties and incorporates that in the properties requested from UIA, so our only risk for conflict is in rendering. The `A11yProperty` class maintains a mapping from system-assigned property ID's to an appropriate `TypeConverter`, and this mapping is not thread-safe. The simplest change we can make here is to replace the `Dictionary` with a `ConcurrentDictonary`, which gives us the thread safety that we need. As it turns out, the API's that we're currently calling on the `Dictionary` require no change for `ConcurrentDictionary`, so the change is trivial--just change the type.

One thing to note is that custom property ID's are issues by the system, and each property is assigned a unique ID for the duration of that Windows session. We don't need to worry about ID's that change or collide. Because of this, there is no risk of TypeConverters colliding within `A11yProperty`.

##### Motivation

Address #770 

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #770
