### PR TITLE
chore: Enable analyzer flags to catch unneeded "this." prefixes

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -27,10 +27,10 @@ charset = utf-8-bom
 # Organize usings
 dotnet_sort_system_directives_first = false
 # this. preferences
-dotnet_style_qualification_for_field = false:silent
-dotnet_style_qualification_for_property = false:silent
-dotnet_style_qualification_for_method = false:silent
-dotnet_style_qualification_for_event = false:silent
+dotnet_style_qualification_for_field = false:error
+dotnet_style_qualification_for_property = false:error
+dotnet_style_qualification_for_method = false:error
+dotnet_style_qualification_for_event = false:error
 # Language keywords vs BCL types preferences
 dotnet_style_predefined_type_for_locals_parameters_members = true:silent
 dotnet_style_predefined_type_for_member_access = true:silent


### PR DESCRIPTION
#### Details

Enable analyzer rules to call out places where `this.` is used unnecessarily

##### Motivation

The code was originally written by folks who used `this.` _everywhere_ because that was the pattern in the team that they came from. Over time, that pattern has fallen by the wayside and now the code is very inconsistent. This PR is part of a series of PRs intended to increase the code consistency by removing unnecessary `this`. usage wherever possible.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
