### PR TITLE
chore: Analyzer-led removal of unneeded "this." prefixes in the Core project

### DIFF
--- a/src/Core/Bases/A11yElement.cs
+++ b/src/Core/Bases/A11yElement.cs
@@ -350,7 +350,7 @@ namespace Axe.Windows.Core.Bases
             // assignment required
             value = default;
 
-            var property = this.GetPropertySafely(propertyId);
+            var property = GetPropertySafely(propertyId);
             if (property == null) return false;
 
             dynamic temp = ConvertValueIfNecessary(propertyId, property.Value);
@@ -401,7 +401,7 @@ namespace Axe.Windows.Core.Bases
         /// <returns>an <see cref="IA11yPattern"/> object for the specified pattern if it exists; otherwise, null.</returns>
         public IA11yPattern GetPattern(int patternId)
         {
-            var pattern = this.Patterns?.FirstOrDefault(p => p.Id == patternId);
+            var pattern = Patterns?.FirstOrDefault(p => p.Id == patternId);
             if (pattern == null) return null;
 
             return pattern;
@@ -415,7 +415,7 @@ namespace Axe.Windows.Core.Bases
         /// <returns>the value of the specified property if it exists; otherwise, the default value for the given type</returns>
         public T GetPlatformPropertyValue<T>(int propertyId)
         {
-            var property = this.PlatformProperties?.ById(propertyId);
+            var property = PlatformProperties?.ById(propertyId);
             if (property == null) return default;
             if (!(property.Value is T)) throw new AxeWindowsException(ExtensionMethods.WithParameters(ErrorMessages.PropertyValueTypeUnexpected, property.Value.GetType().Name, typeof(T).Name));
 
@@ -475,7 +475,7 @@ namespace Axe.Windows.Core.Bases
                 if (_ProcessName != null)
                     return _ProcessName;
 
-                var name = Utility.GetProcessName(this.ProcessId);
+                var name = Utility.GetProcessName(ProcessId);
 
                 _ProcessName = name ?? "";
 
@@ -489,8 +489,8 @@ namespace Axe.Windows.Core.Bases
         /// <returns>an <see cref="IA11yElement"/> object for the child if it exists</returns>
         public IA11yElement GetFirstChild()
         {
-            if (this.Children == null) return null;
-            if (!this.Children.Any()) return null;
+            if (Children == null) return null;
+            if (!Children.Any()) return null;
 
             return Children[0];
         }
@@ -504,7 +504,7 @@ namespace Axe.Windows.Core.Bases
         {
             if (condition == null) throw new ArgumentNullException(nameof(condition));
 
-            Queue<A11yElement> children = new Queue<A11yElement>(this.Children);
+            Queue<A11yElement> children = new Queue<A11yElement>(Children);
             while (children.Count > 0)
             {
                 var currentChild = children.Dequeue();
@@ -531,9 +531,9 @@ namespace Axe.Windows.Core.Bases
         {
             get
             {
-                if (this.ScanResults != null)
+                if (ScanResults != null)
                 {
-                    return this.ScanResults.Status;
+                    return ScanResults.Status;
                 }
 
                 return ScanStatus.NoResult;
@@ -586,9 +586,9 @@ namespace Axe.Windows.Core.Bases
         {
             get
             {
-                if (this.Children == null) yield break;
+                if (Children == null) yield break;
 
-                foreach (var child in this.Children)
+                foreach (var child in Children)
                     yield return child;
             }
         }
@@ -609,7 +609,7 @@ namespace Axe.Windows.Core.Bases
         {
             get
             {
-                return this.Parent;
+                return Parent;
             }
         }
 
@@ -643,9 +643,9 @@ namespace Axe.Windows.Core.Bases
         /// <returns></returns>
         protected A11yProperty GetPropertySafely(int id)
         {
-            if (this.Properties == null) return null;
+            if (Properties == null) return null;
 
-            return this.Properties.TryGetValue(id, out A11yProperty property)
+            return Properties.TryGetValue(id, out A11yProperty property)
                 ? property : null;
         }
 
@@ -748,28 +748,28 @@ namespace Axe.Windows.Core.Bases
                         {
                             ptn.Dispose();
                         }
-                        this.Patterns.Clear();
-                        this.Patterns = null;
+                        Patterns.Clear();
+                        Patterns = null;
                     }
 
                     if (Properties != null)
                     {
-                        foreach (var pp in this.Properties.Values)
+                        foreach (var pp in Properties.Values)
                         {
                             pp.Dispose();
                         }
-                        this.Properties.Clear();
-                        this.Properties = null;
+                        Properties.Clear();
+                        Properties = null;
                     }
 
-                    this.PlatformProperties?.Clear();
-                    this.PlatformProperties = null;
-                    this.Children?.Clear();
-                    this.Children = null;
-                    this.Parent = null;
-                    this.ScanResults = null;
-                    this.PlatformObject = null;
-                    this.Glimpse = null;
+                    PlatformProperties?.Clear();
+                    PlatformProperties = null;
+                    Children?.Clear();
+                    Children = null;
+                    Parent = null;
+                    ScanResults = null;
+                    PlatformObject = null;
+                    Glimpse = null;
                 }
 
                 DisposedValue = true;

--- a/src/Core/Bases/A11yPattern.cs
+++ b/src/Core/Bases/A11yPattern.cs
@@ -66,12 +66,12 @@ namespace Axe.Windows.Core.Bases
         /// <param name="name"></param>
         public A11yPattern(A11yElement e, int id, string name)
         {
-            this.Element = e;
-            this.Id = id;
-            this.Name = name;
-            this.IsUIActionable = this.IsUIActionablePatternByPatternMethodType();
-            this.Properties = new List<A11yPatternProperty>();
-            this.Methods = GetListOfPatternMethods();
+            Element = e;
+            Id = id;
+            Name = name;
+            IsUIActionable = this.IsUIActionablePatternByPatternMethodType();
+            Properties = new List<A11yPatternProperty>();
+            Methods = GetListOfPatternMethods();
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace Axe.Windows.Core.Bases
         /// <returns>if there is no method with "PatternmethodAttribute", return null</returns>
         private List<MethodInfo> GetListOfPatternMethods()
         {
-            return (from m in this.GetType().GetMethods()
+            return (from m in GetType().GetMethods()
                     let a = m.GetCustomAttribute(typeof(PatternMethodAttribute))
                     where a != null
                     select m).ToList();
@@ -93,9 +93,9 @@ namespace Axe.Windows.Core.Bases
 
         public T GetValue<T>(string propertyName)
         {
-            if (this.Properties == null) return default(T);
+            if (Properties == null) return default(T);
 
-            var item = this.Properties.ToList().Find(p => p.Name == propertyName);
+            var item = Properties.ToList().Find(p => p.Name == propertyName);
             if (item == null) return default(T);
 
             if (item.Value is T)
@@ -156,10 +156,10 @@ namespace Axe.Windows.Core.Bases
             {
                 if (disposing)
                 {
-                    ListHelper.DisposeAllItemsAndClearList(this.Properties);
-                    this.Properties = null;
-                    this.Name = null;
-                    this.Element = null;
+                    ListHelper.DisposeAllItemsAndClearList(Properties);
+                    Properties = null;
+                    Name = null;
+                    Element = null;
                 }
 
                 disposedValue = true;

--- a/src/Core/Bases/A11yPatternProperty.cs
+++ b/src/Core/Bases/A11yPatternProperty.cs
@@ -19,12 +19,12 @@ namespace Axe.Windows.Core.Bases
         {
             get
             {
-                if (this.Value is string)
+                if (Value is string)
                 {
-                    return ExtensionMethods.WithParameters("{0} = \"{1}\"", this.Name, this.Value);
+                    return ExtensionMethods.WithParameters("{0} = \"{1}\"", Name, Value);
                 }
 
-                return ExtensionMethods.WithParameters("{0} = {1}", this.Name, this.Value);
+                return ExtensionMethods.WithParameters("{0} = {1}", Name, Value);
             }
         }
 
@@ -37,8 +37,8 @@ namespace Axe.Windows.Core.Bases
             {
                 if (disposing)
                 {
-                    this.Name = null;
-                    this.Value = null;
+                    Name = null;
+                    Value = null;
                 }
 
                 disposedValue = true;

--- a/src/Core/Bases/A11yProperty.cs
+++ b/src/Core/Bases/A11yProperty.cs
@@ -44,7 +44,7 @@ namespace Axe.Windows.Core.Bases
         {
             get
             {
-                return this.ToString();
+                return ToString();
             }
         }
 
@@ -57,7 +57,7 @@ namespace Axe.Windows.Core.Bases
         /// <param name="element"></param>
         public A11yProperty(int id, dynamic value, string name = null) : this(id, name)
         {
-            this.Value = value;
+            Value = value;
         }
 
         /// <summary>
@@ -67,8 +67,8 @@ namespace Axe.Windows.Core.Bases
         /// <param name="name">if null, it is get name from PropertyTypes by id</param>
         private A11yProperty(int id, string name)
         {
-            this.Id = id;
-            this.Name = name ?? PropertyType.GetInstance().GetNameById(id);
+            Id = id;
+            Name = name ?? PropertyType.GetInstance().GetNameById(id);
         }
 
         /// <summary>
@@ -80,22 +80,22 @@ namespace Axe.Windows.Core.Bases
         {
             string txt = null;
 
-            if (this.Value != null)
+            if (Value != null)
             {
-                switch (this.Id)
+                switch (Id)
                 {
                     case PropertyType.UIA_RuntimeIdPropertyId:
                         txt = this.ConvertIntArrayToString();
                         break;
                     case PropertyType.UIA_ControlTypePropertyId:
-                        txt = this.Value != null ? ControlType.GetInstance().GetNameById(this.Value) : "";
+                        txt = Value != null ? ControlType.GetInstance().GetNameById(Value) : "";
                         break;
                     case PropertyType.UIA_BoundingRectanglePropertyId:
                         // if bounding rectangle is [0,0,0,0], treat it as non-exist. same behavior as Inspect
                         txt = GetBoundingRectangleText();
                         break;
                     case PropertyType.UIA_OrientationPropertyId:
-                        switch ((int)this.Value)
+                        switch ((int)Value)
                         {
                             case 0: //OrientationType_None
                                 txt = DisplayStrings.NoneOrientation;
@@ -113,33 +113,33 @@ namespace Axe.Windows.Core.Bases
                     case PropertyType.UIA_SizeOfSetPropertyId:
                         /// these properties are 1 based.
                         /// if value is smaller than 1, it should be ignored.
-                        if (this.Value != null && this.Value > 0)
+                        if (Value != null && Value > 0)
                         {
-                            txt = this.Value?.ToString();
+                            txt = Value?.ToString();
                         }
                         break;
                     case PropertyType.UIA_HeadingLevelPropertyId:
-                        txt = HeadingLevelType.GetInstance().GetNameById(this.Value);
+                        txt = HeadingLevelType.GetInstance().GetNameById(Value);
                         break;
                     case PropertyType.UIA_LandmarkTypePropertyId:
-                        txt = this.Value != 0 ? LandmarkType.GetInstance().GetNameById(this.Value) : null; // 0 is default value.
+                        txt = Value != 0 ? LandmarkType.GetInstance().GetNameById(Value) : null; // 0 is default value.
                         break;
                     default:
                         if (TypeConverterMap.TryGetValue(Id, out ITypeConverter converter))
                         {
                             txt = converter.Render(Value);
                         }
-                        else if (this.Value is Int32[])
+                        else if (Value is Int32[])
                         {
-                            txt = ((Int32[])this.Value).ConvertInt32ArrayToString();
+                            txt = ((Int32[])Value).ConvertInt32ArrayToString();
                         }
-                        else if (this.Value is Double[])
+                        else if (Value is Double[])
                         {
-                            txt = ((Double[])this.Value).ConvertDoubleArrayToString();
+                            txt = ((Double[])Value).ConvertDoubleArrayToString();
                         }
                         else
                         {
-                            txt = this.Value?.ToString();
+                            txt = Value?.ToString();
                         }
                         break;
                 }
@@ -153,7 +153,7 @@ namespace Axe.Windows.Core.Bases
         /// <returns></returns>
         private string GetBoundingRectangleText()
         {
-            var arr = this.Value;
+            var arr = Value;
 
             string text;
             if ((double)arr[2] < 0 || (double)arr[3] < 0)
@@ -183,12 +183,12 @@ namespace Axe.Windows.Core.Bases
             {
                 if (disposing)
                 {
-                    this.Name = null;
-                    if (this.Value != null)
+                    Name = null;
+                    if (Value != null)
                     {
-                        if (NativeMethods.VariantClear(ref this.Value) == Win32Constants.S_OK)
+                        if (NativeMethods.VariantClear(ref Value) == Win32Constants.S_OK)
                         {
-                            this.Value = null;
+                            Value = null;
                         }
                     }
                 }

--- a/src/Core/Results/RuleResult.cs
+++ b/src/Core/Results/RuleResult.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.HelpLinks;
@@ -76,13 +76,13 @@ namespace Axe.Windows.Core.Results
         /// <param name="frameworkIssueLink"></param>
         internal RuleResult(RuleId id, string desc, string source, HelpUrl url, string frameworkIssueLink, ScanMetaInfo meta)
         {
-            this.Rule = id;
-            this.Description = desc;
-            this.Source = source;
-            this.Messages = new List<string>();
-            this.MetaInfo = meta;
-            this.HelpUrl = url;
-            this.FrameworkIssueLink = frameworkIssueLink;
+            Rule = id;
+            Description = desc;
+            Source = source;
+            Messages = new List<string>();
+            MetaInfo = meta;
+            HelpUrl = url;
+            FrameworkIssueLink = frameworkIssueLink;
         }
 
         /// <summary>
@@ -98,9 +98,9 @@ namespace Axe.Windows.Core.Results
         /// <param name="message"></param>
         public void SetStatus(ScanStatus status, string message)
         {
-            if (this.Status < status)
+            if (Status < status)
             {
-                this.Status = status;
+                Status = status;
             }
             AddMessage(message);
         }
@@ -113,7 +113,7 @@ namespace Axe.Windows.Core.Results
         {
             if (!string.IsNullOrEmpty(message))
             {
-                this.Messages.Add(message);
+                Messages.Add(message);
             }
         }
     }

--- a/src/Core/Results/ScanMetaInfo.cs
+++ b/src/Core/Results/ScanMetaInfo.cs
@@ -31,7 +31,7 @@ namespace Axe.Windows.Core.Results
         /// <param name="propertyid"></param>
         public ScanMetaInfo(IA11yElement e, int propertyid) : this(e)
         {
-            this.PropertyId = propertyid;
+            PropertyId = propertyid;
         }
 
         /// <summary>
@@ -42,9 +42,9 @@ namespace Axe.Windows.Core.Results
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            this.UIFramework = e.GetUIFramework();
-            this.ControlType = Types.ControlType.GetInstance().GetNameById(e.ControlTypeId).Split('(')[0];
-            this.PropertyId = 0;
+            UIFramework = e.GetUIFramework();
+            ControlType = Types.ControlType.GetInstance().GetNameById(e.ControlTypeId).Split('(')[0];
+            PropertyId = 0;
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Axe.Windows.Core.Results
         {
             if (PropertyId == 0)
             {
-                this.PropertyId = id;
+                PropertyId = id;
             }
             else
             {
@@ -84,9 +84,9 @@ namespace Axe.Windows.Core.Results
         {
             var mi = new ScanMetaInfo
             {
-                ControlType = this.ControlType,
-                PropertyId = this.PropertyId,
-                UIFramework = this.UIFramework
+                ControlType = ControlType,
+                PropertyId = PropertyId,
+                UIFramework = UIFramework
             };
 
             return mi;

--- a/src/Core/Results/ScanResult.cs
+++ b/src/Core/Results/ScanResult.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -24,7 +24,7 @@ namespace Axe.Windows.Core.Results
             {
                 ScanStatus status = ScanStatus.NoResult;
 
-                if (this.Items != null)
+                if (Items != null)
                 {
                     var tss = from i in Items
                               select i.Status;
@@ -79,11 +79,11 @@ namespace Axe.Windows.Core.Results
         /// <param name="status"></param>
         public ScanResult(string description, string source, string frameworkIssueLink, IA11yElement e, int propertyId = 0)
         {
-            this.Description = description;
-            this.Source = source;
-            this.FrameworkIssueLink = frameworkIssueLink;
-            this.MetaInfo = propertyId != 0 ? new ScanMetaInfo(e, propertyId) : new ScanMetaInfo(e);
-            this.Items = new List<RuleResult>();
+            Description = description;
+            Source = source;
+            FrameworkIssueLink = frameworkIssueLink;
+            MetaInfo = propertyId != 0 ? new ScanMetaInfo(e, propertyId) : new ScanMetaInfo(e);
+            Items = new List<RuleResult>();
         }
 
         /// <summary>
@@ -103,9 +103,9 @@ namespace Axe.Windows.Core.Results
         /// <returns></returns>
         public RuleResult GetRuleResultInstance(RuleId id, string desc)
         {
-            var rr = new RuleResult(id, desc, this.Source, this.HelpUrl, this.FrameworkIssueLink, this.MetaInfo.Clone());
+            var rr = new RuleResult(id, desc, Source, HelpUrl, FrameworkIssueLink, MetaInfo.Clone());
 
-            this.Items.Add(rr);
+            Items.Add(rr);
 
             return rr;
         }

--- a/src/Core/Results/ScanResults.cs
+++ b/src/Core/Results/ScanResults.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Misc;
 using System.Collections.Generic;
@@ -29,7 +29,7 @@ namespace Axe.Windows.Core.Results
             {
                 ScanStatus status = ScanStatus.NoResult;
 
-                if (this.Items != null)
+                if (Items != null)
                 {
                     var tss = from i in Items
                               select i.Status;
@@ -50,7 +50,7 @@ namespace Axe.Windows.Core.Results
         {
             lock (_itemsLock)
             {
-                this.Items.Add(report);
+                Items.Add(report);
             }
         }
 
@@ -60,7 +60,7 @@ namespace Axe.Windows.Core.Results
         /// <param name="desc"></param>
         public ScanResults()
         {
-            this.Items = new List<ScanResult>();
+            Items = new List<ScanResult>();
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Axe.Windows.Core.Results
         /// </summary>
         internal void Clear()
         {
-            this.Items.Clear();
+            Items.Clear();
         }
     }
 }

--- a/src/Core/Types/TypeBase.cs
+++ b/src/Core/Types/TypeBase.cs
@@ -23,7 +23,7 @@ namespace Axe.Windows.Core.Types
         {
             _namePattern = np;
 
-            this.Dic = new Dictionary<int, string>();
+            Dic = new Dictionary<int, string>();
 
             PopulateDictionary();
         }
@@ -33,7 +33,7 @@ namespace Axe.Windows.Core.Types
         /// </summary>
         private void PopulateDictionary()
         {
-            var fields = this.GetType().GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.FlattenHierarchy);
+            var fields = GetType().GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.FlattenHierarchy);
 
             foreach (var f in fields)
             {
@@ -50,7 +50,7 @@ namespace Axe.Windows.Core.Types
         private void AddFieldToDictionary(FieldInfo field)
         {
             int id = (int)field.GetValue(field);
-            this.Dic.Add(id, GetNameInProperFormat(field.Name, id));
+            Dic.Add(id, GetNameInProperFormat(field.Name, id));
         }
 
         /// <summary>
@@ -81,11 +81,11 @@ namespace Axe.Windows.Core.Types
         {
             var list = new List<KeyValuePair<int, string>>();
 
-            foreach (var k in this.Dic.Keys)
+            foreach (var k in Dic.Keys)
             {
                 if (IsPartOfKeyValuePairList(k))
                 {
-                    list.Add(new KeyValuePair<int, string>(k, this.Dic[k]));
+                    list.Add(new KeyValuePair<int, string>(k, Dic[k]));
                 }
             }
 
@@ -99,9 +99,9 @@ namespace Axe.Windows.Core.Types
         /// <returns></returns>
         public string GetNameById(int id)
         {
-            if (this.Dic.ContainsKey(id))
+            if (Dic.ContainsKey(id))
             {
-                return this.Dic[id];
+                return Dic[id];
             }
 
             return string.Format(CultureInfo.CurrentCulture, DisplayStrings.UnknownFormat, id);
@@ -124,7 +124,7 @@ namespace Axe.Windows.Core.Types
         /// <returns></returns>
         public bool Exists(int id)
         {
-            return this.Dic.ContainsKey(id);
+            return Dic.ContainsKey(id);
         }
 
         /// <summary>


### PR DESCRIPTION
#### Details

Apply analyzer-led removal of unneeded `this.` prefixes in the `Core` project. After locally making the changes in #796, the IDE highlighted the `this.` prefixes that were not needed.

##### Motivation

The code was originally written by folks who used `this.` _everywhere_ because that was the pattern in the team that they came from. Over time, that pattern has fallen by the wayside and now the code is very inconsistent. This PR is part of a series of PRs intended to increase the code consistency by removing unnecessary `this`. usage wherever possible.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
