### PR TITLE
fix: Use correct type of redirects

### DIFF
--- a/src/Rules/Library/BoundingRectangleNotNullListViewXAML.cs
+++ b/src/Rules/Library/BoundingRectangleNotNullListViewXAML.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -19,7 +19,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.BoundingRectangleNotNull;
             this.Info.HowToFix = HowToFix.BoundingRectangleNotNull;
             this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-BoundingRectangleNotNullListViewXAML";
+            this.Info.FrameworkIssueLink = "https://go.microsoft.com/fwlink/?linkid=2214242";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/BoundingRectangleNotNullTextBlockXAML.cs
+++ b/src/Rules/Library/BoundingRectangleNotNullTextBlockXAML.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -19,7 +19,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Description = Descriptions.BoundingRectangleNotNull;
             this.Info.HowToFix = HowToFix.BoundingRectangleNotNull;
             this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-BoundingRectangleNotNullTextBlockXAML";
+            this.Info.FrameworkIssueLink = "https://go.microsoft.com/fwlink/?linkid=2213898";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ClickablePointOnScreenWPF.cs
+++ b/src/Rules/Library/ClickablePointOnScreenWPF.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -21,7 +21,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_IsOffscreenPropertyId;
             this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-ClickablePointOnScreenListViewWPF";
+            this.Info.FrameworkIssueLink = "https://go.microsoft.com/fwlink/?linkid=2214600";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportSetInfoWPF.cs
+++ b/src/Rules/Library/ControlShouldSupportSetInfoWPF.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -19,7 +19,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.ControlShouldSupportSetInfo;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-ControlShouldSupportSetInfoWPF";
+            this.Info.FrameworkIssueLink = "https://go.microsoft.com/fwlink/?linkid=2214332";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportTextPatternEditWinform.cs
+++ b/src/Rules/Library/ControlShouldSupportTextPatternEditWinform.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.ControlShouldSupportTextPattern;
             this.Info.Standard = A11yCriteriaId.AvailableActions;
             this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-ControlShouldSupportTextPatternEditWinForm";
+            this.Info.FrameworkIssueLink = "https://go.microsoft.com/fwlink/?linkid=2214162";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/EdgeBrowserHasBeenDeprecated.cs
+++ b/src/Rules/Library/EdgeBrowserHasBeenDeprecated.cs
@@ -16,7 +16,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.EdgeBrowserHasBeenDeprecated;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-EdgeBrowserHasBeenDeprecated";
+            this.Info.FrameworkIssueLink = "https://go.microsoft.com/fwlink/?linkid=2214421";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/FrameworkDoesNotSupportUIAutomation.cs
+++ b/src/Rules/Library/FrameworkDoesNotSupportUIAutomation.cs
@@ -23,7 +23,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.HowToFix = HowToFix.FrameworkDoesNotSupportUIAutomation;
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-FrameworkDoesNotSupportUIAutomation";
+            this.Info.FrameworkIssueLink = "https://go.microsoft.com/fwlink/?linkid=2214160";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsControlElementTrueRequiredButtonWPF.cs
+++ b/src/Rules/Library/IsControlElementTrueRequiredButtonWPF.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -20,7 +20,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_IsControlElementPropertyId;
             this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-IsControlElementTrueRequiredButtonWPF";
+            this.Info.FrameworkIssueLink = "https://go.microsoft.com/fwlink/?linkid=2214420";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsControlElementTrueRequiredTextInEditXAML.cs
+++ b/src/Rules/Library/IsControlElementTrueRequiredTextInEditXAML.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -20,7 +20,7 @@ namespace Axe.Windows.Rules.Library
             this.Info.Standard = A11yCriteriaId.ObjectInformation;
             this.Info.PropertyID = PropertyType.UIA_IsControlElementPropertyId;
             this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-IsControlElementTrueRequiredTextBoxXAML";
+            this.Info.FrameworkIssueLink = "https://go.microsoft.com/fwlink/?linkid=2214418";
         }
 
         public override bool PassesTest(IA11yElement e)


### PR DESCRIPTION
#### Details

When we added the framework issue links, we added them as aka.ms links, which are primarily intended for marketing-related links. In-product links should use fwlinks, which just assign a numeric value to each page. This PR updates the rules to point directly to the fwlink versions, while the redirect system has been already updated to point the existing aka.ms links to their new fwlink counterparts, so that we only need to worry about maintaining the fwlinks going forward. Here is the table that details the mapping between the old links, the new links, and the target pages:

aka.ms link | fwlink | target page
--- | --- | ---
https://aka.ms/FrameworkIssue-BoundingRectangleNotNullListViewXAML  | https://go.microsoft.com/fwlink/?linkid=2214242 | https://learn.microsoft.com/en-us/accessibility-tools-docs/items/uwpxaml/listview_boundingrectanglenotnull
https://aka.ms/FrameworkIssue-BoundingRectangleNotNullTextBlockXAML  | https://go.microsoft.com/fwlink/?linkid=2213898 | https://learn.microsoft.com/en-us/accessibility-tools-docs/items/uwpxaml/textblock_boundingrectanglenotnull
https://aka.ms/FrameworkIssue-ClickablePointOnScreenListViewWPF  | https://go.microsoft.com/fwlink/?linkid=2214600 | https://learn.microsoft.com/en-us/accessibility-tools-docs/items/wpf/clickablepointonscreen
https://aka.ms/FrameworkIssue-ControlShouldSupportSetInfoWPF  | https://go.microsoft.com/fwlink/?linkid=2214332 | https://learn.microsoft.com/en-us/accessibility-tools-docs/items/wpf/controlshouldsupportsetinfo
https://aka.ms/FrameworkIssue-ControlShouldSupportTextPatternEditWinForm  | https://go.microsoft.com/fwlink/?linkid=2214162 | https://learn.microsoft.com/en-us/accessibility-tools-docs/items/winforms/edit_controlshouldsupporttextpattern
https://aka.ms/FrameworkIssue-EdgeBrowserHasBeenDeprecated  | https://go.microsoft.com/fwlink/?linkid=2214421 | https://learn.microsoft.com/en-us/accessibility-tools-docs/items/edge/edgebrowserhasbeendeprecated
https://aka.ms/FrameworkIssue-FrameworkDoesNotSupportUIAutomation  | https://go.microsoft.com/fwlink/?linkid=2214160 | https://learn.microsoft.com/en-us/accessibility-tools-docs/items/win32/frameworkdoesnotsupportuiautomation
https://aka.ms/FrameworkIssue-IsControlElementTrueRequiredButtonWPF  | https://go.microsoft.com/fwlink/?linkid=2214420 | https://learn.microsoft.com/en-us/accessibility-tools-docs/items/wpf/button_iscontrolelementtruerequired
https://aka.ms/FrameworkIssue-IsControlElementTrueRequiredTextBoxXAML  | https://go.microsoft.com/fwlink/?linkid=2214418 | https://learn.microsoft.com/en-us/accessibility-tools-docs/items/uwpxaml/textinedit_iscontrolelementtruerequired

##### Motivation

Use correct link type.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
