### PR TITLE
chore: Analyzer-led removal of unneeded "this." prefixes in the Desktop project

### DIFF
--- a/src/Desktop/ColorContrastAnalyzer/BitmapCollection.cs
+++ b/src/Desktop/ColorContrastAnalyzer/BitmapCollection.cs
@@ -5,27 +5,27 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
 {
     public class BitmapCollection : ImageCollection
     {
-        private readonly System.Drawing.Bitmap bitmap;
+        private readonly System.Drawing.Bitmap _bitmap;
 
         public BitmapCollection(System.Drawing.Bitmap bitmap, IColorContrastConfig colorContrastConfig)
             : base(colorContrastConfig)
         {
-            this.bitmap = bitmap;
+            _bitmap = bitmap;
         }
 
         public override int NumColumns()
         {
-            return bitmap.Width;
+            return _bitmap.Width;
         }
 
         public override int NumRows()
         {
-            return bitmap.Height;
+            return _bitmap.Height;
         }
 
         public override Color GetColor(int row, int column)
         {
-            System.Drawing.Color color = bitmap.GetPixel(column, row);
+            System.Drawing.Color color = _bitmap.GetPixel(column, row);
 
             return new Color(color);
         }

--- a/src/Desktop/ColorContrastAnalyzer/Color.cs
+++ b/src/Desktop/ColorContrastAnalyzer/Color.cs
@@ -125,7 +125,7 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
         public override bool Equals(Object obj)
         {
             //Check for null and compare run-time types.
-            if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+            if ((obj == null) || !GetType().Equals(obj.GetType()))
             {
                 return false;
             }

--- a/src/Desktop/ColorContrastAnalyzer/ColorContrastResult.cs
+++ b/src/Desktop/ColorContrastAnalyzer/ColorContrastResult.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
 
         public ColorContrastResult()
         {
-            this.confidence = Confidence.None;
+            confidence = Confidence.None;
         }
 
         internal ColorContrastResult Add(ColorPair newColorPair)
@@ -54,7 +54,7 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
             }
             else
             {
-                this.confidence = Confidence.High;
+                confidence = Confidence.High;
             }
 
             alternatives.Add(newColorPair);
@@ -64,6 +64,6 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
 
         public ColorPair MostLikelyColorPair => mostContrastingPair;
 
-        public Confidence Confidence => this.confidence;
+        public Confidence Confidence => confidence;
     }
 }

--- a/src/Desktop/ColorContrastAnalyzer/ColorPair.cs
+++ b/src/Desktop/ColorContrastAnalyzer/ColorPair.cs
@@ -40,7 +40,7 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
         public override bool Equals(Object obj)
         {
             //Check for null and compare run-time types.
-            if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+            if ((obj == null) || !GetType().Equals(obj.GetType()))
             {
                 return false;
             }

--- a/src/Desktop/ColorContrastAnalyzer/Pixel.cs
+++ b/src/Desktop/ColorContrastAnalyzer/Pixel.cs
@@ -11,9 +11,9 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
 
         public Pixel(Color color, int row, int column)
         {
-            this.Row = row;
-            this.Column = column;
-            this.Color = color;
+            Row = row;
+            Column = column;
+            Color = color;
         }
     }
 }

--- a/src/Desktop/Settings/SnapshotMetaInfo.cs
+++ b/src/Desktop/Settings/SnapshotMetaInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Newtonsoft.Json;
 using System.Collections.Generic;
@@ -54,15 +54,15 @@ namespace Axe.Windows.Desktop.Settings
         /// <param name="screlementId">the ID of an element which was used to grab the screenshot</param>
         public SnapshotMetaInfo(A11yFileMode mode, string ruleVersion, int? selected, int screlementId)
         {
-            this.Mode = mode;
-            this.RuleVersion = ruleVersion;
-            this.Version = Core.Misc.PackageInfo.InformationalVersion;
+            Mode = mode;
+            RuleVersion = ruleVersion;
+            Version = Core.Misc.PackageInfo.InformationalVersion;
 
             if (selected.HasValue)
             {
-                this.SelectedItems = new List<int> { selected.Value };
+                SelectedItems = new List<int> { selected.Value };
             }
-            this.ScreenshotElementId = screlementId;
+            ScreenshotElementId = screlementId;
         }
 
         /// <summary>

--- a/src/Desktop/UIAutomation/DesktopElement.cs
+++ b/src/Desktop/UIAutomation/DesktopElement.cs
@@ -34,7 +34,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// <param name="setMembers">default is true. if it is true, sets properties and patterns at construction</param>
         public DesktopElement(IUIAutomationElement element, bool keepElement = true, bool setMembers = true)
         {
-            this.PlatformObject = element;
+            PlatformObject = element;
 
             if (setMembers)
             {
@@ -43,10 +43,10 @@ namespace Axe.Windows.Desktop.UIAutomation
 
             if (keepElement == false)
             {
-                this.PlatformObject = null;
+                PlatformObject = null;
             }
 
-            this.Children = new List<A11yElement>();
+            Children = new List<A11yElement>();
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Axe.Windows.Desktop.UIAutomation
 
         public override string ToString()
         {
-            return this.Glimpse;
+            return Glimpse;
         }
 
         #region Static methods for validation
@@ -140,11 +140,11 @@ namespace Axe.Windows.Desktop.UIAutomation
         {
             try
             {
-                if (this.PlatformObject != null)
+                if (PlatformObject != null)
                 {
                     // to make sure for release.
-                    Marshal.ReleaseComObject(this.PlatformObject);
-                    this.PlatformObject = null;
+                    Marshal.ReleaseComObject(PlatformObject);
+                    PlatformObject = null;
                 }
                 base.Dispose(disposing);
             }

--- a/src/Desktop/UIAutomation/EventHandlers/ActiveTextPositionChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/ActiveTextPositionChangedEventListener.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Desktop.Types;
 using System.Collections.Generic;
@@ -22,11 +22,11 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
         public override void Init()
         {
-            IUIAutomation6 uia6 = this.IUIAutomation6;
+            IUIAutomation6 uia6 = IUIAutomation6;
             if (uia6 != null)
             {
-                uia6.AddActiveTextPositionChangedEventHandler(this.Element, this.Scope, null, this);
-                this.IsHooked = true;
+                uia6.AddActiveTextPositionChangedEventHandler(Element, Scope, null, this);
+                IsHooked = true;
             }
         }
 
@@ -35,7 +35,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
             if (range == null) return;
 
 #pragma warning disable CA2000 // Call IDisposable.Dispose()
-            var m = EventMessage.GetInstance(this.EventId, sender);
+            var m = EventMessage.GetInstance(EventId, sender);
 #pragma warning restore CA2000
 
             if (m != null)
@@ -47,7 +47,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     new KeyValuePair<string, dynamic>("Text", range.GetText(maxTextLengthToInclude))
                 };
 
-                this.ListenEventMessage(m);
+                ListenEventMessage(m);
             }
         }
 
