### PR TITLE
fix: Make Telerik Sparkline elements not fail the Bounding Rectangle rule anymore

### DIFF
--- a/src/Rules/Library/BoundingRectangleSizeReasonable.cs
+++ b/src/Rules/Library/BoundingRectangleSizeReasonable.cs
@@ -37,7 +37,7 @@ namespace Axe.Windows.Rules.Library
                 & BoundingRectangle.NotNull
                 & BoundingRectangle.CorrectDataFormat
                 & ~ignoreableText
-                & ~BoundingRectangle.NotTelerikSparklineItemstatusContext;
+                & ~BoundingRectangle.TelerikSparklineItemstatusContext;
         }
     } // class
 } // namespace

--- a/src/Rules/Library/BoundingRectangleSizeReasonable.cs
+++ b/src/Rules/Library/BoundingRectangleSizeReasonable.cs
@@ -26,7 +26,7 @@ namespace Axe.Windows.Rules.Library
 
         public override bool PassesTest(IA11yElement e)
         {
-            if(e.ItemStatus.Contains("<Property Name=\"DataContext\" Value=\"Telerik.Windows.Controls.Sparklines.SparklineColumnDataPoint\" />"))
+            if (e?.ItemStatus?.Contains("<Property Name=\"DataContext\" Value=\"Telerik.Windows.Controls.Sparklines.SparklineColumnDataPoint\" />") == true)
             {
                 return true;
             }

--- a/src/Rules/Library/BoundingRectangleSizeReasonable.cs
+++ b/src/Rules/Library/BoundingRectangleSizeReasonable.cs
@@ -9,6 +9,7 @@ using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 
 namespace Axe.Windows.Rules.Library
 {
@@ -37,7 +38,7 @@ namespace Axe.Windows.Rules.Library
                 & BoundingRectangle.NotNull
                 & BoundingRectangle.CorrectDataFormat
                 & ~ignoreableText
-                & ~BoundingRectangle.TelerikSparklineItemstatusContext;
+                & ~(WPF & BoundingRectangle.TelerikSparklineItemstatusContext);
         }
     } // class
 } // namespace

--- a/src/Rules/Library/BoundingRectangleSizeReasonable.cs
+++ b/src/Rules/Library/BoundingRectangleSizeReasonable.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -26,6 +26,10 @@ namespace Axe.Windows.Rules.Library
 
         public override bool PassesTest(IA11yElement e)
         {
+            if(e.ItemStatus.Contains("<Property Name=\"DataContext\" Value=\"Telerik.Windows.Controls.Sparklines.SparklineColumnDataPoint\" />"))
+            {
+                return true;
+            }
             return BoundingRectangle.Valid.Matches(e);
         }
 

--- a/src/Rules/Library/BoundingRectangleSizeReasonable.cs
+++ b/src/Rules/Library/BoundingRectangleSizeReasonable.cs
@@ -26,10 +26,6 @@ namespace Axe.Windows.Rules.Library
 
         public override bool PassesTest(IA11yElement e)
         {
-            if (e?.ItemStatus?.Contains("<Property Name=\"DataContext\" Value=\"Telerik.Windows.Controls.Sparklines.SparklineColumnDataPoint\" />") == true)
-            {
-                return true;
-            }
             return BoundingRectangle.Valid.Matches(e);
         }
 
@@ -40,7 +36,8 @@ namespace Axe.Windows.Rules.Library
             return IsNotOffScreen
                 & BoundingRectangle.NotNull
                 & BoundingRectangle.CorrectDataFormat
-                & ~ignoreableText;
+                & ~ignoreableText
+                & ~BoundingRectangle.NotTelerikSparklineItemstatusContext;
         }
     } // class
 } // namespace

--- a/src/Rules/PropertyConditions/BoundingRectangle.cs
+++ b/src/Rules/PropertyConditions/BoundingRectangle.cs
@@ -31,7 +31,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         public static Condition CorrectDataFormat = Condition.Create(HasCorrectDataFormat);
         public static Condition NotCorrectDataFormat = ~CorrectDataFormat;
         public static Condition CompletelyObscuresContainer = Condition.Create(ElementCompletelyObscuresContainer, ConditionDescriptions.BoundingRectangleCompletelyObscuresContainer);
-        public static Condition NotTelerikSparklineItemstatusContext = Condition.Create(ElementItemStatusContainsTelerikSparklineContext);
+        public static Condition TelerikSparklineItemstatusContext = Condition.Create(ElementItemStatusContainsTelerikSparklineContext);
 
         private static bool IsBoundingRectangleNull(IA11yElement e)
         {

--- a/src/Rules/PropertyConditions/BoundingRectangle.cs
+++ b/src/Rules/PropertyConditions/BoundingRectangle.cs
@@ -31,6 +31,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         public static Condition CorrectDataFormat = Condition.Create(HasCorrectDataFormat);
         public static Condition NotCorrectDataFormat = ~CorrectDataFormat;
         public static Condition CompletelyObscuresContainer = Condition.Create(ElementCompletelyObscuresContainer, ConditionDescriptions.BoundingRectangleCompletelyObscuresContainer);
+        public static Condition NotTelerikSparklineItemstatusContext = Condition.Create(ElementItemStatusContainsTelerikSparklineContext);
 
         private static bool IsBoundingRectangleNull(IA11yElement e)
         {
@@ -73,6 +74,12 @@ namespace Axe.Windows.Rules.PropertyConditions
             if (container == null) throw new InvalidProgramException(ErrorMessages.ExpectedValidAncestor);
 
             return e.BoundingRectangle.CompletelyObscures(container.BoundingRectangle);
+        }
+        private static bool ElementItemStatusContainsTelerikSparklineContext(IA11yElement e)
+        {
+            if (e == null) throw new ArgumentNullException(nameof(e));
+
+            return e.Framework == "WPF" && e.ItemStatus?.Contains("<Property Name=\"DataContext\" Value=\"Telerik.Windows.Controls.Sparklines.SparklineColumnDataPoint\" />") == true;
         }
     } // class
 } // namespace

