### PR TITLE
feat(localization): Add script to check resource strings for comments

### DIFF
--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -36,7 +36,7 @@ jobs:
       arguments: '-target  $(Build.Repository.LocalPath) -licenseHeaderPath tools\scripts\verification.scripts\LicenseHeader.txt -extensions *.xaml,*.xml,*.cs,*.ps1 -addIfAbsent $false'
 
   - task: PowerShell@2
-    displayName: 'Resource String Comment Check'
+    displayName: 'Resource String Translator Comment Check'
     inputs:
       targetType: "filePath"
       filePath: tools\scripts\verification.scripts\ResourceStringCommentVerification.ps1

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -35,6 +35,13 @@ jobs:
       filePath: tools\scripts\verification.scripts\LicenseHeaderVerification.ps1
       arguments: '-target  $(Build.Repository.LocalPath) -licenseHeaderPath tools\scripts\verification.scripts\LicenseHeader.txt -extensions *.xaml,*.xml,*.cs,*.ps1 -addIfAbsent $false'
 
+  - task: PowerShell@2
+    displayName: 'Resource String Comment Check'
+    inputs:
+      targetType: "filePath"
+      filePath: tools\scripts\verification.scripts\ResourceStringCommentVerification.ps1
+      arguments: '-target  $(Build.Repository.LocalPath)'
+
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
     inputs:

--- a/src/Rules/Resources/ConditionDescriptions.resx
+++ b/src/Rules/Resources/ConditionDescriptions.resx
@@ -284,5 +284,6 @@
   </data>
   <data name="LocalizedLandmarkType" xml:space="preserve">
     <value>LocalizedLandmarkType</value>
+    <comment>Do not translate: the name of a UI Automation property.</comment>
   </data>
 </root>

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -327,6 +327,7 @@
   </data>
   <data name="ChildrenNotAllowedInContentView" xml:space="preserve">
     <value>A separator must not have any children with IsContentElement set to TRUE.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="SelectionPatternSelectionRequired" xml:space="preserve">
     <value>An element of the given ControlType must have the IsSelectionRequired property set to TRUE.</value>

--- a/src/Rules/Resources/ErrorMessages.resx
+++ b/src/Rules/Resources/ErrorMessages.resx
@@ -155,7 +155,7 @@
   </data>
   <data name="MissingRuleInforAttribute" xml:space="preserve">
     <value>expected {0} to have the RuleInfo attribute set</value>
-    <comment>Do not translate: the text of an internal error. {0} is type name</comment>
+    <comment>Do not translate: the text of an internal error. Developers: {0} is type name</comment>
   </data>
   <data name="NoControlTypeEntryFound" xml:space="preserve">
     <value>No control type entry was found in dictionary. Key value = {0}</value>
@@ -171,7 +171,7 @@
   </data>
   <data name="NoRuleMatchingId" xml:space="preserve">
     <value>No rule matching the ID '{0}' was found.</value>
-    <comment>Do not translate: the text of an internal error. {0} is rule id</comment>
+    <comment>Do not translate: the text of an internal error. Developers: {0} is rule id</comment>
   </data>
   <data name="RuleInfoAttributeExpected" xml:space="preserve">
     <value>All rules are expected to have the RuleInfo attribute with the ID property set.</value>

--- a/src/Rules/Resources/ErrorMessages.resx
+++ b/src/Rules/Resources/ErrorMessages.resx
@@ -155,7 +155,7 @@
   </data>
   <data name="MissingRuleInforAttribute" xml:space="preserve">
     <value>expected {0} to have the RuleInfo attribute set</value>
-    <comment>{0} is type name</comment>
+    <comment>Do not translate: the text of an internal error. {0} is type name</comment>
   </data>
   <data name="NoControlTypeEntryFound" xml:space="preserve">
     <value>No control type entry was found in dictionary. Key value = {0}</value>
@@ -171,10 +171,11 @@
   </data>
   <data name="NoRuleMatchingId" xml:space="preserve">
     <value>No rule matching the ID '{0}' was found.</value>
-    <comment>{0} is rule id</comment>
+    <comment>Do not translate: the text of an internal error. {0} is rule id</comment>
   </data>
   <data name="RuleInfoAttributeExpected" xml:space="preserve">
     <value>All rules are expected to have the RuleInfo attribute with the ID property set.</value>
+    <comment>Do not translate: the text of an internal error.</comment>
   </data>
   <data name="StringNullOrWhiteSpace" xml:space="preserve">
     <value>Expected the given string not to be null and not to be white space</value>

--- a/tools/scripts/verification.scripts/ResourceStringCommentVerification.ps1
+++ b/tools/scripts/verification.scripts/ResourceStringCommentVerification.ps1
@@ -49,7 +49,8 @@ function Get-ResourceContent($fileContent){
 
             # There should be a comment directly after the resource value
             if ($resourceStrings[$j + 1] -NotMatch "<comment>") {
-                $resourceName = $resourceStrings[$i] #TODO get only resource name here
+                $match = $resourceStrings[$i] -Match "<data name=`"(?<content>[^;]+)`" xml:space=`"preserve`""
+                $resourceName = $matches["content"]
                 $FailedStrings += "$resourceName ($path)" 
             }
         }