@@ -57,12 +57,12 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
             {
                 if (disposing)
                 {
-                    if (this.IsHooked)
+                    if (IsHooked)
                     {
-                        IUIAutomation6 uia6 = this.IUIAutomation6;
+                        IUIAutomation6 uia6 = IUIAutomation6;
                         if (uia6 != null)
                         {
-                            uia6.RemoveActiveTextPositionChangedEventHandler(this.Element, this);
+                            uia6.RemoveActiveTextPositionChangedEventHandler(Element, this);
                         }
                     }
                 }

--- a/src/Desktop/UIAutomation/EventHandlers/ChangesEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/ChangesEventListener.cs
@@ -41,23 +41,23 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
         public override void Init()
         {
-            IUIAutomation4 uia4 = this.IUIAutomation4;
+            IUIAutomation4 uia4 = IUIAutomation4;
             if (uia4 != null)
             {
-                uia4.AddChangesEventHandler(this.Element, this.Scope, ref ChangeTypes[0], ChangeTypes.Length, null, this);
-                this.IsHooked = true;
+                uia4.AddChangesEventHandler(Element, Scope, ref ChangeTypes[0], ChangeTypes.Length, null, this);
+                IsHooked = true;
             }
         }
 
         public void HandleChangesEvent(IUIAutomationElement sender, ref UiaChangeInfo uiaChanges, int changesCount)
         {
 #pragma warning disable CA2000 // Call IDisposable.Dispose()
-            var m = EventMessage.GetInstance(this.EventId, sender);
+            var m = EventMessage.GetInstance(EventId, sender);
 #pragma warning restore CA2000
 
             if (m != null)
             {
-                this.ListenEventMessage(m);
+                ListenEventMessage(m);
             }
         }
 
@@ -67,12 +67,12 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
             {
                 if (disposing)
                 {
-                    if (this.IsHooked)
+                    if (IsHooked)
                     {
-                        IUIAutomation4 uia4 = this.IUIAutomation4;
+                        IUIAutomation4 uia4 = IUIAutomation4;
                         if (uia4 != null)
                         {
-                            uia4.RemoveChangesEventHandler(this.Element, this);
+                            uia4.RemoveChangesEventHandler(Element, this);
                         }
                     }
                 }

--- a/src/Desktop/UIAutomation/EventHandlers/EventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventListener.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using UIAutomationClient;
 
@@ -19,11 +19,11 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
         public override void Init()
         {
-            IUIAutomation uia = this.IUIAutomation;
+            IUIAutomation uia = IUIAutomation;
             if (uia != null)
             {
-                uia.AddAutomationEventHandler(this.EventId, this.Element, this.Scope, null, this);
-                this.IsHooked = true;
+                uia.AddAutomationEventHandler(EventId, Element, Scope, null, this);
+                IsHooked = true;
             }
         }
 
@@ -35,7 +35,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
             if (m != null)
             {
-                this.ListenEventMessage(m);
+                ListenEventMessage(m);
             }
         }
 
@@ -45,13 +45,13 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
             {
                 if (disposing)
                 {
-                    if (this.IsHooked)
+                    if (IsHooked)
                     {
-                        IUIAutomation uia = this.IUIAutomation;
+                        IUIAutomation uia = IUIAutomation;
 
                         if (uia != null)
                         {
-                            uia.RemoveAutomationEventHandler(this.EventId, this.Element, this);
+                            uia.RemoveAutomationEventHandler(EventId, Element, this);
                         }
                     }
                 }

--- a/src/Desktop/UIAutomation/EventHandlers/EventListenerBase.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventListenerBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using UIAutomationClient;
@@ -33,7 +33,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         protected EventListenerBase(CUIAutomation8 uia8, IUIAutomationElement element, TreeScope scope, int eventId, HandleUIAutomationEventMessage peDelegate)
             : this(element, scope, eventId, peDelegate)
         {
-            this.UIAutomation8 = uia8;
+            UIAutomation8 = uia8;
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         protected EventListenerBase(CUIAutomation uia, IUIAutomationElement element, TreeScope scope, int eventId, HandleUIAutomationEventMessage peDelegate)
             : this(element, scope, eventId, peDelegate)
         {
-            this.UIAutomation = uia;
+            UIAutomation = uia;
         }
 
         /// <summary>
@@ -50,10 +50,10 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         /// </summary>
         protected EventListenerBase(IUIAutomationElement element, TreeScope scope, int eventId, HandleUIAutomationEventMessage peDelegate)
         {
-            this.EventId = eventId;
-            this.Element = element;
-            this.ListenEventMessage = peDelegate;
-            this.Scope = scope;
+            EventId = eventId;
+            Element = element;
+            ListenEventMessage = peDelegate;
+            Scope = scope;
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
             {
                 if (disposing)
                 {
-                    if (disposing && this.IsHooked)
+                    if (disposing && IsHooked)
                     {
                         UIAutomation = null;
                         UIAutomation8 = null;

--- a/src/Desktop/UIAutomation/EventHandlers/EventListenerFactory.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventListenerFactory.cs
@@ -77,13 +77,13 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         /// </summary>
         private void ProcessMessageQueue()
         {
-            this.UIAutomation = new CUIAutomation();
+            UIAutomation = new CUIAutomation();
 
             // CUIAutomation8 was introduced in Windows 8, so don't try it on Windows 7.
             // Reference: https://msdn.microsoft.com/en-us/library/windows/desktop/hh448746(v=vs.85).aspx?f=255&MSPPError=-2147217396
             if (!Win32Helper.IsWindows7())
             {
-                this.UIAutomation8 = new CUIAutomation8();
+                UIAutomation8 = new CUIAutomation8();
             }
 
             _autoEventInit.Set();
@@ -186,12 +186,12 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
             HandleUIAutomationEventMessage listener = null;
             try
             {
-                foreach (var e in this.EventListeners.Values)
+                foreach (var e in EventListeners.Values)
                 {
                     listener = e.ListenEventMessage;
                     e.Dispose();
                 }
-                this.EventListeners.Clear();
+                EventListeners.Clear();
                 if (listener != null)
                 {
 #pragma warning disable CA2000 // Call IDisposable.Dispose()
@@ -229,67 +229,67 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                 switch (msgData.EventId)
                 {
                     case EventType.UIA_AutomationFocusChangedEventId:
-                        if (this.EventListenerFocusChanged != null)
+                        if (EventListenerFocusChanged != null)
                         {
-                            listener = this.EventListenerFocusChanged.ListenEventMessage;
-                            this.EventListenerFocusChanged.Dispose();
-                            this.EventListenerFocusChanged = null;
+                            listener = EventListenerFocusChanged.ListenEventMessage;
+                            EventListenerFocusChanged.Dispose();
+                            EventListenerFocusChanged = null;
                         }
                         break;
                     case EventType.UIA_StructureChangedEventId:
-                        if (this.EventListenerStructureChanged != null)
+                        if (EventListenerStructureChanged != null)
                         {
-                            listener = this.EventListenerStructureChanged.ListenEventMessage;
-                            this.EventListenerStructureChanged.Dispose();
-                            this.EventListenerStructureChanged = null;
+                            listener = EventListenerStructureChanged.ListenEventMessage;
+                            EventListenerStructureChanged.Dispose();
+                            EventListenerStructureChanged = null;
                         }
                         break;
                     case EventType.UIA_AutomationPropertyChangedEventId:
-                        if (this.EventListenerPropertyChanged != null)
+                        if (EventListenerPropertyChanged != null)
                         {
-                            listener = this.EventListenerPropertyChanged.ListenEventMessage;
-                            this.EventListenerPropertyChanged.Dispose();
-                            this.EventListenerPropertyChanged = null;
+                            listener = EventListenerPropertyChanged.ListenEventMessage;
+                            EventListenerPropertyChanged.Dispose();
+                            EventListenerPropertyChanged = null;
                         }
                         break;
                     case EventType.UIA_TextEdit_TextChangedEventId:
-                        if (this.EventListenerTextEditTextChanged != null)
+                        if (EventListenerTextEditTextChanged != null)
                         {
-                            listener = this.EventListenerTextEditTextChanged.ListenEventMessage;
-                            this.EventListenerTextEditTextChanged.Dispose();
-                            this.EventListenerTextEditTextChanged = null;
+                            listener = EventListenerTextEditTextChanged.ListenEventMessage;
+                            EventListenerTextEditTextChanged.Dispose();
+                            EventListenerTextEditTextChanged = null;
                         }
                         break;
                     case EventType.UIA_ChangesEventId:
-                        if (this.EventListenerChanges != null)
+                        if (EventListenerChanges != null)
                         {
-                            listener = this.EventListenerChanges.ListenEventMessage;
-                            this.EventListenerChanges.Dispose();
-                            this.EventListenerChanges = null;
+                            listener = EventListenerChanges.ListenEventMessage;
+                            EventListenerChanges.Dispose();
+                            EventListenerChanges = null;
                         }
                         break;
                     case EventType.UIA_NotificationEventId:
-                        if (this.EventListenerNotification != null)
+                        if (EventListenerNotification != null)
                         {
-                            listener = this.EventListenerNotification.ListenEventMessage;
-                            this.EventListenerNotification.Dispose();
-                            this.EventListenerNotification = null;
+                            listener = EventListenerNotification.ListenEventMessage;
+                            EventListenerNotification.Dispose();
+                            EventListenerNotification = null;
                         }
                         break;
                     case EventType.UIA_ActiveTextPositionChangedEventId:
-                        if (this.EventListenerActiveTextPositionChanged != null)
+                        if (EventListenerActiveTextPositionChanged != null)
                         {
-                            listener = this.EventListenerActiveTextPositionChanged.ListenEventMessage;
-                            this.EventListenerActiveTextPositionChanged.Dispose();
-                            this.EventListenerActiveTextPositionChanged = null;
+                            listener = EventListenerActiveTextPositionChanged.ListenEventMessage;
+                            EventListenerActiveTextPositionChanged.Dispose();
+                            EventListenerActiveTextPositionChanged = null;
                         }
                         break;
                     default:
-                        if (this.EventListeners.ContainsKey(msgData.EventId))
+                        if (EventListeners.ContainsKey(msgData.EventId))
                         {
-                            var l = this.EventListeners[msgData.EventId];
+                            var l = EventListeners[msgData.EventId];
                             listener = l.ListenEventMessage;
-                            this.EventListeners.Remove(msgData.EventId);
+                            EventListeners.Remove(msgData.EventId);
                             l.Dispose();
                         }
                         break;
@@ -349,42 +349,42 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                 switch (msgData.EventId)
                 {
                     case EventType.UIA_AutomationFocusChangedEventId:
-                        if (this.EventListenerFocusChanged == null)
+                        if (EventListenerFocusChanged == null)
                         {
                             var uia = (IUIAutomation)UIAutomation8 ?? UIAutomation;
-                            this.EventListenerFocusChanged = new FocusChangedEventListener(uia, msgData.Listener);
+                            EventListenerFocusChanged = new FocusChangedEventListener(uia, msgData.Listener);
                         }
                         break;
                     case EventType.UIA_StructureChangedEventId:
-                        if (this.EventListenerStructureChanged == null)
+                        if (EventListenerStructureChanged == null)
                         {
-                            this.EventListenerStructureChanged = new StructureChangedEventListener(this.UIAutomation, this.RootElement.PlatformObject, this.Scope, msgData.Listener);
+                            EventListenerStructureChanged = new StructureChangedEventListener(UIAutomation, RootElement.PlatformObject, Scope, msgData.Listener);
                         }
                         break;
                     case EventType.UIA_AutomationPropertyChangedEventId:
-                        if (this.EventListenerPropertyChanged == null)
+                        if (EventListenerPropertyChanged == null)
                         {
-                            this.EventListenerPropertyChanged = new PropertyChangedEventListener(this.UIAutomation, this.RootElement.PlatformObject, this.Scope, msgData.Listener, msgData.Properties);
+                            EventListenerPropertyChanged = new PropertyChangedEventListener(UIAutomation, RootElement.PlatformObject, Scope, msgData.Listener, msgData.Properties);
                         }
                         break;
                     case EventType.UIA_TextEdit_TextChangedEventId:
-                        if (this.EventListenerTextEditTextChanged == null)
+                        if (EventListenerTextEditTextChanged == null)
                         {
-                            this.EventListenerTextEditTextChanged = new TextEditTextChangedEventListener(this.UIAutomation8, this.RootElement.PlatformObject, this.Scope, msgData.Listener);
+                            EventListenerTextEditTextChanged = new TextEditTextChangedEventListener(UIAutomation8, RootElement.PlatformObject, Scope, msgData.Listener);
                         }
                         break;
                     case EventType.UIA_ChangesEventId:
-                        if (this.EventListenerChanges == null)
+                        if (EventListenerChanges == null)
                         {
-                            this.EventListenerChanges = new ChangesEventListener(this.UIAutomation8, this.RootElement.PlatformObject, this.Scope, msgData.Listener);
+                            EventListenerChanges = new ChangesEventListener(UIAutomation8, RootElement.PlatformObject, Scope, msgData.Listener);
                         }
                         break;
                     case EventType.UIA_NotificationEventId:
                         if (win32Helper.IsWindowsRS3OrLater())
                         {
-                            if (this.EventListenerNotification == null)
+                            if (EventListenerNotification == null)
                             {
-                                this.EventListenerNotification = new NotificationEventListener(this.UIAutomation8, this.RootElement.PlatformObject, this.Scope, msgData.Listener);
+                                EventListenerNotification = new NotificationEventListener(UIAutomation8, RootElement.PlatformObject, Scope, msgData.Listener);
                             }
                         }
                         else
@@ -406,9 +406,9 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     case EventType.UIA_ActiveTextPositionChangedEventId:
                         if (win32Helper.IsWindowsRS5OrLater())
                         {
-                            if (this.EventListenerNotification == null)
+                            if (EventListenerNotification == null)
                             {
-                                this.EventListenerActiveTextPositionChanged = new ActiveTextPositionChangedEventListener(this.UIAutomation8, this.RootElement.PlatformObject, this.Scope, msgData.Listener);
+                                EventListenerActiveTextPositionChanged = new ActiveTextPositionChangedEventListener(UIAutomation8, RootElement.PlatformObject, Scope, msgData.Listener);
                             }
                         }
                         else
@@ -428,9 +428,9 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                         }
                         break;
                     default:
-                        if (this.EventListeners.ContainsKey(msgData.EventId) == false)
+                        if (EventListeners.ContainsKey(msgData.EventId) == false)
                         {
-                            this.EventListeners.Add(msgData.EventId, new EventListener(this.UIAutomation, this.RootElement.PlatformObject, this.Scope, msgData.EventId, msgData.Listener));
+                            EventListeners.Add(msgData.EventId, new EventListener(UIAutomation, RootElement.PlatformObject, Scope, msgData.EventId, msgData.Listener));
                         }
                         break;
                 }
@@ -448,7 +448,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                 msgData.Listener(m);
                 if (msgData.EventId == EventType.UIA_AutomationFocusChangedEventId)
                 {
-                    this.EventListenerFocusChanged.ReadyToListen = true;
+                    EventListenerFocusChanged.ReadyToListen = true;
                 }
             }
 #pragma warning disable CA1031 // Do not catch general exception types
@@ -482,11 +482,11 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 #pragma warning restore CA2000
 
             _autoEventFinish.WaitOne(TimeSpan.FromSeconds(ThreadExitGracePeriod));
-            if (this._threadBackground.IsAlive)
+            if (_threadBackground.IsAlive)
             {
                 try
                 {
-                    this._threadBackground.Abort();
+                    _threadBackground.Abort();
                 }
                 catch (PlatformNotSupportedException)
                 { }  // nothing we can do. Just continue
@@ -520,9 +520,9 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         /// <param name="scope"></param>
         public EventListenerFactory(A11yElement rootElement, ListenScope scope)
         {
-            this.RootElement = rootElement;
-            this.Scope = GetUIAScope(scope);
-            this.EventListeners = new Dictionary<int, EventListener>();
+            RootElement = rootElement;
+            Scope = GetUIAScope(scope);
+            EventListeners = new Dictionary<int, EventListener>();
             //Start worker thread
             StartWorkerThread();
         }
@@ -677,7 +677,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
         public EventListenerFactoryMessage()
         {
-            this._autoEventProcessed = new AutoResetEvent(false);
+            _autoEventProcessed = new AutoResetEvent(false);
         }
 
         /// <summary>
@@ -687,7 +687,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         /// <param name="milliseconds"></param>
         public void WaitForProcessed(int milliseconds)
         {
-            this._autoEventProcessed.WaitOne(milliseconds);
+            _autoEventProcessed.WaitOne(milliseconds);
         }
 
         /// <summary>
@@ -695,7 +695,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         /// </summary>
         internal void Processed()
         {
-            this._autoEventProcessed.Set();
+            _autoEventProcessed.Set();
         }
 
         #region IDisposable Support
@@ -707,8 +707,8 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
             {
                 if (disposing)
                 {
-                    this._autoEventProcessed.Dispose();
-                    this._autoEventProcessed = null;
+                    _autoEventProcessed.Dispose();
+                    _autoEventProcessed = null;
                 }
 
                 disposedValue = true;

--- a/src/Desktop/UIAutomation/EventHandlers/EventMessage.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventMessage.cs
@@ -37,8 +37,8 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         private EventMessage(int id, IUIAutomationElement sender)
         {
             TimeStamp = DateTime.Now.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture);
-            this.EventId = id;
-            this.Element = sender != null ? new DesktopElement(sender) : null;
+            EventId = id;
+            Element = sender != null ? new DesktopElement(sender) : null;
         }
 
         /// <summary>
@@ -78,8 +78,8 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
             {
                 if (disposing)
                 {
-                    this.Element?.Dispose();
-                    this.Element = null;
+                    Element?.Dispose();
+                    Element = null;
                 }
 
                 disposedValue = true;

--- a/src/Desktop/UIAutomation/EventHandlers/FocusChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/FocusChangedEventListener.cs
@@ -25,9 +25,9 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
         public FocusChangedEventListener(IUIAutomation uia, HandleUIAutomationEventMessage peDelegate)
         {
-            this.UIAutomation = uia ?? throw new ArgumentNullException(nameof(uia));
-            this.ListenEventMessage = peDelegate;
-            this.UIAutomation.AddFocusChangedEventHandler(null, this);
+            UIAutomation = uia ?? throw new ArgumentNullException(nameof(uia));
+            ListenEventMessage = peDelegate;
+            UIAutomation.AddFocusChangedEventHandler(null, this);
             IsHooked = true;
         }
 
@@ -53,12 +53,12 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         {
             if (!disposedValue)
             {
-                if (IsHooked && this.UIAutomation != null)
+                if (IsHooked && UIAutomation != null)
                 {
                     try
                     {
-                        this.UIAutomation.RemoveFocusChangedEventHandler(this);
-                        this.UIAutomation = null;
+                        UIAutomation.RemoveFocusChangedEventHandler(this);
+                        UIAutomation = null;
                     }
                     catch (ThreadAbortException)
                     {

--- a/src/Desktop/UIAutomation/EventHandlers/NotificationEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/NotificationEventListener.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Desktop.Types;
 using System.Collections.Generic;
@@ -22,11 +22,11 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
         public override void Init()
         {
-            IUIAutomation5 uia5 = this.IUIAutomation5;
+            IUIAutomation5 uia5 = IUIAutomation5;
             if (uia5 != null)
             {
-                uia5.AddNotificationEventHandler(this.Element, this.Scope, null, this);
-                this.IsHooked = true;
+                uia5.AddNotificationEventHandler(Element, Scope, null, this);
+                IsHooked = true;
             }
         }
 
@@ -35,7 +35,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 #pragma warning restore CA1725 // Parameter names should match base declaration
         {
 #pragma warning disable CA2000 // Call IDisposable.Dispose()
-            var m = EventMessage.GetInstance(this.EventId, sender);
+            var m = EventMessage.GetInstance(EventId, sender);
 #pragma warning restore CA2000
 
             if (m != null)
@@ -47,7 +47,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     new KeyValuePair<string, dynamic>("Display", displayString),
                     new KeyValuePair<string, dynamic>("ActivityId", activityId),
                 };
-                this.ListenEventMessage(m);
+                ListenEventMessage(m);
             }
         }
 
@@ -57,12 +57,12 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
             {
                 if (disposing)
                 {
-                    if (this.IsHooked)
+                    if (IsHooked)
                     {
-                        IUIAutomation5 uia5 = this.IUIAutomation5;
+                        IUIAutomation5 uia5 = IUIAutomation5;
                         if (uia5 != null)
                         {
-                            uia5.RemoveNotificationEventHandler(this.Element, this);
+                            uia5.RemoveNotificationEventHandler(Element, this);
                         }
                     }
                 }

--- a/src/Desktop/UIAutomation/EventHandlers/PropertyChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/PropertyChangedEventListener.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.Types;
@@ -16,24 +16,24 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         /// </summary>
         public PropertyChangedEventListener(CUIAutomation uia, IUIAutomationElement element, TreeScope scope, HandleUIAutomationEventMessage peDelegate, int[] properties) : base(uia, element, scope, EventType.UIA_AutomationPropertyChangedEventId, peDelegate)
         {
-            this.propertyArray = properties;
+            propertyArray = properties;
             Init();
         }
 
         public override void Init()
         {
-            IUIAutomation uia = this.IUIAutomation;
+            IUIAutomation uia = IUIAutomation;
             if (uia != null)
             {
-                uia.AddPropertyChangedEventHandler(this.Element, this.Scope, null, this, this.propertyArray);
-                this.IsHooked = true;
+                uia.AddPropertyChangedEventHandler(Element, Scope, null, this, propertyArray);
+                IsHooked = true;
             }
         }
 
         public void HandlePropertyChangedEvent(IUIAutomationElement sender, int propertyId, object newValue)
         {
 #pragma warning disable CA2000 // Call IDisposable.Dispose()
-            var m = EventMessage.GetInstance(this.EventId, sender);
+            var m = EventMessage.GetInstance(EventId, sender);
 #pragma warning restore CA2000
 
             if (m != null)
@@ -48,7 +48,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     m.Properties.Add(new KeyValuePair<string, dynamic>(newValue.GetType().Name, newValue));
                 }
 
-                this.ListenEventMessage(m);
+                ListenEventMessage(m);
             }
         }
 
@@ -58,12 +58,12 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
             {
                 if (disposing)
                 {
-                    if (this.IsHooked)
+                    if (IsHooked)
                     {
-                        IUIAutomation uia = this.IUIAutomation;
+                        IUIAutomation uia = IUIAutomation;
                         if (uia != null)
                         {
-                            uia.RemovePropertyChangedEventHandler(this.Element, this);
+                            uia.RemovePropertyChangedEventHandler(Element, this);
                         }
                     }
                 }

--- a/src/Desktop/UIAutomation/EventHandlers/StructureChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/StructureChangedEventListener.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Desktop.Types;
@@ -20,11 +20,11 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
         public override void Init()
         {
-            IUIAutomation uia = this.IUIAutomation;
+            IUIAutomation uia = IUIAutomation;
             if (uia != null)
             {
-                uia.AddStructureChangedEventHandler(this.Element, this.Scope, null, this);
-                this.IsHooked = true;
+                uia.AddStructureChangedEventHandler(Element, Scope, null, this);
+                IsHooked = true;
             }
         }
 
@@ -41,7 +41,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     new KeyValuePair<string, dynamic>("StructureChangeType", changeType),
                     new KeyValuePair<string, dynamic>("Runtime Id", runtimeId.ConvertInt32ArrayToString()),
                 };
-                this.ListenEventMessage(m);
+                ListenEventMessage(m);
             }
         }
 
@@ -51,12 +51,12 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
             {
                 if (disposing)
                 {
-                    if (this.IsHooked)
+                    if (IsHooked)
                     {
-                        IUIAutomation uia = this.IUIAutomation;
+                        IUIAutomation uia = IUIAutomation;
                         if (uia != null)
                         {
-                            uia.RemoveStructureChangedEventHandler(this.Element, this);
+                            uia.RemoveStructureChangedEventHandler(Element, this);
                         }
                     }
                 }

--- a/src/Desktop/UIAutomation/EventHandlers/TextEditTextChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/TextEditTextChangedEventListener.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Desktop.Types;
 using System.Collections.Generic;
@@ -24,14 +24,14 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
         public override void Init()
         {
-            IUIAutomation4 uia4 = this.IUIAutomation4;
+            IUIAutomation4 uia4 = IUIAutomation4;
             if (uia4 != null)
             {
-                uia4.AddTextEditTextChangedEventHandler(this.Element, this.Scope, TextEditChangeType.TextEditChangeType_AutoComplete, null, this);
-                uia4.AddTextEditTextChangedEventHandler(this.Element, this.Scope, TextEditChangeType.TextEditChangeType_AutoCorrect, null, this);
-                uia4.AddTextEditTextChangedEventHandler(this.Element, this.Scope, TextEditChangeType.TextEditChangeType_Composition, null, this);
-                uia4.AddTextEditTextChangedEventHandler(this.Element, this.Scope, TextEditChangeType.TextEditChangeType_CompositionFinalized, null, this);
-                this.IsHooked = true;
+                uia4.AddTextEditTextChangedEventHandler(Element, Scope, TextEditChangeType.TextEditChangeType_AutoComplete, null, this);
+                uia4.AddTextEditTextChangedEventHandler(Element, Scope, TextEditChangeType.TextEditChangeType_AutoCorrect, null, this);
+                uia4.AddTextEditTextChangedEventHandler(Element, Scope, TextEditChangeType.TextEditChangeType_Composition, null, this);
+                uia4.AddTextEditTextChangedEventHandler(Element, Scope, TextEditChangeType.TextEditChangeType_CompositionFinalized, null, this);
+                IsHooked = true;
             }
         }
 
@@ -40,7 +40,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 #pragma warning restore CA1725 // Parameter names should match base declaration
         {
 #pragma warning disable CA2000 // Call IDisposable.Dispose()
-            var m = EventMessage.GetInstance(this.EventId, sender);
+            var m = EventMessage.GetInstance(EventId, sender);
 
             if (m != null)
             {
@@ -57,7 +57,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     }
                 }
 
-                this.ListenEventMessage(m);
+                ListenEventMessage(m);
             }
 #pragma warning restore CA2000
         }
@@ -68,12 +68,12 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
             {
                 if (disposing)
                 {
-                    if (this.IsHooked)
+                    if (IsHooked)
                     {
-                        IUIAutomation4 uia4 = this.IUIAutomation4;
+                        IUIAutomation4 uia4 = IUIAutomation4;
                         if (uia4 != null)
                         {
-                            uia4.RemoveTextEditTextChangedEventHandler(this.Element, this);
+                            uia4.RemoveTextEditTextChangedEventHandler(Element, this);
                         }
                     }
                 }

--- a/src/Desktop/UIAutomation/Patterns/AnnotationPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/AnnotationPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -27,10 +27,10 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "AnnotationTypeId", Value = this.Pattern.CurrentAnnotationTypeId });
-            this.Properties.Add(new A11yPatternProperty() { Name = "AnnotationTypeName", Value = this.Pattern.CurrentAnnotationTypeName });
-            this.Properties.Add(new A11yPatternProperty() { Name = "Author", Value = this.Pattern.CurrentAuthor });
-            this.Properties.Add(new A11yPatternProperty() { Name = "DateTime", Value = this.Pattern.CurrentDateTime });
+            Properties.Add(new A11yPatternProperty() { Name = "AnnotationTypeId", Value = Pattern.CurrentAnnotationTypeId });
+            Properties.Add(new A11yPatternProperty() { Name = "AnnotationTypeName", Value = Pattern.CurrentAnnotationTypeName });
+            Properties.Add(new A11yPatternProperty() { Name = "Author", Value = Pattern.CurrentAuthor });
+            Properties.Add(new A11yPatternProperty() { Name = "DateTime", Value = Pattern.CurrentDateTime });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
@@ -38,7 +38,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public DesktopElement GetTarget()
         {
-            return new DesktopElement(this.Pattern.CurrentTarget);
+            return new DesktopElement(Pattern.CurrentTarget);
         }
 #pragma warning restore CA1024 // Use properties where appropriate
 
@@ -47,7 +47,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/CustomNavigationPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/CustomNavigationPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -19,7 +19,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         public CustomNavigationPattern(A11yElement e, IUIAutomationCustomNavigationPattern p) : base(e, PatternType.UIA_CustomNavigationPatternId)
         {
-            this.Pattern = p;
+            Pattern = p;
         }
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod(IsUIAction = true)]
         public void Navigate(NavigateDirection direction)
         {
-            this.Pattern.Navigate(direction);
+            Pattern.Navigate(direction);
         }
 
         protected override void Dispose(bool disposing)
@@ -37,7 +37,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/DockPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/DockPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -18,21 +18,21 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
 
         public DockPattern(A11yElement e, IUIAutomationDockPattern p) : base(e, PatternType.UIA_DockPatternId)
         {
-            this.Pattern = p;
+            Pattern = p;
             PopulateProperties();
         }
 
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "DockPosition", Value = this.Pattern.CurrentDockPosition });
+            Properties.Add(new A11yPatternProperty() { Name = "DockPosition", Value = Pattern.CurrentDockPosition });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod(IsUIAction = true)]
         public void SetDockPosition(DockPosition dockPos)
         {
-            this.Pattern.SetDockPosition(dockPos);
+            Pattern.SetDockPosition(dockPos);
         }
 
         protected override void Dispose(bool disposing)
@@ -40,7 +40,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/DragPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/DragPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -31,7 +31,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             Pattern = p;
 
             // though member method is not action specific, this pattern means for UI action.
-            this.IsUIActionable = true;
+            IsUIActionable = true;
 
             PopulateProperties();
         }
@@ -39,9 +39,9 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "DropEffect", Value = this.Pattern.CurrentDropEffect });
-            this.Properties.Add(new A11yPatternProperty() { Name = "DropEffects", Value = GetDropEffectsString(this.Pattern.CurrentDropEffects) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "IsGrabbed", Value = Convert.ToBoolean(this.Pattern.CurrentIsGrabbed) });
+            Properties.Add(new A11yPatternProperty() { Name = "DropEffect", Value = Pattern.CurrentDropEffect });
+            Properties.Add(new A11yPatternProperty() { Name = "DropEffects", Value = GetDropEffectsString(Pattern.CurrentDropEffects) });
+            Properties.Add(new A11yPatternProperty() { Name = "IsGrabbed", Value = Convert.ToBoolean(Pattern.CurrentIsGrabbed) });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
@@ -66,7 +66,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public IList<DesktopElement> GetGrabbedItems()
         {
-            return this.Pattern.GetCurrentGrabbedItems()?.ToListOfDesktopElements();
+            return Pattern.GetCurrentGrabbedItems()?.ToListOfDesktopElements();
         }
 
         protected override void Dispose(bool disposing)
@@ -74,7 +74,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/DropTargetPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/DropTargetPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -32,13 +32,13 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "DropTargetEffect", Value = this.Pattern.CurrentDropTargetEffect });
-            var array = this.Pattern.CurrentDropTargetEffects;
+            Properties.Add(new A11yPatternProperty() { Name = "DropTargetEffect", Value = Pattern.CurrentDropTargetEffect });
+            var array = Pattern.CurrentDropTargetEffects;
             if (array.Length != 0)
             {
                 for (int i = 0; i < array.Length; i++)
                 {
-                    this.Properties.Add(new A11yPatternProperty() { Name = Invariant($"DropTargetEffects[{i}]"), Value = array.GetValue(i)?.ToString() });
+                    Properties.Add(new A11yPatternProperty() { Name = Invariant($"DropTargetEffects[{i}]"), Value = array.GetValue(i)?.ToString() });
                 }
             }
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
@@ -49,7 +49,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/ExpandCollapsePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ExpandCollapsePattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -34,20 +34,20 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "ExpandCollapseState", Value = this.Pattern.CurrentExpandCollapseState });
+            Properties.Add(new A11yPatternProperty() { Name = "ExpandCollapseState", Value = Pattern.CurrentExpandCollapseState });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod(IsUIAction = true)]
         public void Expand()
         {
-            this.Pattern.Expand();
+            Pattern.Expand();
         }
 
         [PatternMethod(IsUIAction = true)]
         public void Collapse()
         {
-            this.Pattern.Collapse();
+            Pattern.Collapse();
         }
 
         protected override void Dispose(bool disposing)
