### PR TITLE
feat(localization): Include .resource.dll files for signing

### DIFF
--- a/build/NetStandardRelease.targets
+++ b/build/NetStandardRelease.targets
@@ -42,6 +42,7 @@
     <When Condition=" '$(DropSignedFile)' == '' ">
       <ItemGroup>
         <DropSignedFile Include="$(TargetPath)" />
+        <DropSignedFile Include="$(TargetDir)\localize\**\$(AssemblyName).resources.dll" Condition="Exists('$(TargetDir)\localize')" />
       </ItemGroup>
     </When>
   </Choose>

--- a/build/NetStandardRelease.targets
+++ b/build/NetStandardRelease.targets
@@ -44,6 +44,9 @@
         <DropSignedFile Include="$(TargetPath)" />
         <DropSignedFile Include="$(TargetDir)\localize\**\$(AssemblyName).resources.dll" />
       </ItemGroup>
+      <SignFilesDependsOn Include="GatherLocalizedOutputsForSigning">
+        <InProject>false</InProject>
+      </SignFilesDependsOn>
     </When>
   </Choose>
 

--- a/build/NetStandardRelease.targets
+++ b/build/NetStandardRelease.targets
@@ -44,9 +44,6 @@
         <DropSignedFile Include="$(TargetPath)" />
         <DropSignedFile Include="$(TargetDir)\localize\**\$(AssemblyName).resources.dll" />
       </ItemGroup>
-      <SignFilesDependsOn Include="GatherLocalizedOutputsForSigning">
-        <InProject>false</InProject>
-      </SignFilesDependsOn>
     </When>
   </Choose>
 

--- a/build/NetStandardRelease.targets
+++ b/build/NetStandardRelease.targets
@@ -42,7 +42,7 @@
     <When Condition=" '$(DropSignedFile)' == '' ">
       <ItemGroup>
         <DropSignedFile Include="$(TargetPath)" />
-        <DropSignedFile Include="$(TargetDir)\localize\**\$(AssemblyName).resources.dll" />
+        <!-- <DropSignedFile Include="$(TargetDir)\localize\**\$(AssemblyName).resources.dll" /> -->
       </ItemGroup>
     </When>
   </Choose>

--- a/build/NetStandardRelease.targets
+++ b/build/NetStandardRelease.targets
@@ -42,7 +42,7 @@
     <When Condition=" '$(DropSignedFile)' == '' ">
       <ItemGroup>
         <DropSignedFile Include="$(TargetPath)" />
-        <DropSignedFile Include="$(TargetDir)\localize\**\$(AssemblyName).resources.dll" Condition="Exists('$(TargetDir)\localize')" />
+        <DropSignedFile Include="$(TargetDir)\localize\**\$(AssemblyName).resources.dll" />
       </ItemGroup>
     </When>
   </Choose>

--- a/build/NetStandardRelease.targets
+++ b/build/NetStandardRelease.targets
@@ -42,7 +42,6 @@
     <When Condition=" '$(DropSignedFile)' == '' ">
       <ItemGroup>
         <DropSignedFile Include="$(TargetPath)" />
-        <!-- <DropSignedFile Include="$(TargetDir)\localize\**\$(AssemblyName).resources.dll" /> -->
       </ItemGroup>
     </When>
   </Choose>

--- a/build/settings.targets
+++ b/build/settings.targets
@@ -27,6 +27,12 @@
     </When>
   </Choose>
 
+  <ItemGroup>
+    <SignFilesDependsOn Include="GatherLocalizedOutputsForSigning">
+      <InProject>false</InProject>
+    </SignFilesDependsOn>
+  </ItemGroup>
+
   <Target Name="GatherLocalizedOutputsForSigning" Condition="'$(LocalizationEnabled)' == 'true'">
     <ItemGroup>
       <FilesToSign Include="$(OutDir)\localize\**\$(AssemblyName).resources.dll">

--- a/build/settings.targets
+++ b/build/settings.targets
@@ -36,7 +36,7 @@
   <Target Name="GatherLocalizedOutputsForSigning" Condition="'$(LocalizationEnabled)' == 'true'">
     <ItemGroup>
       <FilesToSign Include="$(OutDir)\localize\**\$(AssemblyName).resources.dll">
-        <Authenticode>Microsoft</Authenticode>
+        <Authenticode>Microsoft400</Authenticode>
         <StrongName>StrongName</StrongName>
       </FilesToSign>
     </ItemGroup>

--- a/build/settings.targets
+++ b/build/settings.targets
@@ -27,4 +27,13 @@
     </When>
   </Choose>
 
+  <Target Name="GatherLocalizedOutputsForSigning" Condition="'$(LocalizationEnabled)' == 'true'">
+    <ItemGroup>
+      <FilesToSign Include="$(OutDir)\localize\**\$(AssemblyName).resources.dll">
+        <Authenticode>Microsoft</Authenticode>
+        <StrongName>StrongName</StrongName>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -50,6 +50,7 @@ jobs:
       vsVersion: 17.0
       platform: '$(BuildPlatform)'
       configuration: release
+      msbuildArgs: '-bl'
 
   - task: ms.build-release-task.custom-build-release-task.wpf-static-analysis@0
     displayName: 'WPF Static Analysis'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -50,7 +50,6 @@ jobs:
       vsVersion: 17.0
       platform: '$(BuildPlatform)'
       configuration: release
-      msbuildArgs: '-bl'
 
   - task: ms.build-release-task.custom-build-release-task.wpf-static-analysis@0
     displayName: 'WPF Static Analysis'
@@ -189,10 +188,10 @@ jobs:
       ArtifactName: 'Compliance'
 
 - job: SignedRelease
-  dependsOn: 
-  - ComplianceRelease
-  - ComplianceDebug
-  condition: and(succeeded(), succeeded())
+  # dependsOn: 
+  # - ComplianceRelease
+  # - ComplianceDebug
+  # condition: and(succeeded(), succeeded())
   pool: MSEngSS-MicroBuild2022-1ES
   variables:
     PublicRelease: 'true'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -188,10 +188,10 @@ jobs:
       ArtifactName: 'Compliance'
 
 - job: SignedRelease
-  # dependsOn: 
-  # - ComplianceRelease
-  # - ComplianceDebug
-  # condition: and(succeeded(), succeeded())
+  dependsOn: 
+  - ComplianceRelease
+  - ComplianceDebug
+  condition: and(succeeded(), succeeded())
   pool: MSEngSS-MicroBuild2022-1ES
   variables:
     PublicRelease: 'true'


### PR DESCRIPTION
#### Details

.resource.dll files were added to signed build output in https://github.com/microsoft/axe-windows/pull/779, but are not actually included in signing yet. This PR adds those files to `FilesToSign`. 

Test run with these changes: https://dev.azure.com/mseng/1ES/_build/results?buildId=18601521&view=results

##### Motivation

Localization feature work

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [2002189](https://dev.azure.com/mseng/1ES/_workitems/edit/2002189)
