### PR TITLE
chore: Fix malformed rule description

### DIFF
--- a/docs/RulesDescription.md
+++ b/docs/RulesDescription.md
@@ -95,7 +95,7 @@ LandmarkContentInfoIsTopLevel | Error | An element with LocalizedLandmarkType "c
 LandmarkMainIsTopLevel | Error | An element with LocalizedLandmarkType "main" must not descend from another landmark. | WCAG 1.3.1 InfoAndRelationships
 LandmarkNoDuplicateBanner | Error | A page must not have multiple elements with LocalizedLandmarkType "banner." | WCAG 1.3.1 InfoAndRelationships
 LandmarkNoDuplicateContentInfo | Error | A page must not have multiple elements with LocalizedLandmarkType "contentinfo." | WCAG 1.3.1 InfoAndRelationships
-LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters | Error | The [StringProperty not set] property must not contain any characters in the private Unicode range. | WCAG 1.3.1 InfoAndRelationships
+LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters | Error | The LocalizedControlType property must not contain any characters in the private Unicode range. | WCAG 1.3.1 InfoAndRelationships
 LocalizedLandmarkTypeIsReasonableLength | Error | The LocalizedLandmarkType property must not be longer than 64 characters. | WCAG 1.3.1 InfoAndRelationships
 LocalizedLandmarkTypeNotCustom | Error | The LandmarkType and LocalizedLandmarkType must not both be set to "custom." | WCAG 1.3.1 InfoAndRelationships
 LocalizedLandmarkTypeNotEmpty | Error | An element with LandmarkType set must not have an empty LocalizedLandmarkType. | WCAG 1.3.1 InfoAndRelationships

--- a/src/Rules/PropertyConditions/StringProperties.cs
+++ b/src/Rules/PropertyConditions/StringProperties.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.Resources;
@@ -13,7 +13,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         public static StringProperty HelpText = new StringProperty(e => e.HelpText, ConditionDescriptions.HelpText);
         public static StringProperty ItemStatus = new StringProperty(e => e.ItemStatus);
         public static StringProperty LocalizedControlType = new StringProperty(e => e.LocalizedControlType, ConditionDescriptions.LocalizedControlType);
-        public static StringProperty LocalizedLandmarkType = new StringProperty(e => e.LocalizedLandmarkType);
+        public static StringProperty LocalizedLandmarkType = new StringProperty(e => e.LocalizedLandmarkType, ConditionDescriptions.LocalizedControlType);
         public static StringProperty Name = new StringProperty(e => e.Name, ConditionDescriptions.Name);
         public static StringProperty ProcessName = new StringProperty(e => e.ProcessName);
     } // class

--- a/src/Rules/Resources/ConditionDescriptions.Designer.cs
+++ b/src/Rules/Resources/ConditionDescriptions.Designer.cs
@@ -268,6 +268,15 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to LocalizedLandmarkType.
+        /// </summary>
+        internal static string LocalizedLandmarkType {
+            get {
+                return ResourceManager.GetString("LocalizedLandmarkType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to main landmark.
         /// </summary>
         internal static string MainLandmark {

--- a/src/Rules/Resources/ConditionDescriptions.resx
+++ b/src/Rules/Resources/ConditionDescriptions.resx
@@ -245,4 +245,7 @@
   <data name="IsDialog" xml:space="preserve">
     <value>IsDialog</value>
   </data>
+  <data name="LocalizedLandmarkType" xml:space="preserve">
+    <value>LocalizedLandmarkType</value>
+  </data>
 </root>


### PR DESCRIPTION
#### Details

We noticed that the description for the `LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters` was malformed. It read:

The [StringProperty not set] property must not contain any characters in the private Unicode range.

It should read:

The LocalizedControlType property must not contain any characters in the private Unicode range.

Easy fix, just add the description to the property and rebuild RulesDescription.md

##### Motivation

Docs should be correct

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