@@ -55,7 +55,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/GridItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/GridItemPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -27,10 +27,10 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "Column", Value = this.Pattern.CurrentColumn });
-            this.Properties.Add(new A11yPatternProperty() { Name = "ColumnSpan", Value = this.Pattern.CurrentColumnSpan });
-            this.Properties.Add(new A11yPatternProperty() { Name = "Row", Value = this.Pattern.CurrentRow });
-            this.Properties.Add(new A11yPatternProperty() { Name = "RowSpan", Value = this.Pattern.CurrentRowSpan });
+            Properties.Add(new A11yPatternProperty() { Name = "Column", Value = Pattern.CurrentColumn });
+            Properties.Add(new A11yPatternProperty() { Name = "ColumnSpan", Value = Pattern.CurrentColumnSpan });
+            Properties.Add(new A11yPatternProperty() { Name = "Row", Value = Pattern.CurrentRow });
+            Properties.Add(new A11yPatternProperty() { Name = "RowSpan", Value = Pattern.CurrentRowSpan });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
@@ -38,7 +38,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public DesktopElement GetContainingGrid()
         {
-            var e = new DesktopElement(this.Pattern.CurrentContainingGrid);
+            var e = new DesktopElement(Pattern.CurrentContainingGrid);
 
             if (e.Properties != null && e.Properties.Count != 0)
             {
@@ -54,7 +54,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/GridPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/GridPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -25,15 +25,15 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "ColumnCount", Value = this.Pattern.CurrentColumnCount });
-            this.Properties.Add(new A11yPatternProperty() { Name = "RowCount", Value = this.Pattern.CurrentRowCount });
+            Properties.Add(new A11yPatternProperty() { Name = "ColumnCount", Value = Pattern.CurrentColumnCount });
+            Properties.Add(new A11yPatternProperty() { Name = "RowCount", Value = Pattern.CurrentRowCount });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod]
         public DesktopElement GetItem(int row, int column)
         {
-            var uiae = this.Pattern.GetItem(row, column);
+            var uiae = Pattern.GetItem(row, column);
 
             return uiae != null ? new DesktopElement(uiae) : null;
         }
