### PR TITLE
chore: Analyzer-led removal of unneeded "this." prefixes in the Actions project

### DIFF
--- a/src/Actions/Actions/DataManager.cs
+++ b/src/Actions/Actions/DataManager.cs
@@ -52,9 +52,9 @@ namespace Axe.Windows.Actions
         /// <param name="ec"></param>
         internal void AddElementContext(ElementContext ec)
         {
-            if (ec != null && this.ElementContexts.ContainsKey(ec.Id) == false)
+            if (ec != null && ElementContexts.ContainsKey(ec.Id) == false)
             {
-                this.ElementContexts.Add(ec.Id, ec);
+                ElementContexts.Add(ec.Id, ec);
             }
         }
 
@@ -65,7 +65,7 @@ namespace Axe.Windows.Actions
         /// <returns></returns>
         internal ElementContext GetElementContext(Guid ecId)
         {
-            return this.ElementContexts.ContainsKey(ecId) ? this.ElementContexts[ecId] : null;
+            return ElementContexts.ContainsKey(ecId) ? ElementContexts[ecId] : null;
         }
 
         /// <summary>
@@ -76,9 +76,9 @@ namespace Axe.Windows.Actions
         {
             if (ElementContexts.ContainsKey(ecId))
             {
-                var ec = this.ElementContexts[ecId];
+                var ec = ElementContexts[ecId];
 
-                this.ElementContexts.Remove(ecId);
+                ElementContexts.Remove(ecId);
                 ec.Dispose();
             }
         }