--- a/tools/scripts/verification.scripts/ResourceStringCommentVerification.ps1
+++ b/tools/scripts/verification.scripts/ResourceStringCommentVerification.ps1
@@ -1,0 +1,67 @@
+﻿# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+<#
+.SYNOPSIS
+Verifies that all .resx files in the target folder have comments for resource strings.
+
+.PARAMETER Target
+The target folder to search recursively.
+
+.Example Usage 
+.\ResourceStringCommentVerification.ps1 -Target 'C:\code\axe-windows\src'
+#>
+
+param(
+    $Target
+)
+
+$NewLine=([Environment]::NewLine)
+$FailedStrings = @()
+# Exclude the projects that are not yet 
+$excludeList="(Actions|Automation|CLI|Desktop)"
+
+function Get-FileText($pathToFile){
+   return Get-Content $pathToFile -Raw -Encoding UTF8
+}
+
+# Remove resource file header/footers
+function Get-ResourceContent($fileContent){
+    $fileLines = $fileContent.Split($NewLine, [StringSplitOptions]::RemoveEmptyEntries)
+    $headerIndexes = (0..($fileLines.Count-1)) | where {$fileLines[$_] -Match '</resheader>'}
+    $startIndex = $headerIndexes[$headerIndexes.Count - 1] + 1
+    $endIndex = $fileLines.Count - 2
+    $resourceStrings = $fileLines[$startIndex..$endIndex]
+    return $resourceStrings
+}
+
+(Get-ChildItem $Target\* -Include *.resx -Recurse) | Where {$_.FullName -notmatch $excludeList} | Foreach-Object {
+    $path = $_.FullName
+    $fileContent=Get-FileText $path
+    $resourceStrings = Get-ResourceContent($fileContent)
+
+    for($i=0; $i -lt $resourceStrings.Length; $i++) {
+        if ($resourceStrings[$i] -Match "<data name=") {
+            # Account for any multi-line resource values
+            $j = $i + 1;
+            while ($resourceStrings[$j] -NotMatch "</value>") {
+                $j = $j + 1
+            }
+
+            # There should be a comment directly after the resource value
+            if ($resourceStrings[$j + 1] -NotMatch "<comment>") {
+                $resourceName = $resourceStrings[$i] #TODO get only resource name here
+                $FailedStrings += "$resourceName ($path)" 
+            }
+        }
+    }
+
+    echo "Finished scanning $path"
+}
+
+echo "$NewLine"
+if($FailedStrings.Count -gt 0){
+    $message = "The following resources do not have comments $NewLine" + ($FailedStrings -join $NewLine) + "$NewLine"
+    throw ($message)
+} else {
+    echo "All string resources have comments"
+}

--- a/tools/scripts/verification.scripts/ResourceStringCommentVerification.ps1
+++ b/tools/scripts/verification.scripts/ResourceStringCommentVerification.ps1
@@ -18,7 +18,7 @@ param(
 $NewLine=([Environment]::NewLine)
 $FailedStrings = @()
 # Exclude the projects that are not yet 
-$excludeList="(Actions|Automation|CLI|Desktop)"
+$excludeList="(Actions|Automation|CLI|Desktop|tools)"
 
 function Get-FileText($pathToFile){
    return Get-Content $pathToFile -Raw -Encoding UTF8

--- a/tools/scripts/verification.scripts/ResourceStringCommentVerification.ps1
+++ b/tools/scripts/verification.scripts/ResourceStringCommentVerification.ps1
@@ -61,8 +61,8 @@ function Get-ResourceContent($fileContent){
 
 echo "$NewLine"
 if($FailedStrings.Count -gt 0){
-    $message = "The following resources do not have comments $NewLine" + ($FailedStrings -join $NewLine) + "$NewLine"
+    $message = "The following resources do not have translator comments $NewLine" + ($FailedStrings -join $NewLine) + "$NewLine"
     throw ($message)
 } else {
-    echo "All string resources have comments"
+    echo "All string resources have translator comments"
 }


### PR DESCRIPTION
#### Details

As the resource strings in the core, rules, and ruleselection projects will be localized soon, it is important that we include any necessary translator comments along with those resources. We have gone through and added comments in previous PRs, but this PR adds a script to our PR builds to verify that we continue to have translator notes for all resource strings in those projects.

##### Motivation

Localization feature

##### Context

The script does not include the resource files for projects that are not localized right now, since there are quite a lot of strings in those projects that do not have comments yet. If we ever decide to localize those projects, it will be simple to remove them from the exclude list in this script. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [2002611](https://dev.azure.com/mseng/1ES/_workitems/edit/2002611)
