### PR TITLE
feat(async-api): Restore old signature

### DIFF
--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -211,7 +211,7 @@ namespace Axe.Windows.Desktop.UIAutomation
             if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 
             var walker = dataContext.A11yAutomation.GetTreeWalker(TreeViewMode.Control);
-            var tree = new DesktopElementAncestry(TreeViewMode.Control, e, dataContext);
+            var tree = new DesktopElementAncestry(TreeViewMode.Control, e, false, dataContext);
             Marshal.ReleaseComObject(walker);
             A11yElement app = tree.First;
 

--- a/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
@@ -38,29 +38,33 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         public TreeViewMode TreeWalkerMode { get; }
 
         /// <summary>
+        /// Parent elements' SetMembers value
+        /// </summary>
+        private bool SetMembers { get; }
+
+        /// <summary>
         /// Id for next element
         /// it will be used in Tree Walker.
         /// </summary>
         public int NextId { get; }
 
         /// <summary>
-        /// Constructor DesktopElementAncestry
-        /// Get Ancestry Tree elements up to Desktop(at best)
+        /// Constructor for DesktopElementAncestry, currently used only by AIWin
+        /// Get Ancestry Tree elements up to Desktop (ideally)
         /// </summary>
-        /// <param name="walker"></param>
-        /// <param name="e"></param>
-        public DesktopElementAncestry(TreeViewMode mode, A11yElement e)
-            : this (mode, e, DesktopDataContext.DefaultContext)
+        public DesktopElementAncestry(TreeViewMode mode, A11yElement e, bool setMembers)
+            : this(mode, e, setMembers, DesktopDataContext.DefaultContext)
         {
         }
 
-        internal DesktopElementAncestry(TreeViewMode mode, A11yElement e, DesktopDataContext dataContext)
+        internal DesktopElementAncestry(TreeViewMode mode, A11yElement e, bool setMembers, DesktopDataContext dataContext)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             this.TreeWalker = dataContext.A11yAutomation.GetTreeWalker(mode);
             this.TreeWalkerMode = mode;
             this.Items = new List<A11yElement>();
+            this.SetMembers = setMembers;
             SetParent(e, -1, dataContext);
 
             if (Items.Count != 0)
@@ -96,7 +100,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
                 if (puia == null) return;
 
 #pragma warning disable CA2000 // Call IDisposable.Dispose()
-                var parent = new DesktopElement(puia, true, false);
+                var parent = new DesktopElement(puia, true, SetMembers);
                 parent.PopulateMinimumPropertiesForSelection(dataContext);
 
                 // we need to avoid infinite loop of self reference as parent.

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
@@ -70,7 +70,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 
             //Set parent of Root explicitly for testing.
             A11yElement parent = null;
-            var ancestry = new DesktopElementAncestry(this.WalkerMode, e, dataContext);
+            var ancestry = new DesktopElementAncestry(this.WalkerMode, e, false, dataContext);
             parent = ancestry.Last;
 
             this.RootElement = ancestry.First;

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -71,7 +71,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             }
 
             //Set parent of Root explicitly for testing.
-            var ancestry = new DesktopElementAncestry(this.WalkerMode, this.SelectedElement, dataContext);
+            var ancestry = new DesktopElementAncestry(this.WalkerMode, this.SelectedElement, false, dataContext);
 
             // Pre-count the ancestors in our bounded count, so that our count is accurate
             _elementCounter.TryAdd(ancestry.Items.Count);


### PR DESCRIPTION
#### Details

Changes in #767 removed a parameter and from the public constructor of `DesktopElementAncestry` and its associated plumbing, since the field was never used in Axe.Windows. Unfortunately, AIWIn relies on this functionality [here](https://github.com/microsoft/accessibility-insights-windows/blob/main/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml.cs#L419). This PR restores the property with a tiny refactor to (hopefully) make the code clearer.

I've confirmed that AIWin builds correctly with this change

##### Motivation

Part of async feature work

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