@@ -43,7 +43,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/InvokePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/InvokePattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -18,13 +18,13 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         public InvokePattern(A11yElement e, IUIAutomationInvokePattern p) : base(e, PatternType.UIA_InvokePatternId)
         {
             Pattern = p;
-            this.IsUIActionable = true;
+            IsUIActionable = true;
         }
 
         [PatternMethod(IsUIAction = true)]
         public void Invoke()
         {
-            this.Pattern.Invoke();
+            Pattern.Invoke();
         }
 
         protected override void Dispose(bool disposing)
@@ -32,7 +32,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/ItemContainerPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ItemContainerPattern.cs
@@ -26,7 +26,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         public DesktopElement FindItemByProperty(int propertyId, object value)
         {
             // null specifies finding the first matching item
-            return new DesktopElement(this.Pattern.FindItemByProperty(null, propertyId, value));
+            return new DesktopElement(Pattern.FindItemByProperty(null, propertyId, value));
         }
 
         protected override void Dispose(bool disposing)
@@ -34,7 +34,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/LegacyIAccessiblePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/LegacyIAccessiblePattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -30,15 +30,15 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             try
             {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-                this.Properties.Add(new A11yPatternProperty() { Name = "ChildId", Value = this.Pattern.CurrentChildId });
-                this.Properties.Add(new A11yPatternProperty() { Name = "DefaultAction", Value = this.Pattern.CurrentDefaultAction });
-                this.Properties.Add(new A11yPatternProperty() { Name = "Description", Value = this.Pattern.CurrentDescription });
-                this.Properties.Add(new A11yPatternProperty() { Name = "Help", Value = this.Pattern.CurrentHelp });
-                this.Properties.Add(new A11yPatternProperty() { Name = "KeyboardShorcut", Value = this.Pattern.CurrentKeyboardShortcut });
-                this.Properties.Add(new A11yPatternProperty() { Name = "Name", Value = this.Pattern.CurrentName });
-                this.Properties.Add(new A11yPatternProperty() { Name = "Role", Value = this.Pattern.CurrentRole });
-                this.Properties.Add(new A11yPatternProperty() { Name = "State", Value = this.Pattern.CurrentState });
-                this.Properties.Add(new A11yPatternProperty() { Name = "Value", Value = this.Pattern.CurrentValue });
+                Properties.Add(new A11yPatternProperty() { Name = "ChildId", Value = Pattern.CurrentChildId });
+                Properties.Add(new A11yPatternProperty() { Name = "DefaultAction", Value = Pattern.CurrentDefaultAction });
+                Properties.Add(new A11yPatternProperty() { Name = "Description", Value = Pattern.CurrentDescription });
+                Properties.Add(new A11yPatternProperty() { Name = "Help", Value = Pattern.CurrentHelp });
+                Properties.Add(new A11yPatternProperty() { Name = "KeyboardShorcut", Value = Pattern.CurrentKeyboardShortcut });
+                Properties.Add(new A11yPatternProperty() { Name = "Name", Value = Pattern.CurrentName });
+                Properties.Add(new A11yPatternProperty() { Name = "Role", Value = Pattern.CurrentRole });
+                Properties.Add(new A11yPatternProperty() { Name = "State", Value = Pattern.CurrentState });
+                Properties.Add(new A11yPatternProperty() { Name = "Value", Value = Pattern.CurrentValue });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
             }
 #pragma warning disable CA1031 // Do not catch general exception types