--- a/src/Rules/PropertyConditions/BoundingRectangle.cs
+++ b/src/Rules/PropertyConditions/BoundingRectangle.cs
@@ -75,11 +75,12 @@ namespace Axe.Windows.Rules.PropertyConditions
 
             return e.BoundingRectangle.CompletelyObscures(container.BoundingRectangle);
         }
+
         private static bool ElementItemStatusContainsTelerikSparklineContext(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return e.Framework == "WPF" && e.ItemStatus?.Contains("<Property Name=\"DataContext\" Value=\"Telerik.Windows.Controls.Sparklines.SparklineColumnDataPoint\" />") == true;
+            return e.ItemStatus?.Contains("<Property Name=\"DataContext\" Value=\"Telerik.Windows.Controls.Sparklines.SparklineColumnDataPoint\" />") == true;
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/BoundingRectangleSizeReasonableTests.cs
+++ b/src/RulesTest/Library/BoundingRectangleSizeReasonableTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
@@ -30,6 +30,17 @@ namespace Axe.Windows.RulesTests.Library
             {
                 e.BoundingRectangle = Rectangle.Empty;
                 Assert.IsFalse(Rule.PassesTest(e));
+            } // using
+        }
+        
+        [TestMethod]
+        public void TestBoundingRectangleSizeReasonableTelerikSparklineColumnPass()
+        {
+            using (var e = new MockA11yElement())
+            {
+                e.ItemStatus = "<Property Name=\"DataContext\" Value=\"Telerik.Windows.Controls.Sparklines.SparklineColumnDataPoint\" />";
+                e.BoundingRectangle = Rectangle.Empty;
+                Assert.IsTrue(Rule.PassesTest(e));
             } // using
         }
 

--- a/src/RulesTest/Library/BoundingRectangleSizeReasonableTests.cs
+++ b/src/RulesTest/Library/BoundingRectangleSizeReasonableTests.cs
@@ -38,9 +38,10 @@ namespace Axe.Windows.RulesTests.Library
         {
             using (var e = new MockA11yElement())
             {
+                e.Framework = "WPF";
                 e.ItemStatus = "<Property Name=\"DataContext\" Value=\"Telerik.Windows.Controls.Sparklines.SparklineColumnDataPoint\" />";
                 e.BoundingRectangle = Rectangle.Empty;
-                Assert.IsTrue(Rule.PassesTest(e));
+                Assert.IsFalse(Rule.Condition.Matches(e));
             } // using
         }
 

--- a/src/RulesTest/Library/BoundingRectangleSizeReasonableTests.cs
+++ b/src/RulesTest/Library/BoundingRectangleSizeReasonableTests.cs
@@ -32,9 +32,9 @@ namespace Axe.Windows.RulesTests.Library
                 Assert.IsFalse(Rule.PassesTest(e));
             } // using
         }
-        
+
         [TestMethod]
-        public void TestBoundingRectangleSizeReasonableTelerikSparklineColumnPass()
+        public void TestBoundingRectangleSizeReasonableTelerikSparklineColumnWPFPass()
         {
             using (var e = new MockA11yElement())
             {
@@ -42,6 +42,18 @@ namespace Axe.Windows.RulesTests.Library
                 e.ItemStatus = "<Property Name=\"DataContext\" Value=\"Telerik.Windows.Controls.Sparklines.SparklineColumnDataPoint\" />";
                 e.BoundingRectangle = Rectangle.Empty;
                 Assert.IsFalse(Rule.Condition.Matches(e));
+            } // using
+        }
+        
+        [TestMethod]
+        public void TestBoundingRectangleSizeReasonableTelerikSparklineColumnUWPFail()
+        {
+            using (var e = new MockA11yElement())
+            {
+                e.Framework = "UWP";
+                e.ItemStatus = "<Property Name=\"DataContext\" Value=\"Telerik.Windows.Controls.Sparklines.SparklineColumnDataPoint\" />";
+                e.BoundingRectangle = Rectangle.Empty;
+                Assert.IsTrue(Rule.Condition.Matches(e));
             } // using
         }
 


### PR DESCRIPTION
#### Details

Updating the BoundingRectangleReasonableSized rule to exclude the Telerik Sparkline elements.

##### Motivation

Addresses #780

##### Context

N/A

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #780