@@ -91,9 +91,9 @@ namespace Axe.Windows.Actions
         internal void RemoveDataContext(Guid ecId, bool keepMainElement = true)
         {
             // check whether key exists. if not, just silently ignore.
-            if (this.ElementContexts.ContainsKey(ecId))
+            if (ElementContexts.ContainsKey(ecId))
             {
-                var ec = this.ElementContexts[ecId];
+                var ec = ElementContexts[ecId];
                 if (ec.DataContext != null)
                 {
                     if (keepMainElement)
@@ -116,7 +116,7 @@ namespace Axe.Windows.Actions
         /// <returns></returns>
         public A11yElement GetA11yElement(Guid ecId, int eId)
         {
-            if (this.ElementContexts.ContainsKey(ecId))
+            if (ElementContexts.ContainsKey(ecId))
             {
                 var ec = ElementContexts[ecId];
                 if (eId == 0)

--- a/src/Actions/Actions/ListenAction.cs
+++ b/src/Actions/Actions/ListenAction.cs
@@ -37,9 +37,9 @@ namespace Axe.Windows.Actions
         /// <param name="listener"></param>
         private ListenAction(ListenScope listenScope, ElementContext ec, HandleUIAutomationEventMessage listener)
         {
-            this.Id = Guid.NewGuid();
-            this.EventListener = new EventListenerFactory(ec.Element, listenScope);
-            this.ExternalListener = listener;
+            Id = Guid.NewGuid();
+            EventListener = new EventListenerFactory(ec.Element, listenScope);
+            ExternalListener = listener;
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Axe.Windows.Actions
         /// </summary>
         public void Start(IEnumerable<int> eventIDs, IEnumerable<int> propertyIDs)
         {
-            this.IsRunning = true;
+            IsRunning = true;
 
             InitIndividualEventListeners(eventIDs);
             InitPropertyChangeListener(propertyIDs);
@@ -61,7 +61,7 @@ namespace Axe.Windows.Actions
             if (propertyIds == null) return;
             if (!propertyIds.Any()) return;
 
-            this.EventListener.RegisterAutomationEventListener(EventType.UIA_AutomationPropertyChangedEventId, this.onEventFired, propertyIds.ToArray());
+            EventListener.RegisterAutomationEventListener(EventType.UIA_AutomationPropertyChangedEventId, onEventFired, propertyIds.ToArray());
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace Axe.Windows.Actions
 
             foreach (var id in eventIds)
             {
-                this.EventListener.RegisterAutomationEventListener(id, this.onEventFired);
+                EventListener.RegisterAutomationEventListener(id, onEventFired);
             }
         }
 
@@ -83,7 +83,7 @@ namespace Axe.Windows.Actions
         public void Stop()
         {
             IsRunning = false;
-            this.EventListener.UnregisterAllAutomationEventListners();
+            EventListener.UnregisterAllAutomationEventListners();
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Axe.Windows.Actions
         {
             if (IsRunning)
             {
-                this.ExternalListener?.Invoke(message);
+                ExternalListener?.Invoke(message);
             }
         }
 
@@ -163,8 +163,8 @@ namespace Axe.Windows.Actions
             {
                 if (disposing)
                 {
-                    this.EventListener.Dispose();
-                    this.EventListener = null;
+                    EventListener.Dispose();
+                    EventListener = null;
                 }
 
                 disposedValue = true;

--- a/src/Actions/Actions/LoadActionParts.cs
+++ b/src/Actions/Actions/LoadActionParts.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Core.Bases;
@@ -41,10 +41,10 @@ namespace Axe.Windows.Actions
         /// <param name="settings">Metadata about the snapshot</param>
         public LoadActionParts(A11yElement el, Bitmap bmp, Bitmap synthesizedBmp, SnapshotMetaInfo settings)
         {
-            this.Element = el;
-            this.Bmp = bmp;
-            this.SynthesizedBmp = synthesizedBmp;
-            this.MetaInfo = settings;
+            Element = el;
+            Bmp = bmp;
+            SynthesizedBmp = synthesizedBmp;
+            MetaInfo = settings;
         }
     }
 }

--- a/src/Actions/Actions/SelectAction.cs
+++ b/src/Actions/Actions/SelectAction.cs
@@ -46,12 +46,12 @@ namespace Axe.Windows.Actions
         {
             get
             {
-                return this.MouseTracker.IntervalMouseSelector;
+                return MouseTracker.IntervalMouseSelector;
             }
 
             set
             {
-                this.MouseTracker.IntervalMouseSelector = value;
+                MouseTracker.IntervalMouseSelector = value;
             }
         } // default for the case
 
@@ -113,8 +113,8 @@ namespace Axe.Windows.Actions
 
             set
             {
-                this.FocusTracker.Scope = value;
-                this.MouseTracker.Scope = value;
+                FocusTracker.Scope = value;
+                MouseTracker.Scope = value;
             }
         }
 
@@ -124,9 +124,9 @@ namespace Axe.Windows.Actions
         private SelectAction(DataManager dataManager)
         {
             DataManager = dataManager ?? throw new ArgumentNullException(nameof(dataManager));
-            this.FocusTracker = new FocusTracker(SetCandidateElement);
-            this.MouseTracker = new MouseTracker(SetCandidateElement);
-            this.TreeTracker = new TreeTracker(this.SetCandidateElement, this);
+            FocusTracker = new FocusTracker(SetCandidateElement);
+            MouseTracker = new MouseTracker(SetCandidateElement);
+            TreeTracker = new TreeTracker(SetCandidateElement, this);
         }
 
         /// <summary>
@@ -134,10 +134,10 @@ namespace Axe.Windows.Actions
         /// </summary>
         public void Stop()
         {
-            if (!this.IsPaused)
+            if (!IsPaused)
             {
-                this.FocusTracker?.Stop();
-                this.MouseTracker?.Stop();
+                FocusTracker?.Stop();
+                MouseTracker?.Stop();
             }
         }
 
@@ -146,16 +146,16 @@ namespace Axe.Windows.Actions
         /// </summary>
         public void Start()
         {
-            if (!this.IsPaused)
+            if (!IsPaused)
             {
-                if (this.IsFocusSelectOn)
+                if (IsFocusSelectOn)
                 {
-                    this.FocusTracker?.Start();
+                    FocusTracker?.Start();
                 }
 
-                if (this.IsMouseSelectOn)
+                if (IsMouseSelectOn)
                 {
-                    this.MouseTracker?.Start();
+                    MouseTracker?.Start();
                 }
             }
         }
@@ -166,7 +166,7 @@ namespace Axe.Windows.Actions
         public void PauseUIATreeTracker()
         {
             Stop();
-            this.UIATreeState = UIATreeState.Paused;
+            UIATreeState = UIATreeState.Paused;
         }
 
         /// <summary>
@@ -174,7 +174,7 @@ namespace Axe.Windows.Actions
         /// </summary>
         public void ResumeUIATreeTracker()
         {
-            this.UIATreeState = UIATreeState.Resumed;
+            UIATreeState = UIATreeState.Resumed;
             Start();
         }
 
@@ -191,8 +191,8 @@ namespace Axe.Windows.Actions
                 {
                     if (el.IsRootElement() == false)
                     {
-                        this.CandidateEC?.Dispose();
-                        this.CandidateEC = new ElementContext(el);
+                        CandidateEC?.Dispose();
+                        CandidateEC = new ElementContext(el);
                     }
                     else
                     {
@@ -297,7 +297,7 @@ namespace Axe.Windows.Actions
         /// </summary>
         public void ClearSelectedContext()
         {
-            if (!this.IsPaused)
+            if (!IsPaused)
             {
                 lock (_elementContextLock)
                 {
@@ -305,8 +305,8 @@ namespace Axe.Windows.Actions
                     CandidateEC?.Dispose();
                     CandidateEC = null;
 
-                    this.MouseTracker.Clear();
-                    this.FocusTracker.Clear();
+                    MouseTracker.Clear();
+                    FocusTracker.Clear();
                 }
             }
         }
@@ -331,25 +331,25 @@ namespace Axe.Windows.Actions
         /// <returns></returns>
         public bool HasPOIElement()
         {
-            return this.POIElementContext != null;
+            return POIElementContext != null;
         }
 
         public TreeViewMode TreeViewMode
         {
             get
             {
-                return (this.TreeTracker != null)
-                    ? this.TreeTracker.TreeViewMode
+                return (TreeTracker != null)
+                    ? TreeTracker.TreeViewMode
                     : TreeViewMode.Raw;
             }
 
             set
             {
-                if (this.MouseTracker != null)
-                    this.MouseTracker.TreeViewMode = value;
+                if (MouseTracker != null)
+                    MouseTracker.TreeViewMode = value;
 
-                if (this.TreeTracker != null)
-                    this.TreeTracker.TreeViewMode = value;
+                if (TreeTracker != null)
+                    TreeTracker.TreeViewMode = value;
             }
         }
 
@@ -402,26 +402,26 @@ namespace Axe.Windows.Actions
             {
                 if (disposing)
                 {
-                    if (this.POIElementContext != null)
+                    if (POIElementContext != null)
                     {
-                        this.POIElementContext.Dispose();
-                        this.POIElementContext = null;
+                        POIElementContext.Dispose();
+                        POIElementContext = null;
                     }
-                    if (this.CandidateEC != null)
+                    if (CandidateEC != null)
                     {
-                        this.CandidateEC.Dispose();
-                        this.CandidateEC = null;
+                        CandidateEC.Dispose();
+                        CandidateEC = null;
                     }
-                    if (this.MouseTracker != null)
+                    if (MouseTracker != null)
                     {
-                        this.MouseTracker.Dispose();
-                        this.MouseTracker = null;
+                        MouseTracker.Dispose();
+                        MouseTracker = null;
                     }
-                    if (this.FocusTracker != null)
+                    if (FocusTracker != null)
                     {
-                        this.FocusTracker.Stop();
-                        this.FocusTracker.Dispose();
-                        this.FocusTracker = null;
+                        FocusTracker.Stop();
+                        FocusTracker.Dispose();
+                        FocusTracker = null;
                     }
                 }
 

--- a/src/Actions/Attributes/InteractionLevelAttribute.cs
+++ b/src/Actions/Attributes/InteractionLevelAttribute.cs
@@ -27,7 +27,7 @@ namespace Axe.Windows.Actions.Attributes
         /// <param name="interactionLevel"></param>
         public InteractionLevelAttribute(UxInteractionLevel interactionLevel) : base()
         {
-            this._interactionLevel = interactionLevel;
+            _interactionLevel = interactionLevel;
         }
     }
 }

--- a/src/Actions/Contexts/ElementContext.cs
+++ b/src/Actions/Contexts/ElementContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Actions.Enums;
 using Axe.Windows.Core.Bases;
@@ -39,20 +39,20 @@ namespace Axe.Windows.Actions.Contexts
         /// <param name="element"></param>
         public ElementContext(A11yElement element)
         {
-            this.Element = element ?? throw new ArgumentNullException(nameof(element));
+            Element = element ?? throw new ArgumentNullException(nameof(element));
 
-            if (this.Element.PlatformObject == null)
+            if (Element.PlatformObject == null)
             {
-                this.SelectType = SelectType.Loaded;
-                this.ProcessName = "Unknown";
+                SelectType = SelectType.Loaded;
+                ProcessName = "Unknown";
             }
             else
             {
-                this.SelectType = SelectType.Live;
-                this.ProcessName = this.Element.GetProcessName();
+                SelectType = SelectType.Live;
+                ProcessName = Element.GetProcessName();
             }
 
-            this.Id = Guid.NewGuid();
+            Id = Guid.NewGuid();
         }
 
         // Backing object for DataContext - is disposed via DataContext property
@@ -85,14 +85,14 @@ namespace Axe.Windows.Actions.Contexts
             {
                 if (disposing)
                 {
-                    this.ProcessName = null;
-                    if (this.DataContext != null)
+                    ProcessName = null;
+                    if (DataContext != null)
                     {
-                        this.DataContext = null;
+                        DataContext = null;
                     }
                     else
                     {
-                        this.Element.Dispose();
+                        Element.Dispose();
                     }
                 }
                 disposedValue = true;

--- a/src/Actions/Contexts/ElementDataContext.cs
+++ b/src/Actions/Contexts/ElementDataContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Actions.Enums;
 using Axe.Windows.Core.Bases;
@@ -69,7 +69,7 @@ namespace Axe.Windows.Actions.Contexts
         /// </summary>
         internal ElementDataContext(A11yElement e, int maxElements)
         {
-            this.Element = e;
+            Element = e;
             ElementCounter = new BoundedCounter(maxElements);
         }
 
@@ -82,16 +82,16 @@ namespace Axe.Windows.Actions.Contexts
             {
                 if (disposing)
                 {
-                    this.Screenshot?.Dispose();
-                    this.Screenshot = null;
-                    this.Element = null;
-                    if (this.Elements != null)
+                    Screenshot?.Dispose();
+                    Screenshot = null;
+                    Element = null;
+                    if (Elements != null)
                     {
-                        if (this.Mode == DataContextMode.Live)
+                        if (Mode == DataContextMode.Live)
                         {
                             // IUIAutomation can become non-responsive if Dispose is called in parallel.
                             // Explicitly Dispose the Element Values here to avoid this.
-                            foreach (var e in this.Elements.Values)
+                            foreach (var e in Elements.Values)
                             {
                                 e.Dispose();
                             }
@@ -100,10 +100,10 @@ namespace Axe.Windows.Actions.Contexts
                         {
                             // so far when it gets into test, it works OK.
                             // it will keep the same perf when switch back to Live from Test.
-                            this.Elements.Values.AsParallel().ForAll(e => e.Dispose());
+                            Elements.Values.AsParallel().ForAll(e => e.Dispose());
                         }
 
-                        this.Elements.Clear();
+                        Elements.Clear();
                     }
                 }
 

--- a/src/Actions/Trackers/BaseTracker.cs
+++ b/src/Actions/Trackers/BaseTracker.cs
@@ -46,7 +46,7 @@ namespace Axe.Windows.Actions.Trackers
         /// <param name="action"></param>
         protected BaseTracker(Action<A11yElement> action, IActionContext actionContext)
         {
-            this.SetElement = action;
+            SetElement = action;
             ActionContext = actionContext ?? throw new ArgumentNullException(nameof(actionContext));
         }
 
@@ -58,8 +58,8 @@ namespace Axe.Windows.Actions.Trackers
 #pragma warning restore CA1716 // Identifiers should not match keywords
         {
             // clean up selection
-            this.SelectedElementRuntimeId = null;
-            this.SelectedBoundingRectangle = null;
+            SelectedElementRuntimeId = null;
+            SelectedBoundingRectangle = null;
         }
 
         /// <summary>
@@ -117,8 +117,8 @@ namespace Axe.Windows.Actions.Trackers
         /// </summary>
         public virtual void Clear()
         {
-            this.SelectedElementRuntimeId = null;
-            this.SelectedBoundingRectangle = null;
+            SelectedElementRuntimeId = null;
+            SelectedBoundingRectangle = null;
         }
 
         #region IDisposable Support

--- a/src/Actions/Trackers/FocusTracker.cs
+++ b/src/Actions/Trackers/FocusTracker.cs
@@ -26,7 +26,7 @@ namespace Axe.Windows.Actions.Trackers
         /// <param name="action"></param>
         public FocusTracker(Action<A11yElement> action) : base(action, DefaultActionContext.GetDefaultInstance())
         {
-            this.EventHandler = new EventListenerFactory(null); // listen for all element. it works only for FocusChangedEvent
+            EventHandler = new EventListenerFactory(null); // listen for all element. it works only for FocusChangedEvent
         }
 
         /// <summary>
@@ -34,10 +34,10 @@ namespace Axe.Windows.Actions.Trackers
         /// </summary>
         public override void Stop()
         {
-            if (this.EventHandler != null && IsStarted)
+            if (EventHandler != null && IsStarted)
             {
-                this.EventHandler.UnregisterAutomationEventListener(EventType.UIA_AutomationFocusChangedEventId);
-                this.IsStarted = false;
+                EventHandler.UnregisterAutomationEventListener(EventType.UIA_AutomationFocusChangedEventId);
+                IsStarted = false;
             }
             base.Stop();
         }
@@ -49,7 +49,7 @@ namespace Axe.Windows.Actions.Trackers
         {
             if (IsStarted == false)
             {
-                this.EventHandler?.RegisterAutomationEventListener(EventType.UIA_AutomationFocusChangedEventId, this.onFocusChangedEventForSelectingElement);
+                EventHandler?.RegisterAutomationEventListener(EventType.UIA_AutomationFocusChangedEventId, onFocusChangedEventForSelectingElement);
                 IsStarted = true;
             }
         }
@@ -82,10 +82,10 @@ namespace Axe.Windows.Actions.Trackers
 
         protected override void Dispose(bool disposing)
         {
-            if (this.EventHandler != null)
+            if (EventHandler != null)
             {
-                this.EventHandler.Dispose();
-                this.EventHandler = null;
+                EventHandler.Dispose();
+                EventHandler = null;
             }
             base.Dispose(disposing);
         }

--- a/src/Actions/Trackers/MouseTracker.cs
+++ b/src/Actions/Trackers/MouseTracker.cs
@@ -29,14 +29,14 @@ namespace Axe.Windows.Actions.Trackers
         {
             get
             {
-                return this.timerMouse.Interval;
+                return timerMouse.Interval;
             }
 
             set
             {
-                if (this.timerMouse != null)
+                if (timerMouse != null)
                 {
-                    this.timerMouse.Interval = value;
+                    timerMouse.Interval = value;
                 }
             }
         }
@@ -69,9 +69,9 @@ namespace Axe.Windows.Actions.Trackers
         public MouseTracker(Action<A11yElement> action) : base(action, DefaultActionContext.GetDefaultInstance())
         {
             // set up mouse Timer
-            this.timerMouse = new System.Timers.Timer(DefaultTimerInterval); // default but it will be set by config immediately.
-            this.timerMouse.Elapsed += new ElapsedEventHandler(this.ontimerMouseElapsedEvent);
-            this.timerMouse.AutoReset = false;// disable autoreset to do reset in timer handler
+            timerMouse = new System.Timers.Timer(DefaultTimerInterval); // default but it will be set by config immediately.
+            timerMouse.Elapsed += new ElapsedEventHandler(ontimerMouseElapsedEvent);
+            timerMouse.AutoReset = false;// disable autoreset to do reset in timer handler
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace Axe.Windows.Actions.Trackers
         {
             if (IsStarted == true)
             {
-                this.timerMouse?.Stop();
+                timerMouse?.Stop();
                 IsStarted = false;
             }
 
@@ -95,7 +95,7 @@ namespace Axe.Windows.Actions.Trackers
         {
             if (IsStarted == false)
             {
-                this.timerMouse?.Start();
+                timerMouse?.Start();
                 IsStarted = true;
             }
         }
@@ -109,13 +109,13 @@ namespace Axe.Windows.Actions.Trackers
         {
             lock (_elementSetterLock)
             {
-                if (this.timerMouse != null && this.IsStarted)
+                if (timerMouse != null && IsStarted)
                 {
                     NativeMethods.GetCursorPos(out Point p);
 
-                    if (LastMousePoint.Equals(p) && !this.POIPoint.Equals(p))
+                    if (LastMousePoint.Equals(p) && !POIPoint.Equals(p))
                     {
-                        var element = GetElementBasedOnScope(A11yAutomation.NormalizedElementFromPoint(p.X, p.Y, this.TreeViewMode, ActionContext.DesktopDataContext));
+                        var element = GetElementBasedOnScope(A11yAutomation.NormalizedElementFromPoint(p.X, p.Y, TreeViewMode, ActionContext.DesktopDataContext));
                         if (!SelectElementIfItIsEligible(element))
                         {
                             element?.Dispose();
@@ -125,7 +125,7 @@ namespace Axe.Windows.Actions.Trackers
 
                     LastMousePoint = p;
 
-                    this.timerMouse?.Start(); // make sure that it is enabled.
+                    timerMouse?.Start(); // make sure that it is enabled.
                 }
             }
         }
@@ -137,8 +137,8 @@ namespace Axe.Windows.Actions.Trackers
         {
             base.Clear();
             // clean up all points to make sure to start from scratch
-            this.POIPoint = Point.Empty;
-            this.LastMousePoint = Point.Empty;
+            POIPoint = Point.Empty;
+            LastMousePoint = Point.Empty;
         }
 
         /// <summary>
@@ -147,11 +147,11 @@ namespace Axe.Windows.Actions.Trackers
         /// <param name="disposing"></param>
         protected override void Dispose(bool disposing)
         {
-            if (this.timerMouse != null)
+            if (timerMouse != null)
             {
-                this.timerMouse.Stop();
-                this.timerMouse.Dispose();
-                this.timerMouse = null;
+                timerMouse.Stop();
+                timerMouse.Dispose();
+                timerMouse = null;
             }
 
             base.Dispose(disposing);

--- a/src/Actions/Trackers/TreeTracker.cs
+++ b/src/Actions/Trackers/TreeTracker.cs
@@ -29,7 +29,7 @@ namespace Axe.Windows.Actions.Trackers
         public TreeTracker(Action<A11yElement> action, SelectAction selectAction)
             : base(action, DefaultActionContext.GetDefaultInstance())
         {
-            this.SelectAction = selectAction;
+            SelectAction = selectAction;
         }
 
         public override void Start()
@@ -42,7 +42,7 @@ namespace Axe.Windows.Actions.Trackers
 
         public void MoveToParent()
         {
-            MoveTo(this.GetParent);
+            MoveTo(GetParent);
         }
 
         private IUIAutomationElement GetParent(IUIAutomationTreeWalker treeWalker, IUIAutomationElement element)
@@ -54,7 +54,7 @@ namespace Axe.Windows.Actions.Trackers
 
         public void MoveToFirstChild()
         {
-            MoveTo(this.GetFirstChild);
+            MoveTo(GetFirstChild);
         }
 
         private IUIAutomationElement GetFirstChild(IUIAutomationTreeWalker treeWalker, IUIAutomationElement element)
@@ -66,7 +66,7 @@ namespace Axe.Windows.Actions.Trackers
 
         public void MoveToLastChild()
         {
-            MoveTo(this.GetLastChild);
+            MoveTo(GetLastChild);
         }
 
         private IUIAutomationElement GetLastChild(IUIAutomationTreeWalker treeWalker, IUIAutomationElement element)
@@ -78,7 +78,7 @@ namespace Axe.Windows.Actions.Trackers
 
         public void MoveToNextSibling()
         {
-            MoveTo(this.GetNextSibling);
+            MoveTo(GetNextSibling);
         }
 
         private IUIAutomationElement GetNextSibling(IUIAutomationTreeWalker treeWalker, IUIAutomationElement element)
@@ -90,7 +90,7 @@ namespace Axe.Windows.Actions.Trackers
 
         public void MoveToPreviousSibling()
         {
-            MoveTo(this.GetPreviousSibling);
+            MoveTo(GetPreviousSibling);
         }
 
         private IUIAutomationElement GetPreviousSibling(IUIAutomationTreeWalker treeWalker, IUIAutomationElement element)
@@ -133,8 +133,8 @@ namespace Axe.Windows.Actions.Trackers
             desktopElement.PopulateMinimumPropertiesForSelection(ActionContext.DesktopDataContext);
             if (desktopElement.IsRootElement() == false)
             {
-                this.SelectAction?.SetCandidateElement(desktopElement);
-                this.SelectAction?.Select();
+                SelectAction?.SetCandidateElement(desktopElement);
+                SelectAction?.Select();
             }
             else
             {
@@ -149,7 +149,7 @@ namespace Axe.Windows.Actions.Trackers
             var currentElement = GetCurrentElement();
             if (currentElement == null) return null;
 
-            var treeWalker = ActionContext.DesktopDataContext.A11yAutomation.GetTreeWalker(this.TreeViewMode);
+            var treeWalker = ActionContext.DesktopDataContext.A11yAutomation.GetTreeWalker(TreeViewMode);
 
             var nextElement = getNextElement?.Invoke(treeWalker, currentElement);
 
@@ -178,7 +178,7 @@ namespace Axe.Windows.Actions.Trackers
 
         private IUIAutomationElement GetCurrentElement()
         {
-            return this.SelectAction?.POIElementContext?.Element?.PlatformObject as IUIAutomationElement;
+            return SelectAction?.POIElementContext?.Element?.PlatformObject as IUIAutomationElement;
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
#### Details

Apply analyzer-led removal of unneeded `this.` prefixes in the `Actions` project. After locally making the changes in #796, the IDE highlighted the `this.` prefixes that were not needed.

##### Motivation

The code was originally written by folks who used `this.` _everywhere_ because that was the pattern in the team that they came from. Over time, that pattern has fallen by the wayside and now the code is very inconsistent. This PR is part of a series of PRs intended to increase the code consistency by removing unnecessary `this`. usage wherever possible.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