@@ -52,31 +52,31 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public IList<DesktopElement> GetSelection()
         {
-            return this.Pattern.GetCurrentSelection().ToListOfDesktopElements();
+            return Pattern.GetCurrentSelection().ToListOfDesktopElements();
         }
 
         [PatternMethod]
         public void DoDefaultAction()
         {
-            this.Pattern.DoDefaultAction();
+            Pattern.DoDefaultAction();
         }
 
         [PatternMethod]
         public IAccessible GetIAccessible()
         {
-            return this.Pattern.GetIAccessible();
+            return Pattern.GetIAccessible();
         }
 
         [PatternMethod]
         public void Select(int flagSelect)
         {
-            this.Pattern.Select(flagSelect);
+            Pattern.Select(flagSelect);
         }
 
         [PatternMethod]
         public void SetValue(string value)
         {
-            this.Pattern.SetValue(value);
+            Pattern.SetValue(value);
         }
 
         protected override void Dispose(bool disposing)
@@ -84,7 +84,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/MultipleViewPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/MultipleViewPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -27,8 +27,8 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "CurrentView", Value = this.Pattern.CurrentCurrentView });
-            var array = this.Pattern.GetCurrentSupportedViews();
+            Properties.Add(new A11yPatternProperty() { Name = "CurrentView", Value = Pattern.CurrentCurrentView });
+            var array = Pattern.GetCurrentSupportedViews();
             if (array.Length > 0)
             {
                 for (int i = 0; i < array.Length; i++)
@@ -43,7 +43,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public void SetCurrentView(int view)
         {
-            this.Pattern.SetCurrentView(view);
+            Pattern.SetCurrentView(view);
         }
 
         protected override void Dispose(bool disposing)
@@ -51,7 +51,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/ObjectModelPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ObjectModelPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -24,7 +24,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public dynamic GetUnderlyingObjectModel()
         {
-            return this.Pattern.GetUnderlyingObjectModel();
+            return Pattern.GetUnderlyingObjectModel();
         }
 
         protected override void Dispose(bool disposing)
@@ -32,7 +32,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/RangeValuePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/RangeValuePattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -26,26 +26,26 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "IsReadOnly", Value = Convert.ToBoolean(this.Pattern.CurrentIsReadOnly) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "LargeChange", Value = this.Pattern.CurrentLargeChange });
-            this.Properties.Add(new A11yPatternProperty() { Name = "Maximum", Value = this.Pattern.CurrentMaximum });
-            this.Properties.Add(new A11yPatternProperty() { Name = "Minimum", Value = this.Pattern.CurrentMinimum });
-            this.Properties.Add(new A11yPatternProperty() { Name = "SmallChange", Value = this.Pattern.CurrentSmallChange });
-            this.Properties.Add(new A11yPatternProperty() { Name = "Value", Value = this.Pattern.CurrentValue });
+            Properties.Add(new A11yPatternProperty() { Name = "IsReadOnly", Value = Convert.ToBoolean(Pattern.CurrentIsReadOnly) });
+            Properties.Add(new A11yPatternProperty() { Name = "LargeChange", Value = Pattern.CurrentLargeChange });
+            Properties.Add(new A11yPatternProperty() { Name = "Maximum", Value = Pattern.CurrentMaximum });
+            Properties.Add(new A11yPatternProperty() { Name = "Minimum", Value = Pattern.CurrentMinimum });
+            Properties.Add(new A11yPatternProperty() { Name = "SmallChange", Value = Pattern.CurrentSmallChange });
+            Properties.Add(new A11yPatternProperty() { Name = "Value", Value = Pattern.CurrentValue });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod(IsUIAction = true)]
         public void SetValue(double val)
         {
-            this.Pattern.SetValue(val);
+            Pattern.SetValue(val);
         }
         protected override void Dispose(bool disposing)
         {
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/ScrollItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ScrollItemPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -26,7 +26,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public void ScrollIntoView()
         {
-            this.Pattern.ScrollIntoView();
+            Pattern.ScrollIntoView();
         }
 
         protected override void Dispose(bool disposing)
@@ -34,7 +34,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/ScrollPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ScrollPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -26,12 +26,12 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "HorizontallyScrollable", Value = Convert.ToBoolean(this.Pattern.CurrentHorizontallyScrollable) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "HorizontalScrollPercent", Value = this.Pattern.CurrentHorizontalScrollPercent });
-            this.Properties.Add(new A11yPatternProperty() { Name = "HorizontalViewSize", Value = this.Pattern.CurrentHorizontalViewSize });
-            this.Properties.Add(new A11yPatternProperty() { Name = "VerticallyScrollable", Value = Convert.ToBoolean(this.Pattern.CurrentVerticallyScrollable) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "VerticalScrollPercent", Value = this.Pattern.CurrentVerticalScrollPercent });
-            this.Properties.Add(new A11yPatternProperty() { Name = "VerticalViewSize", Value = this.Pattern.CurrentVerticalViewSize });
+            Properties.Add(new A11yPatternProperty() { Name = "HorizontallyScrollable", Value = Convert.ToBoolean(Pattern.CurrentHorizontallyScrollable) });
+            Properties.Add(new A11yPatternProperty() { Name = "HorizontalScrollPercent", Value = Pattern.CurrentHorizontalScrollPercent });
+            Properties.Add(new A11yPatternProperty() { Name = "HorizontalViewSize", Value = Pattern.CurrentHorizontalViewSize });
+            Properties.Add(new A11yPatternProperty() { Name = "VerticallyScrollable", Value = Convert.ToBoolean(Pattern.CurrentVerticallyScrollable) });
+            Properties.Add(new A11yPatternProperty() { Name = "VerticalScrollPercent", Value = Pattern.CurrentVerticalScrollPercent });
+            Properties.Add(new A11yPatternProperty() { Name = "VerticalViewSize", Value = Pattern.CurrentVerticalViewSize });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
@@ -39,7 +39,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public void Scroll(ScrollAmount ha, ScrollAmount va)
         {
-            this.Pattern.Scroll(ha, va);
+            Pattern.Scroll(ha, va);
         }
 
         protected override void Dispose(bool disposing)
@@ -47,7 +47,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/SelectionItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SelectionItemPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -30,32 +30,32 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "IsSelected", Value = Convert.ToBoolean(this.Pattern.CurrentIsSelected) });
+            Properties.Add(new A11yPatternProperty() { Name = "IsSelected", Value = Convert.ToBoolean(Pattern.CurrentIsSelected) });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod(IsUIAction = true)]
         public void AddToSelect()
         {
-            this.Pattern.AddToSelection();
+            Pattern.AddToSelection();
         }
 
         [PatternMethod(IsUIAction = true)]
         public void RemoveFromSelection()
         {
-            this.Pattern.RemoveFromSelection();
+            Pattern.RemoveFromSelection();
         }
 
         [PatternMethod(IsUIAction = true)]
         public void Select()
         {
-            this.Pattern.Select();
+            Pattern.Select();
         }
 
         [PatternMethod]
         public DesktopElement SelectionContainer()
         {
-            return new DesktopElement(this.Pattern.CurrentSelectionContainer);
+            return new DesktopElement(Pattern.CurrentSelectionContainer);
         }
 
         protected override void Dispose(bool disposing)
@@ -63,7 +63,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/SelectionPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SelectionPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -30,15 +30,15 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "CanSelectMultiple", Value = Convert.ToBoolean(this.Pattern.CurrentCanSelectMultiple) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "IsSelectionRequired", Value = Convert.ToBoolean(this.Pattern.CurrentIsSelectionRequired) });
+            Properties.Add(new A11yPatternProperty() { Name = "CanSelectMultiple", Value = Convert.ToBoolean(Pattern.CurrentCanSelectMultiple) });
+            Properties.Add(new A11yPatternProperty() { Name = "IsSelectionRequired", Value = Convert.ToBoolean(Pattern.CurrentIsSelectionRequired) });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod]
         public IList<DesktopElement> GetSelection()
         {
-            return this.Pattern.GetCurrentSelection().ToListOfDesktopElements();
+            return Pattern.GetCurrentSelection().ToListOfDesktopElements();
         }
 
         protected override void Dispose(bool disposing)
@@ -46,7 +46,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/SelectionPattern2.cs
+++ b/src/Desktop/UIAutomation/Patterns/SelectionPattern2.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -30,34 +30,34 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "CanSelectMultiple", Value = Convert.ToBoolean(this.Pattern.CurrentCanSelectMultiple) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "IsSelectionRequired", Value = Convert.ToBoolean(this.Pattern.CurrentIsSelectionRequired) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "CurrentItemCount", Value = this.Pattern.CurrentItemCount });
+            Properties.Add(new A11yPatternProperty() { Name = "CanSelectMultiple", Value = Convert.ToBoolean(Pattern.CurrentCanSelectMultiple) });
+            Properties.Add(new A11yPatternProperty() { Name = "IsSelectionRequired", Value = Convert.ToBoolean(Pattern.CurrentIsSelectionRequired) });
+            Properties.Add(new A11yPatternProperty() { Name = "CurrentItemCount", Value = Pattern.CurrentItemCount });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod]
         public IList<DesktopElement> GetSelection()
         {
-            return this.Pattern.GetCurrentSelection().ToListOfDesktopElements();
+            return Pattern.GetCurrentSelection().ToListOfDesktopElements();
         }
 
         [PatternMethod]
         public DesktopElement LastSelectedItem()
         {
-            return new DesktopElement(this.Pattern.CurrentLastSelectedItem);
+            return new DesktopElement(Pattern.CurrentLastSelectedItem);
         }
 
         [PatternMethod]
         public DesktopElement CurrentSelectedItem()
         {
-            return new DesktopElement(this.Pattern.CurrentCurrentSelectedItem);
+            return new DesktopElement(Pattern.CurrentCurrentSelectedItem);
         }
 
         [PatternMethod]
         public DesktopElement FirstSelectedItem()
         {
-            return new DesktopElement(this.Pattern.CurrentFirstSelectedItem);
+            return new DesktopElement(Pattern.CurrentFirstSelectedItem);
         }
 
         protected override void Dispose(bool disposing)
