### PR TITLE
feat(localization): Add translator comments for RuleSelection namespace

### DIFF
--- a/src/RuleSelection/Resources/DefaultGuidelineShortDescriptions.resx
+++ b/src/RuleSelection/Resources/DefaultGuidelineShortDescriptions.resx
@@ -119,20 +119,26 @@
   </resheader>
   <data name="AvailableActions" xml:space="preserve">
     <value>Section 508 502.3.10</value>
+    <comment>Do not translate: the name of an accessibility standard.</comment>
   </data>
   <data name="InfoAndRelationships" xml:space="preserve">
     <value>WCAG 1.3.1</value>
+    <comment>Do not translate: the name of an accessibility standard.</comment>
   </data>
   <data name="Keyboard" xml:space="preserve">
     <value>WCAG 2.1.1</value>
+    <comment>Do not translate: the name of an accessibility standard.</comment>
   </data>
   <data name="NameRoleValue" xml:space="preserve">
     <value>WCAG 4.1.2</value>
+    <comment>Do not translate: the name of an accessibility standard.</comment>
   </data>
   <data name="None" xml:space="preserve">
     <value>None</value>
+    <comment>Indicates that no accessibility standard applies to this problem.</comment>
   </data>
   <data name="ObjectInformation" xml:space="preserve">
     <value>Section 508 502.3.1</value>
+    <comment>Do not translate: the name of an accessibility standard.</comment>
   </data>
 </root>

--- a/src/RuleSelection/Resources/DefaultGuidelineUrls.resx
+++ b/src/RuleSelection/Resources/DefaultGuidelineUrls.resx
@@ -119,17 +119,22 @@
   </resheader>
   <data name="AvailableActions" xml:space="preserve">
     <value>https://www.access-board.gov/ict/#502-interoperability-assistive-technology</value>
+    <comment>Do not translate: a URL to a web page.</comment>
   </data>
   <data name="InfoAndRelationships" xml:space="preserve">
     <value>https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html</value>
+    <comment>Do not translate: a URL to a web page.</comment>
   </data>
   <data name="Keyboard" xml:space="preserve">
     <value>https://www.w3.org/TR/UNDERSTANDING-WCAG20/keyboard-operation-keyboard-operable.html</value>
+    <comment>Do not translate: a URL to a web page.</comment>
   </data>
   <data name="NameRoleValue" xml:space="preserve">
     <value>https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-rsv.html</value>
+    <comment>Do not translate: a URL to a web page.</comment>
   </data>
   <data name="ObjectInformation" xml:space="preserve">
     <value>https://www.access-board.gov/ict/#502-interoperability-assistive-technology</value>
+    <comment>Do not translate: a URL to a web page.</comment>
   </data>
 </root>

--- a/src/RuleSelection/Resources/ErrorMessages.resx
+++ b/src/RuleSelection/Resources/ErrorMessages.resx
@@ -119,5 +119,6 @@
   </resheader>
   <data name="RunResultRuleInfoNull" xml:space="preserve">
     <value>Expected the RuleInfo property of the given RunResult not to be null</value>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
 </root>


### PR DESCRIPTION
#### Details
This PR adds translator comments for each string in the resource files under the `RuleSelection` directory.

##### Motivation
Part of localization feature (internal access required to view).

##### Context
Other namespaces to follow in subsequent PRs.

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
