### PR TITLE
feat(localization): Add translator comments for Core namespace

### DIFF
--- a/src/Core/Resources/DisplayStrings.resx
+++ b/src/Core/Resources/DisplayStrings.resx
@@ -119,7 +119,7 @@
   </resheader>
   <data name="BoundingRectangleFormat" xml:space="preserve">
     <value>[l={0},t={1},w={2},h={3}]</value>
-    <comment>Do not translate: the coordinate specification of a bounding rectangle for an accessibility element.</comment>
+    <comment>The coordinate specification of a bounding rectangle for an accessibility element. l refers to the left position, t to the top position, w to the width, and h to the height. When translating, please keep these descriptions to one or two characters for display purposes.</comment>
   </data>
   <data name="HorizontalOrientation" xml:space="preserve">
     <value>Horizontal(1)</value>
@@ -127,7 +127,7 @@
   </data>
   <data name="LeftTopRightBottomFormat" xml:space="preserve">
     <value>[l={0},t={1},r={2},b={3}]</value>
-    <comment>Do not translate: the coordinate specification of the position of an accessibility element.</comment>
+    <comment>The coordinate specification of the position of an accessibility element. l refers to the left position, t to the top position, r to the right position, and b to the bottom position. When translating, please keep these descriptions to one or two characters for display purposes.</comment>
   </data>
   <data name="NoneOrientation" xml:space="preserve">
     <value>None(0)</value>

--- a/src/Core/Resources/DisplayStrings.resx
+++ b/src/Core/Resources/DisplayStrings.resx
@@ -119,23 +119,30 @@
   </resheader>
   <data name="BoundingRectangleFormat" xml:space="preserve">
     <value>[l={0},t={1},w={2},h={3}]</value>
+    <comment>Do not translate: the coordinate specification of a bounding rectangle for an accessibility element.</comment>
   </data>
   <data name="HorizontalOrientation" xml:space="preserve">
     <value>Horizontal(1)</value>
+    <comment>A description of the visual orientation of an accessibility element.</comment>
   </data>
   <data name="LeftTopRightBottomFormat" xml:space="preserve">
     <value>[l={0},t={1},r={2},b={3}]</value>
+    <comment>Do not translate: the coordinate specification of the position of an accessibility element.</comment>
   </data>
   <data name="NoneOrientation" xml:space="preserve">
     <value>None(0)</value>
+    <comment>A description of the visual orientation of an accessibility element.</comment>
   </data>
   <data name="PointFormat" xml:space="preserve">
     <value>[x={0},y={1}]</value>
+    <comment>Do not translate: the coordinate specification of the position of an accessibility element.</comment>
   </data>
   <data name="UnknownFormat" xml:space="preserve">
     <value>Unknown ({0})</value>
+    <comment>The description of data obtained from an accessibility element that the accessibility scanner does not know how to interpret.</comment>
   </data>
   <data name="VerticalOrientation" xml:space="preserve">
     <value>Vertical(2)</value>
+    <comment>A description of the visual orientation of an accessibility element.</comment>
   </data>
 </root>

--- a/src/Core/Resources/ErrorMessages.resx
+++ b/src/Core/Resources/ErrorMessages.resx
@@ -119,41 +119,50 @@
   </resheader>
   <data name="ParameterMustBeLessThanIntMaxValue" xml:space="preserve">
     <value>This parameter must be less than int.MaxValue</value>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="ParameterMustBePositive" xml:space="preserve">
     <value>This parameter must be positive</value>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="ParameterMustNotBeNegative" xml:space="preserve">
     <value>This parameter must not be negative</value>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="PropertyAlreadySet" xml:space="preserve">
     <value>The given property was already set.</value>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="UnableToLocateTargetElementInFile" xml:space="preserve">
     <value>Unable to locate the target element in the file.</value>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="ValueCannotBeNull" xml:space="preserve">
     <value>Value cannot be null</value>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="ValueCannotBeEmptyOrWhiteSpace" xml:space="preserve">
     <value>Value cannot be empty or white space</value>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="PropertyValueTypeUnexpected" xml:space="preserve">
     <value>Expected property.Value, which is type {0}, to be type {1}</value>
-    <comment>{0} is actual type, {1} is expected type</comment>
+    <comment>Do not translate: the text of an internal error. Developers: {0} is actual type, {1} is expected type</comment>
   </data>
   <data name="NoRuleIdExists" xml:space="preserve">
     <value>No rule id exists for the given view mode {0}</value>
-    <comment>{0} is view mode</comment>
+    <comment>Do not translate: the text of an internal error. Developers: {0} is view mode</comment>
   </data>
   <data name="NotSupportedType" xml:space="preserve">
     <value>'{0}' is not a supported type</value>
-    <comment>{0} is type</comment>
+    <comment>Do not translate: the text of an internal error. Developers: {0} is type</comment>
   </data>
   <data name="ValuesCannotBeDefined" xml:space="preserve">
     <value>Values cannot be defined for non-enumeration types.</value>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="ValuesRequired" xml:space="preserve">
     <value>Values required for enumeration types.</value>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
 </root>


### PR DESCRIPTION
#### Details
This PR adds translator comments for each string in the resource files under the `Core` directory.

##### Motivation
Part of localization feature (internal access required to view).

##### Context
Other namespaces to follow in subsequent PRs.

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