@@ -65,7 +65,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/SpreadsheetItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SpreadsheetItemPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -28,20 +28,20 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "Formula", Value = this.Pattern.CurrentFormula });
+            Properties.Add(new A11yPatternProperty() { Name = "Formula", Value = Pattern.CurrentFormula });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod]
         public IList<DesktopElement> GetAnnotationObjects()
         {
-            return this.Pattern.GetCurrentAnnotationObjects()?.ToListOfDesktopElements();
+            return Pattern.GetCurrentAnnotationObjects()?.ToListOfDesktopElements();
         }
 
         [PatternMethod]
         public IList<string> GetAnnotationTypes()
         {
-            var array = this.Pattern.GetCurrentAnnotationTypes();
+            var array = Pattern.GetCurrentAnnotationTypes();
             List<string> list = new List<string>();
 
             if (array.Length > 0)
@@ -60,7 +60,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/SpreadsheetPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SpreadsheetPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -23,7 +23,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public DesktopElement GetItemByName(string name)
         {
-            return new DesktopElement(this.Pattern.GetItemByName(name));
+            return new DesktopElement(Pattern.GetItemByName(name));
         }
 
         protected override void Dispose(bool disposing)
@@ -31,7 +31,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/StylesPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/StylesPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
@@ -24,13 +24,13 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "ExtendedProperties", Value = this.Pattern.CurrentExtendedProperties });
-            this.Properties.Add(new A11yPatternProperty() { Name = "FillColor ", Value = this.Pattern.CurrentFillColor });
-            this.Properties.Add(new A11yPatternProperty() { Name = "FillPatternColor ", Value = this.Pattern.CurrentFillPatternColor });
-            this.Properties.Add(new A11yPatternProperty() { Name = "FillPatternStyle ", Value = this.Pattern.CurrentFillPatternStyle });
-            this.Properties.Add(new A11yPatternProperty() { Name = "Shape ", Value = this.Pattern.CurrentShape });
-            this.Properties.Add(new A11yPatternProperty() { Name = "StyleId ", Value = this.Pattern.CurrentStyleId });
-            this.Properties.Add(new A11yPatternProperty() { Name = "StyleName ", Value = this.Pattern.CurrentStyleName });
+            Properties.Add(new A11yPatternProperty() { Name = "ExtendedProperties", Value = Pattern.CurrentExtendedProperties });
+            Properties.Add(new A11yPatternProperty() { Name = "FillColor ", Value = Pattern.CurrentFillColor });
+            Properties.Add(new A11yPatternProperty() { Name = "FillPatternColor ", Value = Pattern.CurrentFillPatternColor });
+            Properties.Add(new A11yPatternProperty() { Name = "FillPatternStyle ", Value = Pattern.CurrentFillPatternStyle });
+            Properties.Add(new A11yPatternProperty() { Name = "Shape ", Value = Pattern.CurrentShape });
+            Properties.Add(new A11yPatternProperty() { Name = "StyleId ", Value = Pattern.CurrentStyleId });
+            Properties.Add(new A11yPatternProperty() { Name = "StyleName ", Value = Pattern.CurrentStyleName });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
@@ -39,7 +39,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/SynchronizedInputPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SynchronizedInputPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -25,13 +25,13 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public void StartListening(SynchronizedInputType inputType)
         {
-            this.Pattern.StartListening(inputType);
+            Pattern.StartListening(inputType);
         }
 
         [PatternMethod]
         public void Cancel()
         {
-            this.Pattern.Cancel();
+            Pattern.Cancel();
         }
 
         protected override void Dispose(bool disposing)
@@ -39,7 +39,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/TableItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TableItemPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -25,13 +25,13 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public IList<DesktopElement> GetColumnHeaderItems()
         {
-            return this.Pattern.GetCurrentColumnHeaderItems()?.ToListOfDesktopElements();
+            return Pattern.GetCurrentColumnHeaderItems()?.ToListOfDesktopElements();
         }
 
         [PatternMethod]
         public IList<DesktopElement> GetRowHeaderItems()
         {
-            return this.Pattern.GetCurrentRowHeaderItems()?.ToListOfDesktopElements();
+            return Pattern.GetCurrentRowHeaderItems()?.ToListOfDesktopElements();
         }
 
         protected override void Dispose(bool disposing)
@@ -39,7 +39,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/TablePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TablePattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -27,20 +27,20 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "RowOrColumnMajor", Value = this.Pattern.CurrentRowOrColumnMajor });
+            Properties.Add(new A11yPatternProperty() { Name = "RowOrColumnMajor", Value = Pattern.CurrentRowOrColumnMajor });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod]
         public IList<DesktopElement> GetColumnHeaders()
         {
-            return this.Pattern.GetCurrentColumnHeaders()?.ToListOfDesktopElements();
+            return Pattern.GetCurrentColumnHeaders()?.ToListOfDesktopElements();
         }
 
         [PatternMethod]
         public IList<DesktopElement> GetRowHeaders()
         {
-            return this.Pattern.GetCurrentRowHeaders()?.ToListOfDesktopElements();
+            return Pattern.GetCurrentRowHeaders()?.ToListOfDesktopElements();
         }
 
         protected override void Dispose(bool disposing)
@@ -48,7 +48,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/TextChildPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextChildPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -23,13 +23,13 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public DesktopElement TextContainer()
         {
-            return new DesktopElement(this.Pattern.TextContainer, true, true);
+            return new DesktopElement(Pattern.TextContainer, true, true);
         }
 
         [PatternMethod]
         public TextRange TextRange()
         {
-            return new TextRange(this.Pattern.TextRange, null);
+            return new TextRange(Pattern.TextRange, null);
         }
 
         protected override void Dispose(bool disposing)
@@ -37,7 +37,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/TextEditPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextEditPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -26,14 +26,14 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public TextRange GetActiveComposition()
         {
-            var tr = this.Pattern.GetActiveComposition();
+            var tr = Pattern.GetActiveComposition();
             return tr != null ? new TextRange(tr, null) : null;
         }
 
         [PatternMethod]
         public TextRange GetConversionTarget()
         {
-            var tr = this.Pattern.GetConversionTarget();
+            var tr = Pattern.GetConversionTarget();
             return tr != null ? new TextRange(tr, null) : null;
         }
 
@@ -42,7 +42,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/TextPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -39,26 +39,26 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "SupportedTextSelection", Value = this.Pattern.SupportedTextSelection });
+            Properties.Add(new A11yPatternProperty() { Name = "SupportedTextSelection", Value = Pattern.SupportedTextSelection });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod]
         public TextRange DocumentRange()
         {
-            return new TextRange(this.Pattern.DocumentRange, this);
+            return new TextRange(Pattern.DocumentRange, this);
         }
 
         [PatternMethod]
         public IList<TextRange> GetSelection()
         {
-            return ToListOfTextRanges(this.Pattern.GetSelection());
+            return ToListOfTextRanges(Pattern.GetSelection());
         }
 
         [PatternMethod]
         public IList<TextRange> GetVisibleRanges()
         {
-            return ToListOfTextRanges(this.Pattern.GetVisibleRanges());
+            return ToListOfTextRanges(Pattern.GetVisibleRanges());
         }
 
         [PatternMethod]
@@ -66,13 +66,13 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         {
             if (child == null) throw new ArgumentNullException(nameof(child));
 
-            return new TextRange(this.Pattern.RangeFromChild(child.PlatformObject), this);
+            return new TextRange(Pattern.RangeFromChild(child.PlatformObject), this);
         }
 
         [PatternMethod]
         public TextRange RangeFromPoint(tagPOINT pt)
         {
-            return new TextRange(this.Pattern.RangeFromPoint(pt), this);
+            return new TextRange(Pattern.RangeFromPoint(pt), this);
         }
 
         List<TextRange> ToListOfTextRanges(IUIAutomationTextRangeArray array)
@@ -95,7 +95,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/TextPattern2.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextPattern2.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -23,7 +23,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public TextRange GetCaretRange(out int isActive)
         {
-            return new TextRange(this.Pattern.GetCaretRange(out isActive), null);
+            return new TextRange(Pattern.GetCaretRange(out isActive), null);
         }
 
         [PatternMethod]
@@ -31,7 +31,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            return new TextRange(this.Pattern.RangeFromAnnotation(e.PlatformObject), null);
+            return new TextRange(Pattern.RangeFromAnnotation(e.PlatformObject), null);
         }
 
         protected override void Dispose(bool disposing)
@@ -39,7 +39,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/TextRange.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextRange.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Desktop.Utility;
@@ -30,49 +30,49 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         public TextRange(IUIAutomationTextRange tr, TextPattern tp)
         {
             UIATextRange = tr;
-            this.TextPattern = tp;
+            TextPattern = tp;
         }
 
         [PatternMethod]
         public void Select()
         {
-            this.UIATextRange.Select();
+            UIATextRange.Select();
         }
 
         [PatternMethod]
         public void AddToSelection()
         {
-            this.UIATextRange.AddToSelection();
+            UIATextRange.AddToSelection();
         }
 
         [PatternMethod]
         public void RemoveFromSelection()
         {
-            this.UIATextRange.RemoveFromSelection();
+            UIATextRange.RemoveFromSelection();
         }
 
         [PatternMethod]
         public void ScrollIntoView(bool alignToTop)
         {
-            this.UIATextRange.ScrollIntoView(alignToTop ? 1 : 0);
+            UIATextRange.ScrollIntoView(alignToTop ? 1 : 0);
         }
 
         [PatternMethod]
         public IList<DesktopElement> GetChildren()
         {
-            return this.UIATextRange.GetChildren()?.ToListOfDesktopElements();
+            return UIATextRange.GetChildren()?.ToListOfDesktopElements();
         }
 
         [PatternMethod]
         public DesktopElement GetEnclosingElement()
         {
-            return new DesktopElement(this.UIATextRange.GetEnclosingElement());
+            return new DesktopElement(UIATextRange.GetEnclosingElement());
         }
 
         [PatternMethod]
         public int Move(TextUnit unit, int count)
         {
-            return this.UIATextRange.Move(unit, count);
+            return UIATextRange.Move(unit, count);
         }
 
         [PatternMethod]
@@ -80,25 +80,25 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         {
             if (tr == null) throw new ArgumentNullException(nameof(tr));
 
-            this.UIATextRange.MoveEndpointByRange(srcEndPoint, tr.UIATextRange, targetEndPoint);
+            UIATextRange.MoveEndpointByRange(srcEndPoint, tr.UIATextRange, targetEndPoint);
         }
 
         [PatternMethod]
         public int MoveEndpointByUnit(TextPatternRangeEndpoint endpoint, TextUnit unit, int count)
         {
-            return this.UIATextRange.MoveEndpointByUnit(endpoint, unit, count);
+            return UIATextRange.MoveEndpointByUnit(endpoint, unit, count);
         }
 
         [PatternMethod]
         public void ExpandToEnclosingUnit(TextUnit tu)
         {
-            this.UIATextRange.ExpandToEnclosingUnit(tu);
+            UIATextRange.ExpandToEnclosingUnit(tu);
         }
 
         [PatternMethod]
         public TextRange Clone()
         {
-            return new TextRange(this.UIATextRange.Clone(), this.TextPattern);
+            return new TextRange(UIATextRange.Clone(), TextPattern);
         }
 
         [PatternMethod]
@@ -106,7 +106,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         {
             if (tr == null) throw new ArgumentNullException(nameof(tr));
 
-            return Convert.ToBoolean(this.UIATextRange.Compare(tr.UIATextRange));
+            return Convert.ToBoolean(UIATextRange.Compare(tr.UIATextRange));
         }
 
         [PatternMethod]
