### PR TITLE
feat(localization): Refactor script to auto-detect localized projects

### DIFF
--- a/src/CI/CI.csproj
+++ b/src/CI/CI.csproj
@@ -57,9 +57,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Condition=" '$(MicroBuild_NuPkgSigningEnabled)' == 'true' " Name="CopyLocalizedFiles" AfterTargets="Build">
-    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\CopyLocalizedFiles.ps1 -SrcDir $(SolutionDir)Core\bin\$(ConfigurationName)\netStandard2.0\localize -TargetDir $(TargetDir) " />
-    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\CopyLocalizedFiles.ps1 -SrcDir $(SolutionDir)Rules\bin\$(ConfigurationName)\netStandard2.0\localize -TargetDir $(TargetDir) " />
-    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\CopyLocalizedFiles.ps1 -SrcDir $(SolutionDir)RuleSelection\bin\$(ConfigurationName)\netStandard2.0\localize -TargetDir $(TargetDir) " />
+    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\CopyLocalizedFiles.ps1 -Verbose -SrcDir $(SolutionDir) -TargetDir $(TargetDir) " />
   </Target>
   <Target Condition=" '$(CreateAxeWindowsNugetPackage)' == 'true' " Name="Pack" AfterTargets="Build" DependsOnTargets="CopyLocalizedFiles">
     <Exec Command="nuget.exe pack -properties Configuration=$(Configuration);VersionString=&quot;$(SemVerNumber)$(SemVerSuffix)&quot; Axe.Windows.nuspec -OutputDirectory bin\$(Configuration)\NuGet\$(SemVerNumber)$(SemVerSuffix) -NonInteractive" />

--- a/tools/scripts/CopyLocalizedFiles.ps1
+++ b/tools/scripts/CopyLocalizedFiles.ps1
@@ -3,16 +3,16 @@
 
 <#
 .SYNOPSIS
-Copies MicroBuild-generated localized files from SrcDir to their .NET equivalents in TargetDir.
+Copies MicroBuild-generated localized files from a solution to their .NET equivalents in TargetDir.
 
 .PARAMETER SrcDir
-The base directory where the MicroBuild localized files are located.
+The directory of the .sln file. Localized projects will be auto-discovered
 
 .PARAMETER TargetDir
 The base directory where the localized files shoudld be copied. Locale folders will be create as children of this driectory.
 
 .Example Usage
-.\CopyLocalizedFiles.ps1 -SrcDir c:\myrepo\src\Core\bin\release\netstandard\localize -TargetDir c:\myrepo\src\CI\bin\release
+.\CopyLocalizedFiles.ps1 -SrcDir c:\myrepo\src -TargetDir c:\myrepo\src\CI\bin\release
 #>
 
 param(


### PR DESCRIPTION
#### Details

In https://github.com/microsoft/axe-windows/pull/786#discussion_r1005849979, the suggestion was made to have `CopyLocalizedFiles.ps1` detect which projects had localized folders to copy, as oppose to requiring that `src\CI\CI.csproj` call them out explicitly. This PR makes that change. The logic is as follows:

1. Start with the solution folder
2. Walk through all child directories of the solution folder (these are the project folders)
3. Check for the existence of a `bin\Release\netstandard2.0\localize` directory within each project. This is the folder created by MicroBuild if localization is enabled
4. If the folder exists, call into the code that was already in place in the script.

Within the script, some internal function names have been massaged to better reflect what they do.

`src\CI\CI.csproj` now executes the script just once. It enables Verbose logging so that we have a nice trace inside the build pipeline. This output is visible [here](https://dev.azure.com/mseng/1ES/_build/results?buildId=18613371&view=logs&j=7c3ebc89-e7dd-5791-8c02-2ea1f3a27b50&t=9b81c1c0-976a-538f-a1e1-f4d170544876&l=4010)

The files included in the package are still correct:
```
Axe.Windows.2.0.1\lib\netstandard20\Axe.Windows.Actions.dll
Axe.Windows.2.0.1\lib\netstandard20\Axe.Windows.Automation.dll
Axe.Windows.2.0.1\lib\netstandard20\Axe.Windows.Automation.xml
Axe.Windows.2.0.1\lib\netstandard20\Axe.Windows.Core.dll
Axe.Windows.2.0.1\lib\netstandard20\Axe.Windows.Desktop.dll
Axe.Windows.2.0.1\lib\netstandard20\Axe.Windows.Rules.dll
Axe.Windows.2.0.1\lib\netstandard20\Axe.Windows.RuleSelection.dll
Axe.Windows.2.0.1\lib\netstandard20\Axe.Windows.SystemAbstractions.dll
Axe.Windows.2.0.1\lib\netstandard20\Axe.Windows.Telemetry.dll
Axe.Windows.2.0.1\lib\netstandard20\Axe.Windows.Win32.dll
Axe.Windows.2.0.1\lib\netstandard20\cs\Axe.Windows.Core.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\cs\Axe.Windows.Rules.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\cs\Axe.Windows.RuleSelection.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\de\Axe.Windows.Core.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\de\Axe.Windows.Rules.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\de\Axe.Windows.RuleSelection.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\es\Axe.Windows.Core.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\es\Axe.Windows.Rules.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\es\Axe.Windows.RuleSelection.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\fr\Axe.Windows.Core.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\fr\Axe.Windows.Rules.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\fr\Axe.Windows.RuleSelection.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\it\Axe.Windows.Core.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\it\Axe.Windows.Rules.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\it\Axe.Windows.RuleSelection.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\ja\Axe.Windows.Core.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\ja\Axe.Windows.Rules.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\ja\Axe.Windows.RuleSelection.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\ko\Axe.Windows.Core.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\ko\Axe.Windows.Rules.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\ko\Axe.Windows.RuleSelection.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\pl\Axe.Windows.Core.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\pl\Axe.Windows.Rules.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\pl\Axe.Windows.RuleSelection.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\pt-BR\Axe.Windows.Core.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\pt-BR\Axe.Windows.Rules.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\pt-BR\Axe.Windows.RuleSelection.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\ru\Axe.Windows.Core.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\ru\Axe.Windows.Rules.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\ru\Axe.Windows.RuleSelection.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\tr\Axe.Windows.Core.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\tr\Axe.Windows.Rules.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\tr\Axe.Windows.RuleSelection.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\zh-Hans\Axe.Windows.Core.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\zh-Hans\Axe.Windows.Rules.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\zh-Hans\Axe.Windows.RuleSelection.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\zh-Hant\Axe.Windows.Core.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\zh-Hant\Axe.Windows.Rules.resources.dll
Axe.Windows.2.0.1\lib\netstandard20\zh-Hant\Axe.Windows.RuleSelection.resources.dll
```

##### Motivation

Reduced maintenance if/when other projects are localized, easier debugging of the build script

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
