### PR TITLE
feat(localization): Onboard to microbuild loc plugin

### DIFF
--- a/build/NetStandardRelease.targets
+++ b/build/NetStandardRelease.targets
@@ -41,7 +41,8 @@
   <Choose>
     <When Condition=" '$(DropSignedFile)' == '' ">
       <ItemGroup>
-        <DropSignedFile Include="$(TargetPath)" />
+        <!-- TODO include file.resources.dll in signing -->
+        <DropSignedFile Include="$(TargetPath)" /> 
       </ItemGroup>
     </When>
   </Choose>

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -30,7 +30,7 @@ jobs:
   - task: MicroBuildLocalizationPlugin@1
     inputs:
       languages: ${{ parameters.LocLanguages }}
-      feedSource: '$(SigningPluginFeedSource)'
+      feedSource: '$(MicrobuildPluginFeedSource)'
     displayName: Install MicroBuild Localization plugin
 
   - task: NuGetCommand@2
@@ -212,7 +212,7 @@ jobs:
     inputs:
       signType: real
       esrpSigning: true
-      feedSource: '$(SigningPluginFeedSource)'
+      feedSource: '$(MicrobuildPluginFeedSource)'
     condition: and(succeeded(), ne(variables['SignType'], ''))
 
   - task: NuGetToolInstaller@1

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -30,6 +30,7 @@ jobs:
   - task: MicroBuildLocalizationPlugin@1
     inputs:
       languages: ${{ parameters.LocLanguages }}
+      feedSource: '$(SigningPluginFeedSource)'
     displayName: Install MicroBuild Localization plugin
 
   - task: NuGetCommand@2

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -1,6 +1,11 @@
 name: $(date:yyyy-MM-dd)$(rev:.rr)
 trigger: none
 pr: none
+parameters:
+- name: LocLanguages
+  displayName: Localization Languages
+  type: string
+  default: VS
 variables:
   BuildPlatform: 'x86'
   CreateAxeWindowsNugetPackage: 'true'
@@ -21,6 +26,11 @@ jobs:
     displayName: 'Use NuGet 5.x'
     inputs:
       versionSpec: '5.x'
+
+  - task: MicroBuildLocalizationPlugin@1
+    inputs:
+      languages: ${{ parameters.LocLanguages }}
+    displayName: Install MicroBuild Localization plugin
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -27,12 +27,6 @@ jobs:
     inputs:
       versionSpec: '5.x'
 
-  - task: MicroBuildLocalizationPlugin@1
-    inputs:
-      languages: ${{ parameters.LocLanguages }}
-      feedSource: '$(MicrobuildPluginFeedSource)'
-    displayName: Install MicroBuild Localization plugin
-
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
 
@@ -219,6 +213,12 @@ jobs:
     displayName: 'Use NuGet 5.x'
     inputs:
       versionSpec: '5.x'
+
+  - task: MicroBuildLocalizationPlugin@1
+    inputs:
+      languages: ${{ parameters.LocLanguages }}
+      feedSource: '$(MicrobuildPluginFeedSource)'
+    displayName: Install MicroBuild Localization plugin
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -49,4 +49,10 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+  <FilesToLocalize Include="$(OutDir)\Axe.Windows.Core.dll">
+    <TranslationFile>$(MSBuildThisFileDirectory)..\loc\lcl\{Lang}\Axe.Windows.Core.lcl</TranslationFile>
+  </FilesToLocalize>
+</ItemGroup>
+
 </Project>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -50,9 +50,9 @@
   </ItemGroup>
 
   <ItemGroup>
-  <FilesToLocalize Include="$(OutDir)\Axe.Windows.Core.dll">
-    <TranslationFile>$(MSBuildThisFileDirectory)..\loc\lcl\{Lang}\Axe.Windows.Core.lcl</TranslationFile>
-  </FilesToLocalize>
-</ItemGroup>
+    <FilesToLocalize Include="$(OutDir)\$(AssemblyName).dll">
+      <TranslationFile>$(MSBuildThisFileDirectory)..\loc\lcl\{Lang}\$(AssemblyName).lcl</TranslationFile>
+    </FilesToLocalize>
+  </ItemGroup>
 
 </Project>

--- a/src/RuleSelection/RuleSelection.csproj
+++ b/src/RuleSelection/RuleSelection.csproj
@@ -78,4 +78,10 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <FilesToLocalize Include="$(OutDir)\$(AssemblyName).dll">
+      <TranslationFile>$(MSBuildThisFileDirectory)..\loc\lcl\{Lang}\$(AssemblyName).lcl</TranslationFile>
+    </FilesToLocalize>
+  </ItemGroup>
+
 </Project>

--- a/src/Rules/Rules.csproj
+++ b/src/Rules/Rules.csproj
@@ -113,4 +113,10 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <FilesToLocalize Include="$(OutDir)\$(AssemblyName).dll">
+      <TranslationFile>$(MSBuildThisFileDirectory)..\loc\lcl\{Lang}\$(AssemblyName).lcl</TranslationFile>
+    </FilesToLocalize>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
#### Details

This PR onboards to the microbuild loc plugin such that the projects that will need to be localized begin generating `localize/*/*.lce` files in the signed build output. These files will be picked up by the loc team for translation, and eventually the loc team will check .lcl files into this repo.

Test run with these changes: https://dev.azure.com/mseng/1ES/_build/results?buildId=18577457&view=results
See relevant files at `drop/src/{ projects that need to be localized }/bin/release/netstandard2.0/localize/*`.

##### Motivation

Localization feature

##### Context

This PR does not address 2 items: 
- Including the resulting loc files in signing. I added a TODO in the code to address this as well as created a user story: https://dev.azure.com/mseng/1ES/_workitems/edit/2002189
- Including the resulting loc files in the nuget package. I created a user story to address this: https://dev.azure.com/mseng/1ES/_workitems/edit/2002203

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [2002085](https://dev.azure.com/mseng/1ES/_workitems/edit/2002085)