@@ -114,21 +114,21 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         {
             if (tr == null) throw new ArgumentNullException(nameof(tr));
 
-            return this.UIATextRange.CompareEndpoints(srcEndPoint, tr.UIATextRange, targetEndPoint);
+            return UIATextRange.CompareEndpoints(srcEndPoint, tr.UIATextRange, targetEndPoint);
         }
 
         [PatternMethod]
         public TextRange FindAttribute(int attr, object val, bool backward)
         {
-            var uiatr = this.UIATextRange.FindAttribute(attr, val, backward ? 1 : 0);
-            return uiatr != null ? new TextRange(uiatr, this.TextPattern) : null;
+            var uiatr = UIATextRange.FindAttribute(attr, val, backward ? 1 : 0);
+            return uiatr != null ? new TextRange(uiatr, TextPattern) : null;
         }
 
         [PatternMethod]
         public TextRange FindText(string text, bool backward, bool ignoreCase)
         {
-            var uiatr = this.UIATextRange.FindText(text, backward ? 1 : 0, ignoreCase ? 1 : 0);
-            return uiatr != null ? new TextRange(uiatr, this.TextPattern) : null;
+            var uiatr = UIATextRange.FindText(text, backward ? 1 : 0, ignoreCase ? 1 : 0);
+            return uiatr != null ? new TextRange(uiatr, TextPattern) : null;
         }
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         {
             try
             {
-                return this.UIATextRange.GetAttributeValue(attr);
+                return UIATextRange.GetAttributeValue(attr);
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception e)
@@ -159,7 +159,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         {
             List<Rectangle> list = new List<Rectangle>();
 
-            var arr = this.UIATextRange.GetBoundingRectangles();
+            var arr = UIATextRange.GetBoundingRectangles();
             for (int i = 0; i < arr.Length; i += 4)
             {
                 list.Add(new Rectangle(Convert.ToInt32((double)arr.GetValue(i)), Convert.ToInt32((double)arr.GetValue(i + 1)), Convert.ToInt32((double)arr.GetValue(i + 2)), Convert.ToInt32((double)arr.GetValue(i + 3))));
@@ -171,7 +171,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public string GetText(int max)
         {
-            return this.UIATextRange.GetText(max);
+            return UIATextRange.GetText(max);
         }
 
         #region IDisposable Support
@@ -181,7 +181,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         {
             if (!disposedValue)
             {
-                if (this.UIATextRange != null)
+                if (UIATextRange != null)
                 {
                     Marshal.ReleaseComObject(UIATextRange);
                     UIATextRange = null;

--- a/src/Desktop/UIAutomation/Patterns/TogglePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TogglePattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -24,14 +24,14 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "ToggleState", Value = this.Pattern.CurrentToggleState });
+            Properties.Add(new A11yPatternProperty() { Name = "ToggleState", Value = Pattern.CurrentToggleState });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod(IsUIAction = true)]
         public void Toggle()
         {
-            this.Pattern.Toggle();
+            Pattern.Toggle();
         }
 
         protected override void Dispose(bool disposing)
@@ -39,7 +39,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/TransformPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TransformPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -24,34 +24,34 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             PopulateProperties();
 
             // Get UI Actionability based on Properties than methods.
-            this.IsUIActionable = this.Properties.Any(pp => pp.Value == true);
+            IsUIActionable = Properties.Any(pp => pp.Value == true);
         }
 
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "CanMove", Value = Convert.ToBoolean(this.Pattern.CurrentCanMove) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "CanResize", Value = Convert.ToBoolean(this.Pattern.CurrentCanResize) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "CanRotate", Value = Convert.ToBoolean(this.Pattern.CurrentCanRotate) });
+            Properties.Add(new A11yPatternProperty() { Name = "CanMove", Value = Convert.ToBoolean(Pattern.CurrentCanMove) });
+            Properties.Add(new A11yPatternProperty() { Name = "CanResize", Value = Convert.ToBoolean(Pattern.CurrentCanResize) });
+            Properties.Add(new A11yPatternProperty() { Name = "CanRotate", Value = Convert.ToBoolean(Pattern.CurrentCanRotate) });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod]
         public void Move(double x, double y)
         {
-            this.Pattern.Move(x, y);
+            Pattern.Move(x, y);
         }
 
         [PatternMethod]
         public void Resize(double width, double height)
         {
-            this.Pattern.Resize(width, height);
+            Pattern.Resize(width, height);
         }
 
         [PatternMethod]
         public void Rotate(double degree)
         {
-            this.Pattern.Rotate(degree);
+            Pattern.Rotate(degree);
         }
 
         protected override void Dispose(bool disposing)
@@ -59,7 +59,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/TransformPattern2.cs
+++ b/src/Desktop/UIAutomation/Patterns/TransformPattern2.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -26,26 +26,26 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "CanMove", Value = Convert.ToBoolean(this.Pattern.CurrentCanMove) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "CanResize", Value = Convert.ToBoolean(this.Pattern.CurrentCanResize) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "CanRotate", Value = Convert.ToBoolean(this.Pattern.CurrentCanRotate) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "CanZoom", Value = Convert.ToBoolean(this.Pattern.CurrentCanZoom) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "CanZoomLevel", Value = Convert.ToBoolean(this.Pattern.CurrentZoomLevel) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "CanZoomMaximum", Value = Convert.ToBoolean(this.Pattern.CurrentZoomMaximum) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "CanZoomMinimum", Value = Convert.ToBoolean(this.Pattern.CurrentZoomMinimum) });
+            Properties.Add(new A11yPatternProperty() { Name = "CanMove", Value = Convert.ToBoolean(Pattern.CurrentCanMove) });
+            Properties.Add(new A11yPatternProperty() { Name = "CanResize", Value = Convert.ToBoolean(Pattern.CurrentCanResize) });
+            Properties.Add(new A11yPatternProperty() { Name = "CanRotate", Value = Convert.ToBoolean(Pattern.CurrentCanRotate) });
+            Properties.Add(new A11yPatternProperty() { Name = "CanZoom", Value = Convert.ToBoolean(Pattern.CurrentCanZoom) });
+            Properties.Add(new A11yPatternProperty() { Name = "CanZoomLevel", Value = Convert.ToBoolean(Pattern.CurrentZoomLevel) });
+            Properties.Add(new A11yPatternProperty() { Name = "CanZoomMaximum", Value = Convert.ToBoolean(Pattern.CurrentZoomMaximum) });
+            Properties.Add(new A11yPatternProperty() { Name = "CanZoomMinimum", Value = Convert.ToBoolean(Pattern.CurrentZoomMinimum) });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod(IsUIAction = true)]
         public void Zoom(double zoomValue)
         {
-            this.Pattern.Zoom(zoomValue);
+            Pattern.Zoom(zoomValue);
         }
 
         [PatternMethod(IsUIAction = true)]
         public void ZoomByUnit(ZoomUnit zu)
         {
-            this.Pattern.ZoomByUnit(zu);
+            Pattern.ZoomByUnit(zu);
         }
 
         protected override void Dispose(bool disposing)
@@ -53,7 +53,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/ValuePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ValuePattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -26,10 +26,10 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "IsReadOnly", Value = Convert.ToBoolean(this.Pattern.CurrentIsReadOnly) });
+            Properties.Add(new A11yPatternProperty() { Name = "IsReadOnly", Value = Convert.ToBoolean(Pattern.CurrentIsReadOnly) });
             try
             {
-                this.Properties.Add(new A11yPatternProperty() { Name = "Value", Value = this.Pattern.CurrentValue });
+                Properties.Add(new A11yPatternProperty() { Name = "Value", Value = Pattern.CurrentValue });
             }
             catch (InvalidOperationException e)
             {
@@ -43,7 +43,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public void SetValue(string val)
         {
-            this.Pattern.SetValue(val);
+            Pattern.SetValue(val);
         }
 
         protected override void Dispose(bool disposing)
@@ -51,7 +51,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/VirtualizedItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/VirtualizedItemPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -22,7 +22,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public void Realize()
         {
-            this.Pattern.Realize();
+            Pattern.Realize();
         }
 
         protected override void Dispose(bool disposing)
@@ -30,7 +30,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Patterns/WindowPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/WindowPattern.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
@@ -28,19 +28,19 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         private void PopulateProperties()
         {
 #pragma warning disable CA2000 // Properties are disposed in A11yPattern.Dispose()
-            this.Properties.Add(new A11yPatternProperty() { Name = "CanMaximize", Value = Convert.ToBoolean(this.Pattern.CurrentCanMaximize) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "CanMinimize", Value = Convert.ToBoolean(this.Pattern.CurrentCanMinimize) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "IsModal", Value = Convert.ToBoolean(this.Pattern.CurrentIsModal) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "IsTopmost", Value = Convert.ToBoolean(this.Pattern.CurrentIsTopmost) });
-            this.Properties.Add(new A11yPatternProperty() { Name = "WindowInteractionState", Value = this.Pattern.CurrentWindowInteractionState });
-            this.Properties.Add(new A11yPatternProperty() { Name = "WindowVisualState", Value = this.Pattern.CurrentWindowVisualState });
+            Properties.Add(new A11yPatternProperty() { Name = "CanMaximize", Value = Convert.ToBoolean(Pattern.CurrentCanMaximize) });
+            Properties.Add(new A11yPatternProperty() { Name = "CanMinimize", Value = Convert.ToBoolean(Pattern.CurrentCanMinimize) });
+            Properties.Add(new A11yPatternProperty() { Name = "IsModal", Value = Convert.ToBoolean(Pattern.CurrentIsModal) });
+            Properties.Add(new A11yPatternProperty() { Name = "IsTopmost", Value = Convert.ToBoolean(Pattern.CurrentIsTopmost) });
+            Properties.Add(new A11yPatternProperty() { Name = "WindowInteractionState", Value = Pattern.CurrentWindowInteractionState });
+            Properties.Add(new A11yPatternProperty() { Name = "WindowVisualState", Value = Pattern.CurrentWindowVisualState });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()
         }
 
         [PatternMethod]
         public void SetWindowVisualState(WindowVisualState state)
         {
-            this.Pattern.SetWindowVisualState(state);
+            Pattern.SetWindowVisualState(state);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         [PatternMethod]
         public void WaitForInputIdle(int ms)
         {
-            this.Pattern.WaitForInputIdle(ms);
+            Pattern.WaitForInputIdle(ms);
         }
 
         protected override void Dispose(bool disposing)
@@ -58,7 +58,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             if (Pattern != null)
             {
                 System.Runtime.InteropServices.Marshal.ReleaseComObject(Pattern);
-                this.Pattern = null;
+                Pattern = null;
             }
 
             base.Dispose(disposing);

--- a/src/Desktop/UIAutomation/Support/TextRangeFinder.cs
+++ b/src/Desktop/UIAutomation/Support/TextRangeFinder.cs
@@ -20,42 +20,42 @@ namespace Axe.Windows.Desktop.UIAutomation.Support
         /// <param name="range">Original range</param>
         public TextRangeFinder(TextRange range)
         {
-            this.OriginalRange = range;
+            OriginalRange = range;
         }
 
         public TextRange Find(int id, dynamic value, bool backward)
         {
             using (var range = GetRangeForFind(backward))
             {
-                this.FoundRange = range.FindAttribute(id, value, backward);
+                FoundRange = range.FindAttribute(id, value, backward);
             } // using
 
-            return this.FoundRange;
+            return FoundRange;
         }
 
         public TextRange FindText(string value, bool backward, bool ignorecase)
         {
             using (var range = GetRangeForFind(backward))
             {
-                this.FoundRange = range.FindText(value, backward, ignorecase);
+                FoundRange = range.FindText(value, backward, ignorecase);
             } // using
 
-            return this.FoundRange;
+            return FoundRange;
         }
 
         private TextRange GetRangeForFind(bool backward)
         {
-            var range = this.OriginalRange.Clone();
+            var range = OriginalRange.Clone();
 
-            if (this.FoundRange != null)
+            if (FoundRange != null)
             {
                 if (backward == true)
                 {
-                    range.MoveEndpointByRange(UIAutomationClient.TextPatternRangeEndpoint.TextPatternRangeEndpoint_End, this.FoundRange, UIAutomationClient.TextPatternRangeEndpoint.TextPatternRangeEndpoint_Start);
+                    range.MoveEndpointByRange(UIAutomationClient.TextPatternRangeEndpoint.TextPatternRangeEndpoint_End, FoundRange, UIAutomationClient.TextPatternRangeEndpoint.TextPatternRangeEndpoint_Start);
                 }
                 else
                 {
-                    range.MoveEndpointByRange(UIAutomationClient.TextPatternRangeEndpoint.TextPatternRangeEndpoint_Start, this.FoundRange, UIAutomationClient.TextPatternRangeEndpoint.TextPatternRangeEndpoint_End);
+                    range.MoveEndpointByRange(UIAutomationClient.TextPatternRangeEndpoint.TextPatternRangeEndpoint_Start, FoundRange, UIAutomationClient.TextPatternRangeEndpoint.TextPatternRangeEndpoint_End);
                 }
             }
 

--- a/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
@@ -61,28 +61,28 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            this.TreeWalker = dataContext.A11yAutomation.GetTreeWalker(mode);
-            this.TreeWalkerMode = mode;
-            this.Items = new List<A11yElement>();
-            this.SetMembers = setMembers;
+            TreeWalker = dataContext.A11yAutomation.GetTreeWalker(mode);
+            TreeWalkerMode = mode;
+            Items = new List<A11yElement>();
+            SetMembers = setMembers;
             SetParent(e, -1, dataContext);
 
             if (Items.Count != 0)
             {
-                this.First = Items.Last();
-                this.Last = Items.First();
-                if (this.Last.IsRootElement() == false)
+                First = Items.Last();
+                Last = Items.First();
+                if (Last.IsRootElement() == false)
                 {
-                    this.Last.Children.Clear();
-                    this.NextId = PopulateSiblingTreeNodes(this.Last, e, dataContext);
+                    Last.Children.Clear();
+                    NextId = PopulateSiblingTreeNodes(Last, e, dataContext);
                 }
                 else
                 {
-                    this.NextId = 1;
+                    NextId = 1;
                 }
             }
 
-            Marshal.ReleaseComObject(this.TreeWalker);
+            Marshal.ReleaseComObject(TreeWalker);
         }
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
 
             try
             {
-                var puia = this.TreeWalker.GetParentElement((IUIAutomationElement)e.PlatformObject);
+                var puia = TreeWalker.GetParentElement((IUIAutomationElement)e.PlatformObject);
                 if (puia == null) return;
 
 #pragma warning disable CA2000 // Call IDisposable.Dispose()
@@ -110,7 +110,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
                     parent.IsAncestorOfSelected = true;
                     parent.Children.Add(e);
                     e.Parent = parent;
-                    this.Items.Add(parent);
+                    Items.Add(parent);
                     parent.UniqueId = uniqueId;
 
                     SetParent(parent, uniqueId - 1, dataContext);
@@ -137,7 +137,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         {
             int childId = 1;
 
-            IUIAutomationTreeWalker walker = this.TreeWalker;
+            IUIAutomationTreeWalker walker = TreeWalker;
             if ((IUIAutomationElement)parentNode.PlatformObject != null)
             {
                 IUIAutomationElement child;
@@ -165,8 +165,8 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
                     {
                         childNode.UniqueId = childId++;
                         childNode.Parent = parentNode;
-                        childNode.TreeWalkerMode = this.TreeWalkerMode;
-                        this.Items.Add(childNode);
+                        childNode.TreeWalkerMode = TreeWalkerMode;
+                        Items.Add(childNode);
                     }
                     else
                     {

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
@@ -52,7 +52,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// <param name="showAncestry"></param>
         public TreeWalkerForLive()
         {
-            this.Elements = new List<A11yElement>();
+            Elements = new List<A11yElement>();
         }
 
         /// <summary>
@@ -66,28 +66,28 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var begin = DateTime.Now;
-            this.WalkerMode = mode;
+            WalkerMode = mode;
 
             //Set parent of Root explicitly for testing.
             A11yElement parent = null;
-            var ancestry = new DesktopElementAncestry(this.WalkerMode, e, false, dataContext);
+            var ancestry = new DesktopElementAncestry(WalkerMode, e, false, dataContext);
             parent = ancestry.Last;
 
-            this.RootElement = ancestry.First;
+            RootElement = ancestry.First;
 
             // clear children
             ListHelper.DisposeAllItemsAndClearList(e.Children);
 
             // populate selected element relationship and add it to list.
             e.Parent = ancestry.Last;
-            e.TreeWalkerMode = this.WalkerMode; // set tree walker mode.
+            e.TreeWalkerMode = WalkerMode; // set tree walker mode.
             e.UniqueId = 0; // it is the selected element which should be id 0.
-            this.Elements.Add(e);
+            Elements.Add(e);
 
             PopulateChildrenTreeNode(e, ancestry.NextId, dataContext);
 
             // populate descendant Elements first in parallel
-            this.Elements.AsParallel().ForAll(el =>
+            Elements.AsParallel().ForAll(el =>
             {
                 el.PopulateMinimumPropertiesForSelection(dataContext);
             });
@@ -95,10 +95,10 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
             // Add ancestry into Elements list.
             foreach (var item in ancestry.Items)
             {
-                this.Elements.Add(item);
+                Elements.Add(item);
             }
 
-            this.LastWalkTime = DateTime.Now - begin;
+            LastWalkTime = DateTime.Now - begin;
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         {
             int childId = startId;
 
-            IUIAutomationTreeWalker walker = dataContext.A11yAutomation.GetTreeWalker(this.WalkerMode);
+            IUIAutomationTreeWalker walker = dataContext.A11yAutomation.GetTreeWalker(WalkerMode);
             IUIAutomationElement child = (IUIAutomationElement)rootNode.PlatformObject;
 
             if (child != null)
@@ -140,9 +140,9 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
                     rootNode.Children.Add(childNode);
 
                     childNode.Parent = rootNode;
-                    childNode.TreeWalkerMode = this.WalkerMode;
+                    childNode.TreeWalkerMode = WalkerMode;
 
-                    this.Elements.Add(childNode);
+                    Elements.Add(childNode);
                     try
                     {
                         child = walker.GetNextSiblingElement(child);

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -52,8 +52,8 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         public TreeWalkerForTest(A11yElement element, BoundedCounter elementCounter)
         {
             _elementCounter = elementCounter;
-            this.SelectedElement = element;
-            this.Elements = new List<A11yElement>();
+            SelectedElement = element;
+            Elements = new List<A11yElement>();
         }
 
         /// <summary>
@@ -64,38 +64,38 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         {
             dataContext.CancellationToken.ThrowIfCancellationRequested();
 
-            this.WalkerMode = mode;
-            if (this.Elements.Count != 0)
+            WalkerMode = mode;
+            if (Elements.Count != 0)
             {
-                this.Elements.Clear();
+                Elements.Clear();
             }
 
             //Set parent of Root explicitly for testing.
-            var ancestry = new DesktopElementAncestry(this.WalkerMode, this.SelectedElement, false, dataContext);
+            var ancestry = new DesktopElementAncestry(WalkerMode, SelectedElement, false, dataContext);
 
             // Pre-count the ancestors in our bounded count, so that our count is accurate
             _elementCounter.TryAdd(ancestry.Items.Count);
 
-            this.TopMostElement = ancestry.First;
+            TopMostElement = ancestry.First;
 
             // clear children
-            ListHelper.DisposeAllItemsAndClearList(this.SelectedElement.Children);
-            this.SelectedElement.UniqueId = 0;
+            ListHelper.DisposeAllItemsAndClearList(SelectedElement.Children);
+            SelectedElement.UniqueId = 0;
 
-            PopulateChildrenTreeNode(this.SelectedElement, ancestry.Last, ancestry.NextId, dataContext);
+            PopulateChildrenTreeNode(SelectedElement, ancestry.Last, ancestry.NextId, dataContext);
 
             // do population of ancestors all together with children
-            var list = new List<A11yElement>(this.Elements);
+            var list = new List<A11yElement>(Elements);
             foreach (var item in ancestry.Items)
             {
-                this.Elements.Add(item);
+                Elements.Add(item);
             }
 
             // populate Elements first
-            this.Elements.AsParallel().ForAll(e => e.PopulateAllPropertiesWithLiveData(dataContext));
+            Elements.AsParallel().ForAll(e => e.PopulateAllPropertiesWithLiveData(dataContext));
 
             // check whether there is any elements which couldn't be updated in parallel, if so, update it in sequence.
-            var nuel = this.Elements.Where(e => e.Properties == null);
+            var nuel = Elements.Where(e => e.Properties == null);
 
             if (nuel.Any())
             {
@@ -128,12 +128,12 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// <param name="startChildId"></param>
         private int PopulateChildrenTreeNode(A11yElement rootNode, A11yElement parentNode, int startChildId, DesktopDataContext dataContext)
         {
-            this.Elements.Add(rootNode);
+            Elements.Add(rootNode);
 
             rootNode.Parent = parentNode;
-            rootNode.TreeWalkerMode = this.WalkerMode; // set tree walker mode.
+            rootNode.TreeWalkerMode = WalkerMode; // set tree walker mode.
 
-            IUIAutomationTreeWalker walker = dataContext.A11yAutomation.GetTreeWalker(this.WalkerMode);
+            IUIAutomationTreeWalker walker = dataContext.A11yAutomation.GetTreeWalker(WalkerMode);
             IUIAutomationElement child = (IUIAutomationElement)rootNode.PlatformObject;
 
             if (child != null)

--- a/src/Desktop/Utility/ProcessItem.cs
+++ b/src/Desktop/Utility/ProcessItem.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using System.Diagnostics;
@@ -17,9 +17,9 @@ namespace Axe.Windows.Desktop.Utility
         {
             if (p == null) throw new ArgumentNullException(nameof(p));
 
-            this.HWnd = p.MainWindowHandle;
-            this.ProcessID = p.Id;
-            this.MainWindowTitle = p.MainWindowTitle;
+            HWnd = p.MainWindowHandle;
+            ProcessID = p.Id;
+            MainWindowTitle = p.MainWindowTitle;
         }
 
         public override string ToString()


### PR DESCRIPTION
#### Details

Apply analyzer-led removal of unneeded `this.` prefixes in the `Desktop` project. After locally making the changes in #796, the IDE highlighted the `this.` prefixes that were not needed.

##### Motivation

The code was originally written by folks who used `this.` _everywhere_ because that was the pattern in the team that they came from. Over time, that pattern has fallen by the wayside and now the code is very inconsistent. This PR is part of a series of PRs intended to increase the code consistency by removing unnecessary `this`. usage wherever possible.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
