### PR TITLE
chore: Analyzer-led removal of unneeded "this." prefixes in the Rules project

### DIFF
--- a/src/Rules/Conditions/AndCondition.cs
+++ b/src/Rules/Conditions/AndCondition.cs
@@ -15,19 +15,19 @@ namespace Axe.Windows.Rules
 
         public AndCondition(Condition a, Condition b)
         {
-            this.A = a ?? throw new ArgumentNullException(nameof(a));
-            this.B = b ?? throw new ArgumentNullException(nameof(b));
+            A = a ?? throw new ArgumentNullException(nameof(a));
+            B = b ?? throw new ArgumentNullException(nameof(b));
         }
 
         public override bool Matches(IA11yElement element)
         {
-            return this.A.Matches(element)
-                && this.B.Matches(element);
+            return A.Matches(element)
+                && B.Matches(element);
         }
 
         public override string ToString()
         {
-            return ConditionDescriptions.And.WithParameters(this.A.ToString(), this.B.ToString());
+            return ConditionDescriptions.And.WithParameters(A.ToString(), B.ToString());
         }
     } // class
 } // namespace

--- a/src/Rules/Conditions/ContextCondition.cs
+++ b/src/Rules/Conditions/ContextCondition.cs
@@ -19,16 +19,16 @@ namespace Axe.Windows.Rules
 
         public ContextCondition(Condition sub, ContextDelegate initialize, ContextDelegate finalize)
         {
-            this.Sub = sub ?? throw new ArgumentNullException(nameof(sub));
-            this.Initialize = initialize ?? throw new ArgumentNullException(nameof(initialize));
-            this.Finalize = finalize ?? throw new ArgumentNullException(nameof(finalize));
+            Sub = sub ?? throw new ArgumentNullException(nameof(sub));
+            Initialize = initialize ?? throw new ArgumentNullException(nameof(initialize));
+            Finalize = finalize ?? throw new ArgumentNullException(nameof(finalize));
         }
 
         public override bool Matches(IA11yElement e)
         {
             // Ensure the context is initialized
             Condition.InitContext();
-            this.Initialize(e);
+            Initialize(e);
 
             bool retVal = false;
 
@@ -38,18 +38,18 @@ namespace Axe.Windows.Rules
             }
             catch (Exception)
             {
-                this.Finalize(e);
+                Finalize(e);
                 throw;
             }
 
-            this.Finalize(e);
+            Finalize(e);
 
             return retVal;
         }
 
         public override string ToString()
         {
-            return this.Sub?.ToString();
+            return Sub?.ToString();
         }
     } // class
 } // namespace

--- a/src/Rules/Conditions/ControlTypeCondition.cs
+++ b/src/Rules/Conditions/ControlTypeCondition.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules.Resources;
@@ -14,20 +14,20 @@ namespace Axe.Windows.Rules
         {
             if (controlType == 0) throw new ArgumentException(ErrorMessages.IntParameterEqualsZero, nameof(controlType));
 
-            this.ControlType = controlType;
+            ControlType = controlType;
         }
 
         public override bool Matches(IA11yElement element)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
 
-            return element.ControlTypeId == this.ControlType;
+            return element.ControlTypeId == ControlType;
         }
 
         public override string ToString()
         {
             // stripping away the integer name because it makes conditions harder to read
-            var s = Axe.Windows.Core.Types.ControlType.GetInstance()?.GetNameById(this.ControlType);
+            var s = Axe.Windows.Core.Types.ControlType.GetInstance()?.GetNameById(ControlType);
             return s.Substring(0, s.IndexOf('('));
         }
     } // class

--- a/src/Rules/Conditions/DelegateCondition.cs
+++ b/src/Rules/Conditions/DelegateCondition.cs
@@ -12,12 +12,12 @@ namespace Axe.Windows.Rules
 
         public DelegateCondition(MatchesDelegate matches)
         {
-            this._Matches = matches ?? throw new ArgumentNullException(nameof(matches));
+            _Matches = matches ?? throw new ArgumentNullException(nameof(matches));
         }
 
         public override bool Matches(IA11yElement element)
         {
-            return this._Matches(element);
+            return _Matches(element);
         }
 
         public override string ToString()

--- a/src/Rules/Conditions/NotCondition.cs
+++ b/src/Rules/Conditions/NotCondition.cs
@@ -14,17 +14,17 @@ namespace Axe.Windows.Rules
 
         public NotCondition(Condition a)
         {
-            this.A = a ?? throw new ArgumentNullException(nameof(a));
+            A = a ?? throw new ArgumentNullException(nameof(a));
         }
 
         public override bool Matches(IA11yElement element)
         {
-            return !this.A.Matches(element);
+            return !A.Matches(element);
         }
 
         public override string ToString()
         {
-            return ConditionDescriptions.Not.WithParameters(this.A.ToString());
+            return ConditionDescriptions.Not.WithParameters(A.ToString());
         }
     } // class
 } // namespace

--- a/src/Rules/Conditions/OrCondition.cs
+++ b/src/Rules/Conditions/OrCondition.cs
@@ -15,19 +15,19 @@ namespace Axe.Windows.Rules
 
         public OrCondition(Condition a, Condition b)
         {
-            this.A = a ?? throw new ArgumentNullException(nameof(a));
-            this.B = b ?? throw new ArgumentNullException(nameof(b));
+            A = a ?? throw new ArgumentNullException(nameof(a));
+            B = b ?? throw new ArgumentNullException(nameof(b));
         }
 
         public override bool Matches(IA11yElement element)
         {
-            return this.A.Matches(element)
-                || this.B.Matches(element);
+            return A.Matches(element)
+                || B.Matches(element);
         }
 
         public override string ToString()
         {
-            return ConditionDescriptions.Or.WithParameters(this.A.ToString(), this.B.ToString());
+            return ConditionDescriptions.Or.WithParameters(A.ToString(), B.ToString());
         }
     } // class
 } // namespace

--- a/src/Rules/Conditions/PatternCondition.cs
+++ b/src/Rules/Conditions/PatternCondition.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
@@ -18,22 +18,22 @@ namespace Axe.Windows.Rules
         {
             if (patternID == 0) throw new ArgumentNullException(nameof(patternID));
 
-            this.PatternID = patternID;
-            this.Validate = validate;
+            PatternID = patternID;
+            Validate = validate;
         }
 
         public override bool Matches(IA11yElement e)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
 
-            var pattern = e.GetPattern(this.PatternID);
+            var pattern = e.GetPattern(PatternID);
 
-            return pattern != null && (this.Validate == null || Validate(e));
+            return pattern != null && (Validate == null || Validate(e));
         }
 
         public override string ToString()
         {
-            var patternName = PatternType.GetInstance().GetNameById(this.PatternID);
+            var patternName = PatternType.GetInstance().GetNameById(PatternID);
             return $"has {patternName} pattern";
         }
     } // class

--- a/src/Rules/Conditions/RecursiveCondition.cs
+++ b/src/Rules/Conditions/RecursiveCondition.cs
@@ -11,7 +11,7 @@ namespace Axe.Windows.Rules
 
         private void Init(Condition a)
         {
-            this.A = a ?? throw new ArgumentNullException(nameof(a));
+            A = a ?? throw new ArgumentNullException(nameof(a));
         }
 
         public static RecursiveCondition operator %(RecursiveCondition r, Condition c)
@@ -25,7 +25,7 @@ namespace Axe.Windows.Rules
             if (e == null) throw new ArgumentNullException(nameof(e));
             if (A == null) return false;
 
-            return this.A.Matches(e);
+            return A.Matches(e);
         }
 
         public override string ToString()

--- a/src/Rules/Conditions/StringDecoratorCondition.cs
+++ b/src/Rules/Conditions/StringDecoratorCondition.cs
@@ -18,18 +18,18 @@ namespace Axe.Windows.Rules
 
         public StringDecoratorCondition(Condition c, string decoration)
         {
-            this.Sub = c ?? throw new ArgumentNullException(nameof(c));
-            this.Decoration = decoration ?? throw new ArgumentNullException(nameof(decoration));
+            Sub = c ?? throw new ArgumentNullException(nameof(c));
+            Decoration = decoration ?? throw new ArgumentNullException(nameof(decoration));
         }
 
         public override bool Matches(IA11yElement element)
         {
-            return this.Sub.Matches(element);
+            return Sub.Matches(element);
         }
 
         public override string ToString()
         {
-            return this.Decoration.WithParameters(this.Sub);
+            return Decoration.WithParameters(Sub);
         }
     } // class
 } // namespace

--- a/src/Rules/Conditions/TreeDescentCondition.cs
+++ b/src/Rules/Conditions/TreeDescentCondition.cs
@@ -17,23 +17,23 @@ namespace Axe.Windows.Rules
 
         public TreeDescentCondition(Condition parentCondition, Condition childCondition)
         {
-            this.ParentCondition = parentCondition ?? throw new ArgumentNullException(nameof(parentCondition));
-            this.ChildCondition = childCondition ?? throw new ArgumentNullException(nameof(childCondition));
+            ParentCondition = parentCondition ?? throw new ArgumentNullException(nameof(parentCondition));
+            ChildCondition = childCondition ?? throw new ArgumentNullException(nameof(childCondition));
         }
 
         public override bool Matches(IA11yElement e)
         {
-            if (!this.ParentCondition.Matches(e))
+            if (!ParentCondition.Matches(e))
                 return false;
 
             var child = e?.GetFirstChild();
 
-            return this.ChildCondition.Matches(child);
+            return ChildCondition.Matches(child);
         }
 
         public override string ToString()
         {
-            return Invariant($"{this.ParentCondition} / {this.ChildCondition}");
+            return Invariant($"{ParentCondition} / {ChildCondition}");
         }
     } // class
 } // namespace

--- a/src/Rules/Conditions/ValueCondition.cs
+++ b/src/Rules/Conditions/ValueCondition.cs
@@ -21,8 +21,8 @@ namespace Axe.Windows.Rules
 
         public ValueCondition(GetterDelegate getter, string description)
         {
-            this.GetValue = getter ?? throw new ArgumentNullException(nameof(getter));
-            this.Description = description ?? throw new ArgumentNullException(nameof(description));
+            GetValue = getter ?? throw new ArgumentNullException(nameof(getter));
+            Description = description ?? throw new ArgumentNullException(nameof(description));
         }
 
         public override bool Matches(IA11yElement element)

--- a/src/Rules/Library/BoundingRectangleCompletelyObscuresContainer.cs
+++ b/src/Rules/Library/BoundingRectangleCompletelyObscuresContainer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -19,11 +19,11 @@ namespace Axe.Windows.Rules.Library
     {
         public BoundingRectangleCompletelyObscuresContainer()
         {
-            this.Info.Description = Descriptions.BoundingRectangleCompletelyObscuresContainer;
-            this.Info.HowToFix = HowToFix.BoundingRectangleCompletelyObscuresContainer;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.BoundingRectangleCompletelyObscuresContainer;
+            Info.HowToFix = HowToFix.BoundingRectangleCompletelyObscuresContainer;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/BoundingRectangleContainedInParent.cs
+++ b/src/Rules/Library/BoundingRectangleContainedInParent.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -21,11 +21,11 @@ namespace Axe.Windows.Rules.Library
 
         public BoundingRectangleContainedInParent()
         {
-            this.Info.Description = Descriptions.BoundingRectangleContainedInParent;
-            this.Info.HowToFix = HowToFix.BoundingRectangleContainedInParent;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            Info.Description = Descriptions.BoundingRectangleContainedInParent;
+            Info.HowToFix = HowToFix.BoundingRectangleContainedInParent;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
+            Info.ErrorCode = EvaluationCode.Warning;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/BoundingRectangleDataFormatCorrect.cs
+++ b/src/Rules/Library/BoundingRectangleDataFormatCorrect.cs
@@ -14,11 +14,11 @@ namespace Axe.Windows.Rules.Library
     {
         public BoundingRectangleDataFormatCorrect()
         {
-            this.Info.Description = Descriptions.BoundingRectangleDataFormatCorrect;
-            this.Info.HowToFix = HowToFix.BoundingRectangleDataFormatCorrect;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.BoundingRectangleDataFormatCorrect;
+            Info.HowToFix = HowToFix.BoundingRectangleDataFormatCorrect;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/BoundingRectangleNotAllZeros.cs
+++ b/src/Rules/Library/BoundingRectangleNotAllZeros.cs
@@ -14,11 +14,11 @@ namespace Axe.Windows.Rules.Library
     {
         public BoundingRectangleNotAllZeros()
         {
-            this.Info.Description = Descriptions.BoundingRectangleNotAllZeros;
-            this.Info.HowToFix = HowToFix.BoundingRectangleNotAllZeros;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.BoundingRectangleNotAllZeros;
+            Info.HowToFix = HowToFix.BoundingRectangleNotAllZeros;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/BoundingRectangleNotNull.cs
+++ b/src/Rules/Library/BoundingRectangleNotNull.cs
@@ -14,11 +14,11 @@ namespace Axe.Windows.Rules.Library
     {
         public BoundingRectangleNotNull()
         {
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = Axe.Windows.Core.Types.PropertyType.UIA_BoundingRectanglePropertyId;
-            this.Info.Description = Descriptions.BoundingRectangleNotNull;
-            this.Info.HowToFix = HowToFix.BoundingRectangleNotNull;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = Axe.Windows.Core.Types.PropertyType.UIA_BoundingRectanglePropertyId;
+            Info.Description = Descriptions.BoundingRectangleNotNull;
+            Info.HowToFix = HowToFix.BoundingRectangleNotNull;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/BoundingRectangleNotNullListViewXAML.cs
+++ b/src/Rules/Library/BoundingRectangleNotNullListViewXAML.cs
@@ -14,12 +14,12 @@ namespace Axe.Windows.Rules.Library
     {
         public BoundingRectangleNotNullListViewXAML()
         {
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = Axe.Windows.Core.Types.PropertyType.UIA_BoundingRectanglePropertyId;
-            this.Info.Description = Descriptions.BoundingRectangleNotNull;
-            this.Info.HowToFix = HowToFix.BoundingRectangleNotNull;
-            this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-BoundingRectangleNotNullListViewXAML";
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = Axe.Windows.Core.Types.PropertyType.UIA_BoundingRectanglePropertyId;
+            Info.Description = Descriptions.BoundingRectangleNotNull;
+            Info.HowToFix = HowToFix.BoundingRectangleNotNull;
+            Info.ErrorCode = EvaluationCode.Error;
+            Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-BoundingRectangleNotNullListViewXAML";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/BoundingRectangleNotNullTextBlockXAML.cs
+++ b/src/Rules/Library/BoundingRectangleNotNullTextBlockXAML.cs
@@ -14,12 +14,12 @@ namespace Axe.Windows.Rules.Library
     {
         public BoundingRectangleNotNullTextBlockXAML()
         {
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = Axe.Windows.Core.Types.PropertyType.UIA_BoundingRectanglePropertyId;
-            this.Info.Description = Descriptions.BoundingRectangleNotNull;
-            this.Info.HowToFix = HowToFix.BoundingRectangleNotNull;
-            this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-BoundingRectangleNotNullTextBlockXAML";
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = Axe.Windows.Core.Types.PropertyType.UIA_BoundingRectanglePropertyId;
+            Info.Description = Descriptions.BoundingRectangleNotNull;
+            Info.HowToFix = HowToFix.BoundingRectangleNotNull;
+            Info.ErrorCode = EvaluationCode.Error;
+            Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-BoundingRectangleNotNullTextBlockXAML";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/BoundingRectangleNotValidButOffScreen.cs
+++ b/src/Rules/Library/BoundingRectangleNotValidButOffScreen.cs
@@ -14,11 +14,11 @@ namespace Axe.Windows.Rules.Library
     {
         public BoundingRectangleNotValidButOffScreen()
         {
-            this.Info.Description = Descriptions.BoundingRectangleNotValidButOffScreen;
-            this.Info.HowToFix = HowToFix.BoundingRectangleNotValidButOffScreen;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.BoundingRectangleNotValidButOffScreen;
+            Info.HowToFix = HowToFix.BoundingRectangleNotValidButOffScreen;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/BoundingRectangleSizeReasonable.cs
+++ b/src/Rules/Library/BoundingRectangleSizeReasonable.cs
@@ -18,11 +18,11 @@ namespace Axe.Windows.Rules.Library
     {
         public BoundingRectangleSizeReasonable()
         {
-            this.Info.Description = Descriptions.BoundingRectangleSizeReasonable;
-            this.Info.HowToFix = HowToFix.BoundingRectangleSizeReasonable;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.BoundingRectangleSizeReasonable;
+            Info.HowToFix = HowToFix.BoundingRectangleSizeReasonable;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_BoundingRectanglePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ButtonInvokeAndExpandeCollapsePatterns.cs
+++ b/src/Rules/Library/ButtonInvokeAndExpandeCollapsePatterns.cs
@@ -13,10 +13,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ButtonInvokeAndExpandCollapsePatterns()
         {
-            this.Info.Description = Descriptions.ButtonInvokeAndExpandCollapsePatterns;
-            this.Info.HowToFix = HowToFix.ButtonInvokeAndExpandCollapsePatterns;
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            Info.Description = Descriptions.ButtonInvokeAndExpandCollapsePatterns;
+            Info.HowToFix = HowToFix.ButtonInvokeAndExpandCollapsePatterns;
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.Warning;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ButtonInvokeAndTogglePatterns.cs
+++ b/src/Rules/Library/ButtonInvokeAndTogglePatterns.cs
@@ -13,10 +13,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ButtonInvokeAndTogglePatterns()
         {
-            this.Info.Description = Descriptions.ButtonInvokeAndTogglePatterns;
-            this.Info.HowToFix = HowToFix.ButtonInvokeAndTogglePatterns;
-            this.Info.Standard = A11yCriteriaId.NameRoleValue;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ButtonInvokeAndTogglePatterns;
+            Info.HowToFix = HowToFix.ButtonInvokeAndTogglePatterns;
+            Info.Standard = A11yCriteriaId.NameRoleValue;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ButtonShouldHavePatterns.cs
+++ b/src/Rules/Library/ButtonShouldHavePatterns.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ButtonShouldHavePatterns()
         {
-            this.Info.Description = Descriptions.ButtonShouldHavePatterns;
-            this.Info.HowToFix = HowToFix.ButtonShouldHavePatterns;
-            this.Info.Standard = A11yCriteriaId.NameRoleValue;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ButtonShouldHavePatterns;
+            Info.HowToFix = HowToFix.ButtonShouldHavePatterns;
+            Info.Standard = A11yCriteriaId.NameRoleValue;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ButtonToggleAndExpandeCollapsePatterns.cs
+++ b/src/Rules/Library/ButtonToggleAndExpandeCollapsePatterns.cs
@@ -13,10 +13,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ButtonToggleAndExpandCollapsePatterns()
         {
-            this.Info.Description = Descriptions.ButtonToggleAndExpandCollapsePatterns;
-            this.Info.HowToFix = HowToFix.ButtonToggleAndExpandCollapsePatterns;
-            this.Info.Standard = A11yCriteriaId.NameRoleValue;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ButtonToggleAndExpandCollapsePatterns;
+            Info.HowToFix = HowToFix.ButtonToggleAndExpandCollapsePatterns;
+            Info.Standard = A11yCriteriaId.NameRoleValue;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ChildrenNotAllowedInContentView.cs
+++ b/src/Rules/Library/ChildrenNotAllowedInContentView.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ChildrenNotAllowedInContentView()
         {
-            this.Info.Description = Descriptions.ChildrenNotAllowedInContentView;
-            this.Info.HowToFix = HowToFix.ChildrenNotAllowedInContentView;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ChildrenNotAllowedInContentView;
+            Info.HowToFix = HowToFix.ChildrenNotAllowedInContentView;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ClickablePointOffScreen.cs
+++ b/src/Rules/Library/ClickablePointOffScreen.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public ClickablePointOffScreen()
         {
-            this.Info.Description = Descriptions.ClickablePointOffScreen;
-            this.Info.HowToFix = HowToFix.ClickablePointOffScreen;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_IsOffscreenPropertyId;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            Info.Description = Descriptions.ClickablePointOffScreen;
+            Info.HowToFix = HowToFix.ClickablePointOffScreen;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_IsOffscreenPropertyId;
+            Info.ErrorCode = EvaluationCode.Warning;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ClickablePointOnScreen.cs
+++ b/src/Rules/Library/ClickablePointOnScreen.cs
@@ -16,11 +16,11 @@ namespace Axe.Windows.Rules.Library
     {
         public ClickablePointOnScreen()
         {
-            this.Info.Description = Descriptions.ClickablePointOnScreen;
-            this.Info.HowToFix = HowToFix.ClickablePointOnScreen;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_IsOffscreenPropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ClickablePointOnScreen;
+            Info.HowToFix = HowToFix.ClickablePointOnScreen;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_IsOffscreenPropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ClickablePointOnScreenWPF.cs
+++ b/src/Rules/Library/ClickablePointOnScreenWPF.cs
@@ -16,12 +16,12 @@ namespace Axe.Windows.Rules.Library
     {
         public ClickablePointOnScreenWPF()
         {
-            this.Info.Description = Descriptions.ClickablePointOnScreen;
-            this.Info.HowToFix = HowToFix.ClickablePointOnScreen;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_IsOffscreenPropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-ClickablePointOnScreenListViewWPF";
+            Info.Description = Descriptions.ClickablePointOnScreen;
+            Info.HowToFix = HowToFix.ClickablePointOnScreen;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_IsOffscreenPropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
+            Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-ClickablePointOnScreenListViewWPF";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ComboBoxShouldNotSupportScrollPattern.cs
+++ b/src/Rules/Library/ComboBoxShouldNotSupportScrollPattern.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ComboBoxShouldNotSupportScrollPattern()
         {
-            this.Info.Description = Descriptions.ComboBoxShouldNotSupportScrollPattern;
-            this.Info.HowToFix = HowToFix.ComboBoxShouldNotSupportScrollPattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            Info.Description = Descriptions.ComboBoxShouldNotSupportScrollPattern;
+            Info.HowToFix = HowToFix.ComboBoxShouldNotSupportScrollPattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Warning;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldNotSupportInvokePattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportInvokePattern.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldNotSupportInvokePattern()
         {
-            this.Info.Description = Descriptions.ControlShouldNotSupportInvokePattern;
-            this.Info.HowToFix = HowToFix.ControlShouldNotSupportInvokePattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ControlShouldNotSupportInvokePattern;
+            Info.HowToFix = HowToFix.ControlShouldNotSupportInvokePattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldNotSupportScrollPattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportScrollPattern.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldNotSupportScrollPattern()
         {
-            this.Info.Description = Descriptions.ControlShouldNotSupportScrollPattern;
-            this.Info.HowToFix = HowToFix.ControlShouldNotSupportScrollPattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ControlShouldNotSupportScrollPattern;
+            Info.HowToFix = HowToFix.ControlShouldNotSupportScrollPattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldNotSupportValuePattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportValuePattern.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldNotSupportValuePattern()
         {
-            this.Info.Description = Descriptions.ControlShouldNotSupportValuePattern;
-            this.Info.HowToFix = HowToFix.ControlShouldNotSupportValuePattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            Info.Description = Descriptions.ControlShouldNotSupportValuePattern;
+            Info.HowToFix = HowToFix.ControlShouldNotSupportValuePattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Warning;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldNotSupportWindowPattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportWindowPattern.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldNotSupportWindowPattern()
         {
-            this.Info.Description = Descriptions.ControlShouldNotSupportWindowPattern;
-            this.Info.HowToFix = HowToFix.ControlShouldNotSupportWindowPattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            Info.Description = Descriptions.ControlShouldNotSupportWindowPattern;
+            Info.HowToFix = HowToFix.ControlShouldNotSupportWindowPattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Warning;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportExpandCollapsePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportExpandCollapsePattern.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldSupportExpandCollapsePattern()
         {
-            this.Info.Description = Descriptions.ControlShouldSupportExpandCollapsePattern;
-            this.Info.HowToFix = HowToFix.ControlShouldSupportExpandCollapsePattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ControlShouldSupportExpandCollapsePattern;
+            Info.HowToFix = HowToFix.ControlShouldSupportExpandCollapsePattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportGridItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportGridItemPattern.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldSupportGridItemPattern()
         {
-            this.Info.Description = Descriptions.ControlShouldSupportGridItemPattern;
-            this.Info.HowToFix = HowToFix.ControlShouldSupportGridItemPattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ControlShouldSupportGridItemPattern;
+            Info.HowToFix = HowToFix.ControlShouldSupportGridItemPattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportGridPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportGridPattern.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldSupportGridPattern()
         {
-            this.Info.Description = Descriptions.ControlShouldSupportGridPattern;
-            this.Info.HowToFix = HowToFix.ControlShouldSupportGridPattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.PropertyID = PropertyType.UIA_IsGridPatternAvailablePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ControlShouldSupportGridPattern;
+            Info.HowToFix = HowToFix.ControlShouldSupportGridPattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.PropertyID = PropertyType.UIA_IsGridPatternAvailablePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportInvokePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportInvokePattern.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldSupportInvokePattern()
         {
-            this.Info.Description = Descriptions.ControlShouldSupportInvokePattern;
-            this.Info.HowToFix = HowToFix.ControlShouldSupportInvokePattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ControlShouldSupportInvokePattern;
+            Info.HowToFix = HowToFix.ControlShouldSupportInvokePattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportScrollItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportScrollItemPattern.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldSupportScrollItemPattern()
         {
-            this.Info.Description = Descriptions.ControlShouldSupportScrollItemPattern;
-            this.Info.HowToFix = HowToFix.ControlShouldSupportScrollItemPattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ControlShouldSupportScrollItemPattern;
+            Info.HowToFix = HowToFix.ControlShouldSupportScrollItemPattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportSelectionItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportSelectionItemPattern.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldSupportSelectionItemPattern()
         {
-            this.Info.Description = Descriptions.ControlShouldSupportSelectionItemPattern;
-            this.Info.HowToFix = HowToFix.ControlShouldSupportSelectionItemPattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ControlShouldSupportSelectionItemPattern;
+            Info.HowToFix = HowToFix.ControlShouldSupportSelectionItemPattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportSelectionPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportSelectionPattern.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldSupportSelectionPattern()
         {
-            this.Info.Description = Descriptions.ControlShouldSupportSelectionPattern;
-            this.Info.HowToFix = HowToFix.ControlShouldSupportSelectionPattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ControlShouldSupportSelectionPattern;
+            Info.HowToFix = HowToFix.ControlShouldSupportSelectionPattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportSetInfoWPF.cs
+++ b/src/Rules/Library/ControlShouldSupportSetInfoWPF.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldSupportSetInfoWPF()
         {
-            this.Info.Description = Descriptions.ControlShouldSupportSetInfo;
-            this.Info.HowToFix = HowToFix.ControlShouldSupportSetInfo;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-ControlShouldSupportSetInfoWPF";
+            Info.Description = Descriptions.ControlShouldSupportSetInfo;
+            Info.HowToFix = HowToFix.ControlShouldSupportSetInfo;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.ErrorCode = EvaluationCode.Error;
+            Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-ControlShouldSupportSetInfoWPF";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportSetInfoXAML.cs
+++ b/src/Rules/Library/ControlShouldSupportSetInfoXAML.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldSupportSetInfoXAML()
         {
-            this.Info.Description = Descriptions.ControlShouldSupportSetInfo;
-            this.Info.HowToFix = HowToFix.ControlShouldSupportSetInfo;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ControlShouldSupportSetInfo;
+            Info.HowToFix = HowToFix.ControlShouldSupportSetInfo;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportSpreadsheetItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportSpreadsheetItemPattern.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldSupportSpreadsheetItemPattern()
         {
-            this.Info.Description = Descriptions.ControlShouldSupportSpreadsheetItemPattern;
-            this.Info.HowToFix = HowToFix.ControlShouldSupportSpreadsheetItemPattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ControlShouldSupportSpreadsheetItemPattern;
+            Info.HowToFix = HowToFix.ControlShouldSupportSpreadsheetItemPattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportTableItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTableItemPattern.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldSupportTableItemPattern()
         {
-            this.Info.Description = Descriptions.ControlShouldSupportTableItemPattern;
-            this.Info.HowToFix = HowToFix.ControlShouldSupportTableItemPattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ControlShouldSupportTableItemPattern;
+            Info.HowToFix = HowToFix.ControlShouldSupportTableItemPattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportTablePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTablePattern.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldSupportTablePattern()
         {
-            this.Info.Description = Descriptions.ControlShouldSupportTablePattern;
-            this.Info.HowToFix = HowToFix.ControlShouldSupportTablePattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.PropertyID = PropertyType.UIA_IsTablePatternAvailablePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ControlShouldSupportTablePattern;
+            Info.HowToFix = HowToFix.ControlShouldSupportTablePattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.PropertyID = PropertyType.UIA_IsTablePatternAvailablePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportTextPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTextPattern.cs
@@ -17,10 +17,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldSupportTextPattern()
         {
-            this.Info.Description = Descriptions.ControlShouldSupportTextPattern;
-            this.Info.HowToFix = HowToFix.ControlShouldSupportTextPattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ControlShouldSupportTextPattern;
+            Info.HowToFix = HowToFix.ControlShouldSupportTextPattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportTextPatternEditWinform.cs
+++ b/src/Rules/Library/ControlShouldSupportTextPatternEditWinform.cs
@@ -14,11 +14,11 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldSupportTextPatternEditWinform()
         {
-            this.Info.Description = Descriptions.ControlShouldSupportTextPattern;
-            this.Info.HowToFix = HowToFix.ControlShouldSupportTextPattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-ControlShouldSupportTextPatternEditWinForm";
+            Info.Description = Descriptions.ControlShouldSupportTextPattern;
+            Info.HowToFix = HowToFix.ControlShouldSupportTextPattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
+            Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-ControlShouldSupportTextPatternEditWinForm";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportTogglePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTogglePattern.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldSupportTogglePattern()
         {
-            this.Info.Description = Descriptions.ControlShouldSupportTogglePattern;
-            this.Info.HowToFix = HowToFix.ControlShouldSupportTogglePattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ControlShouldSupportTogglePattern;
+            Info.HowToFix = HowToFix.ControlShouldSupportTogglePattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ControlShouldSupportTransformPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTransformPattern.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlShouldSupportTransformPattern()
         {
-            this.Info.Description = Descriptions.ControlShouldSupportTransformPattern;
-            this.Info.HowToFix = HowToFix.ControlShouldSupportTransformPattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ControlShouldSupportTransformPattern;
+            Info.HowToFix = HowToFix.ControlShouldSupportTransformPattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/EdgeBrowserHasBeenDeprecated.cs
+++ b/src/Rules/Library/EdgeBrowserHasBeenDeprecated.cs
@@ -12,11 +12,11 @@ namespace Axe.Windows.Rules.Library
     {
         public EdgeBrowserHasBeenDeprecated()
         {
-            this.Info.Description = Descriptions.EdgeBrowserHasBeenDeprecated;
-            this.Info.HowToFix = HowToFix.EdgeBrowserHasBeenDeprecated;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-EdgeBrowserHasBeenDeprecated";
+            Info.Description = Descriptions.EdgeBrowserHasBeenDeprecated;
+            Info.HowToFix = HowToFix.EdgeBrowserHasBeenDeprecated;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.ErrorCode = EvaluationCode.Error;
+            Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-EdgeBrowserHasBeenDeprecated";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/EditSupportsIncorrectRangeValuePattern.cs
+++ b/src/Rules/Library/EditSupportsIncorrectRangeValuePattern.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
     {
         public EditSupportsIncorrectRangeValuePattern()
         {
-            this.Info.Description = Descriptions.EditSupportsIncorrectRangeValuePattern;
-            this.Info.HowToFix = HowToFix.EditSupportsIncorrectRangeValuePattern;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.EditSupportsIncorrectRangeValuePattern;
+            Info.HowToFix = HowToFix.EditSupportsIncorrectRangeValuePattern;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/FrameworkDoesNotSupportUIAutomation.cs
+++ b/src/Rules/Library/FrameworkDoesNotSupportUIAutomation.cs
@@ -19,11 +19,11 @@ namespace Axe.Windows.Rules.Library
 
         public FrameworkDoesNotSupportUIAutomation()
         {
-            this.Info.Description = Descriptions.FrameworkDoesNotSupportUIAutomation;
-            this.Info.HowToFix = HowToFix.FrameworkDoesNotSupportUIAutomation;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-FrameworkDoesNotSupportUIAutomation";
+            Info.Description = Descriptions.FrameworkDoesNotSupportUIAutomation;
+            Info.HowToFix = HowToFix.FrameworkDoesNotSupportUIAutomation;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.ErrorCode = EvaluationCode.Error;
+            Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-FrameworkDoesNotSupportUIAutomation";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/HeadingLevelDescendsWhenNested.cs
+++ b/src/Rules/Library/HeadingLevelDescendsWhenNested.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
     {
         public HeadingLevelDescendsWhenNested()
         {
-            this.Info.Description = Descriptions.HeadingLevelDescendsWhenNested;
-            this.Info.HowToFix = HowToFix.HeadingLevelDescendsWhenNested;
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.HeadingLevelDescendsWhenNested;
+            Info.HowToFix = HowToFix.HeadingLevelDescendsWhenNested;
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/HelpTextExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/HelpTextExcludesPrivateUnicodeCharacters.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public HelpTextExcludesPrivateUnicodeCharacters()
         {
-            this.Info.Description = string.Format(CultureInfo.CurrentCulture, Descriptions.PropertyExcludesPrivateUnicodeCharacters, HelpText.PropertyDescription);
-            this.Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.PropertyExcludesPrivateUnicodeCharacters, HelpText.PropertyDescription);
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_HelpTextPropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = string.Format(CultureInfo.CurrentCulture, Descriptions.PropertyExcludesPrivateUnicodeCharacters, HelpText.PropertyDescription);
+            Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.PropertyExcludesPrivateUnicodeCharacters, HelpText.PropertyDescription);
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_HelpTextPropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/HelpTextNotEqualToName.cs
+++ b/src/Rules/Library/HelpTextNotEqualToName.cs
@@ -13,10 +13,10 @@ namespace Axe.Windows.Rules.Library
     {
         public HelpTextNotEqualToName()
         {
-            this.Info.Description = Descriptions.HelpTextNotEqualToName;
-            this.Info.HowToFix = HowToFix.HelpTextNotEqualToName;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            Info.Description = Descriptions.HelpTextNotEqualToName;
+            Info.HowToFix = HowToFix.HelpTextNotEqualToName;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.ErrorCode = EvaluationCode.Warning;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/HyperlinkNameShouldBeUnique.cs
+++ b/src/Rules/Library/HyperlinkNameShouldBeUnique.cs
@@ -19,10 +19,10 @@ namespace Axe.Windows.Rules.Library
 
         public HyperlinkNameShouldBeUnique()
         {
-            this.Info.Description = Descriptions.HyperlinkNameShouldBeUnique;
-            this.Info.HowToFix = HowToFix.HyperlinkNameShouldBeUnique;
-            this.Info.Standard = A11yCriteriaId.NameRoleValue;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            Info.Description = Descriptions.HyperlinkNameShouldBeUnique;
+            Info.HowToFix = HowToFix.HyperlinkNameShouldBeUnique;
+            Info.Standard = A11yCriteriaId.NameRoleValue;
+            Info.ErrorCode = EvaluationCode.Warning;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsContentElementFalseOptional.cs
+++ b/src/Rules/Library/IsContentElementFalseOptional.cs
@@ -16,11 +16,11 @@ namespace Axe.Windows.Rules.Library
         public IsContentElementFalseOptional()
         {
 
-            this.Info.Description = Descriptions.IsContentElementFalseOptional;
-            this.Info.HowToFix = HowToFix.IsContentElementFalseOptional;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_IsContentElementPropertyId;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.IsContentElementFalseOptional;
+            Info.HowToFix = HowToFix.IsContentElementFalseOptional;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_IsContentElementPropertyId;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsContentElementPropertyExists.cs
+++ b/src/Rules/Library/IsContentElementPropertyExists.cs
@@ -16,11 +16,11 @@ namespace Axe.Windows.Rules.Library
     {
         public IsContentElementPropertyExists()
         {
-            this.Info.Description = Descriptions.IsContentElementPropertyExists;
-            this.Info.HowToFix = HowToFix.IsContentElementPropertyExists;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_IsContentElementPropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.IsContentElementPropertyExists;
+            Info.HowToFix = HowToFix.IsContentElementPropertyExists;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_IsContentElementPropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsContentElementTrueOptional.cs
+++ b/src/Rules/Library/IsContentElementTrueOptional.cs
@@ -16,11 +16,11 @@ namespace Axe.Windows.Rules.Library
     {
         public IsContentElementTrueOptional()
         {
-            this.Info.Description = Descriptions.IsContentElementTrueOptional;
-            this.Info.HowToFix = HowToFix.IsContentElementTrueOptional;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_IsContentElementPropertyId;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.IsContentElementTrueOptional;
+            Info.HowToFix = HowToFix.IsContentElementTrueOptional;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_IsContentElementPropertyId;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsControlElementPropertyExists.cs
+++ b/src/Rules/Library/IsControlElementPropertyExists.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public IsControlElementPropertyExists()
         {
-            this.Info.Description = Descriptions.IsControlElementPropertyExists;
-            this.Info.HowToFix = HowToFix.IsControlElementPropertyExists;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_IsControlElementPropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.IsControlElementPropertyExists;
+            Info.HowToFix = HowToFix.IsControlElementPropertyExists;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_IsControlElementPropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsControlElementTrueOptional.cs
+++ b/src/Rules/Library/IsControlElementTrueOptional.cs
@@ -14,11 +14,11 @@ namespace Axe.Windows.Rules.Library
     {
         public IsControlElementTrueOptional()
         {
-            this.Info.Description = Descriptions.IsControlElementTrueOptional;
-            this.Info.HowToFix = HowToFix.IsControlElementTrueOptional;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_IsControlElementPropertyId;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.IsControlElementTrueOptional;
+            Info.HowToFix = HowToFix.IsControlElementTrueOptional;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_IsControlElementPropertyId;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsControlElementTrueRequired.cs
+++ b/src/Rules/Library/IsControlElementTrueRequired.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public IsControlElementTrueRequired()
         {
-            this.Info.Description = Descriptions.IsControlElementTrueRequired;
-            this.Info.HowToFix = HowToFix.IsControlElementTrueRequired;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_IsControlElementPropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.IsControlElementTrueRequired;
+            Info.HowToFix = HowToFix.IsControlElementTrueRequired;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_IsControlElementPropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsControlElementTrueRequiredButtonWPF.cs
+++ b/src/Rules/Library/IsControlElementTrueRequiredButtonWPF.cs
@@ -15,12 +15,12 @@ namespace Axe.Windows.Rules.Library
     {
         public IsControlElementTrueRequiredButtonWPF()
         {
-            this.Info.Description = Descriptions.IsControlElementTrueRequired;
-            this.Info.HowToFix = HowToFix.IsControlElementTrueRequired;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_IsControlElementPropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-IsControlElementTrueRequiredButtonWPF";
+            Info.Description = Descriptions.IsControlElementTrueRequired;
+            Info.HowToFix = HowToFix.IsControlElementTrueRequired;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_IsControlElementPropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
+            Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-IsControlElementTrueRequiredButtonWPF";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsControlElementTrueRequiredTextInEditXAML.cs
+++ b/src/Rules/Library/IsControlElementTrueRequiredTextInEditXAML.cs
@@ -15,12 +15,12 @@ namespace Axe.Windows.Rules.Library
     {
         public IsControlElementTrueRequiredTextInEditXAML()
         {
-            this.Info.Description = Descriptions.IsControlElementTrueRequired;
-            this.Info.HowToFix = HowToFix.IsControlElementTrueRequired;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_IsControlElementPropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
-            this.Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-IsControlElementTrueRequiredTextBoxXAML";
+            Info.Description = Descriptions.IsControlElementTrueRequired;
+            Info.HowToFix = HowToFix.IsControlElementTrueRequired;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_IsControlElementPropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
+            Info.FrameworkIssueLink = "https://aka.ms/FrameworkIssue-IsControlElementTrueRequiredTextBoxXAML";
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsKeyboardFocusableDescendantTextPattern.cs
+++ b/src/Rules/Library/IsKeyboardFocusableDescendantTextPattern.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public IsKeyboardFocusableDescendantTextPattern()
         {
-            this.Info.Description = Descriptions.IsKeyboardFocusableDescendantTextPattern;
-            this.Info.HowToFix = HowToFix.IsKeyboardFocusableDescendantTextPattern;
-            this.Info.Standard = A11yCriteriaId.Keyboard;
-            this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.IsKeyboardFocusableDescendantTextPattern;
+            Info.HowToFix = HowToFix.IsKeyboardFocusableDescendantTextPattern;
+            Info.Standard = A11yCriteriaId.Keyboard;
+            Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsKeyboardFocusableFalseButDisabled.cs
+++ b/src/Rules/Library/IsKeyboardFocusableFalseButDisabled.cs
@@ -14,11 +14,11 @@ namespace Axe.Windows.Rules.Library
     {
         public IsKeyboardFocusableFalseButDisabled()
         {
-            this.Info.Description = Descriptions.IsKeyboardFocusableFalseButDisabled;
-            this.Info.HowToFix = HowToFix.IsKeyboardFocusableFalseButDisabled;
-            this.Info.Standard = A11yCriteriaId.Keyboard;
-            this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.IsKeyboardFocusableFalseButDisabled;
+            Info.HowToFix = HowToFix.IsKeyboardFocusableFalseButDisabled;
+            Info.Standard = A11yCriteriaId.Keyboard;
+            Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsKeyboardFocusableFalseButOffscreen.cs
+++ b/src/Rules/Library/IsKeyboardFocusableFalseButOffscreen.cs
@@ -14,11 +14,11 @@ namespace Axe.Windows.Rules.Library
     {
         public IsKeyboardFocusableFalseButOffscreen()
         {
-            this.Info.Description = Descriptions.IsKeyboardFocusableFalseButOffscreen;
-            this.Info.HowToFix = HowToFix.IsKeyboardFocusableFalseButOffscreen;
-            this.Info.Standard = A11yCriteriaId.Keyboard;
-            this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.IsKeyboardFocusableFalseButOffscreen;
+            Info.HowToFix = HowToFix.IsKeyboardFocusableFalseButOffscreen;
+            Info.Standard = A11yCriteriaId.Keyboard;
+            Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsKeyboardFocusableForCustomShouldBeTrue.cs
+++ b/src/Rules/Library/IsKeyboardFocusableForCustomShouldBeTrue.cs
@@ -16,11 +16,11 @@ namespace Axe.Windows.Rules.Library
     {
         public IsKeyboardFocusableForCustomShouldBeTrue()
         {
-            this.Info.Description = Descriptions.IsKeyboardFocusableForCustomShouldBeTrue;
-            this.Info.HowToFix = HowToFix.IsKeyboardFocusableForCustomShouldBeTrue;
-            this.Info.Standard = A11yCriteriaId.Keyboard;
-            this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            Info.Description = Descriptions.IsKeyboardFocusableForCustomShouldBeTrue;
+            Info.HowToFix = HowToFix.IsKeyboardFocusableForCustomShouldBeTrue;
+            Info.Standard = A11yCriteriaId.Keyboard;
+            Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            Info.ErrorCode = EvaluationCode.Warning;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsKeyboardFocusableForListItemShouldBeTrue.cs
+++ b/src/Rules/Library/IsKeyboardFocusableForListItemShouldBeTrue.cs
@@ -17,11 +17,11 @@ namespace Axe.Windows.Rules.Library
     {
         public IsKeyboardFocusableForListItemShouldBeTrue()
         {
-            this.Info.Description = Descriptions.IsKeyboardFocusableForListItemShouldBeTrue;
-            this.Info.HowToFix = HowToFix.IsKeyboardFocusableForListItemShouldBeTrue;
-            this.Info.Standard = A11yCriteriaId.Keyboard;
-            this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            Info.Description = Descriptions.IsKeyboardFocusableForListItemShouldBeTrue;
+            Info.HowToFix = HowToFix.IsKeyboardFocusableForListItemShouldBeTrue;
+            Info.Standard = A11yCriteriaId.Keyboard;
+            Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            Info.ErrorCode = EvaluationCode.Warning;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsKeyboardFocusableOnEmptyContainer.cs
+++ b/src/Rules/Library/IsKeyboardFocusableOnEmptyContainer.cs
@@ -14,11 +14,11 @@ namespace Axe.Windows.Rules.Library
     {
         public IsKeyboardFocusableOnEmptyContainer()
         {
-            this.Info.Description = Descriptions.IsKeyboardFocusableOnEmptyContainer;
-            this.Info.HowToFix = HowToFix.IsKeyboardFocusableOnEmptyContainer;
-            this.Info.Standard = A11yCriteriaId.Keyboard;
-            this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.IsKeyboardFocusableOnEmptyContainer;
+            Info.HowToFix = HowToFix.IsKeyboardFocusableOnEmptyContainer;
+            Info.Standard = A11yCriteriaId.Keyboard;
+            Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsKeyboardFocusableShouldBeFalse.cs
+++ b/src/Rules/Library/IsKeyboardFocusableShouldBeFalse.cs
@@ -14,11 +14,11 @@ namespace Axe.Windows.Rules.Library
     {
         public IsKeyboardFocusableShouldBeFalse()
         {
-            this.Info.Description = Descriptions.IsKeyboardFocusableShouldBeFalse;
-            this.Info.HowToFix = HowToFix.IsKeyboardFocusableShouldBeFalse;
-            this.Info.Standard = A11yCriteriaId.Keyboard;
-            this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            Info.Description = Descriptions.IsKeyboardFocusableShouldBeFalse;
+            Info.HowToFix = HowToFix.IsKeyboardFocusableShouldBeFalse;
+            Info.Standard = A11yCriteriaId.Keyboard;
+            Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            Info.ErrorCode = EvaluationCode.Warning;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsKeyboardFocusableShouldBeTrue.cs
+++ b/src/Rules/Library/IsKeyboardFocusableShouldBeTrue.cs
@@ -17,11 +17,11 @@ namespace Axe.Windows.Rules.Library
     {
         public IsKeyboardFocusableShouldBeTrue()
         {
-            this.Info.Description = Descriptions.IsKeyboardFocusableShouldBeTrue;
-            this.Info.HowToFix = HowToFix.IsKeyboardFocusableShouldBeTrue;
-            this.Info.Standard = A11yCriteriaId.Keyboard;
-            this.Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            Info.Description = Descriptions.IsKeyboardFocusableShouldBeTrue;
+            Info.HowToFix = HowToFix.IsKeyboardFocusableShouldBeTrue;
+            Info.Standard = A11yCriteriaId.Keyboard;
+            Info.PropertyID = PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            Info.ErrorCode = EvaluationCode.Warning;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/IsKeyboardFocusableTopLevelTextPattern.cs
+++ b/src/Rules/Library/IsKeyboardFocusableTopLevelTextPattern.cs
@@ -17,11 +17,11 @@ namespace Axe.Windows.Rules.Library
     {
         public IsKeyboardFocusableTopLevelTextPattern()
         {
-            this.Info.Description = Descriptions.IsKeyboardFocusableTopLevelTextPattern;
-            this.Info.HowToFix = HowToFix.IsKeyboardFocusableTopLevelTextPattern;
-            this.Info.Standard = A11yCriteriaId.Keyboard;
-            this.Info.PropertyID = Axe.Windows.Core.Types.PropertyType.UIA_IsKeyboardFocusablePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            Info.Description = Descriptions.IsKeyboardFocusableTopLevelTextPattern;
+            Info.HowToFix = HowToFix.IsKeyboardFocusableTopLevelTextPattern;
+            Info.Standard = A11yCriteriaId.Keyboard;
+            Info.PropertyID = Axe.Windows.Core.Types.PropertyType.UIA_IsKeyboardFocusablePropertyId;
+            Info.ErrorCode = EvaluationCode.Warning;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ItemStatusExists.cs
+++ b/src/Rules/Library/ItemStatusExists.cs
@@ -14,11 +14,11 @@ namespace Axe.Windows.Rules.Library
     {
         public ItemStatusExists()
         {
-            this.Info.Description = Descriptions.ItemStatusExists;
-            this.Info.HowToFix = HowToFix.ItemStatusExists;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_ItemStatusPropertyId;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.ItemStatusExists;
+            Info.HowToFix = HowToFix.ItemStatusExists;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_ItemStatusPropertyId;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ItemTypeRecommended.cs
+++ b/src/Rules/Library/ItemTypeRecommended.cs
@@ -14,11 +14,11 @@ namespace Axe.Windows.Rules.Library
     {
         public ItemTypeRecommended()
         {
-            this.Info.Description = Descriptions.ItemTypeRecommended;
-            this.Info.HowToFix = HowToFix.ItemTypeRecommended;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_ItemTypePropertyId;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.ItemTypeRecommended;
+            Info.HowToFix = HowToFix.ItemTypeRecommended;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_ItemTypePropertyId;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LandmarkBannerIsTopLevel.cs
+++ b/src/Rules/Library/LandmarkBannerIsTopLevel.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public LandmarkBannerIsTopLevel()
         {
-            this.Info.Description = Descriptions.LandmarkBannerIsTopLevel;
-            this.Info.HowToFix = HowToFix.LandmarkBannerIsTopLevel;
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.LandmarkBannerIsTopLevel;
+            Info.HowToFix = HowToFix.LandmarkBannerIsTopLevel;
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LandmarkComplementaryIsTopLevel.cs
+++ b/src/Rules/Library/LandmarkComplementaryIsTopLevel.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public LandmarkComplementaryIsTopLevel()
         {
-            this.Info.Description = Descriptions.LandmarkComplementaryIsTopLevel;
-            this.Info.HowToFix = HowToFix.LandmarkComplementaryIsTopLevel;
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.LandmarkComplementaryIsTopLevel;
+            Info.HowToFix = HowToFix.LandmarkComplementaryIsTopLevel;
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LandmarkContentInfoIsTopLevel.cs
+++ b/src/Rules/Library/LandmarkContentInfoIsTopLevel.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public LandmarkContentInfoIsTopLevel()
         {
-            this.Info.Description = Descriptions.LandmarkContentInfoIsTopLevel;
-            this.Info.HowToFix = HowToFix.LandmarkContentInfoIsTopLevel;
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.LandmarkContentInfoIsTopLevel;
+            Info.HowToFix = HowToFix.LandmarkContentInfoIsTopLevel;
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LandmarkMainIsTopLevel.cs
+++ b/src/Rules/Library/LandmarkMainIsTopLevel.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public LandmarkMainIsTopLevel()
         {
-            this.Info.Description = Descriptions.LandmarkMainIsTopLevel;
-            this.Info.HowToFix = HowToFix.LandmarkMainIsTopLevel;
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.LandmarkMainIsTopLevel;
+            Info.HowToFix = HowToFix.LandmarkMainIsTopLevel;
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LandmarkNoDuplicateBanner.cs
+++ b/src/Rules/Library/LandmarkNoDuplicateBanner.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
     {
         public LandmarkNoDuplicateBanner()
         {
-            this.Info.Description = Descriptions.LandmarkNoDuplicateBanner;
-            this.Info.HowToFix = HowToFix.LandmarkNoDuplicateBanner;
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.LandmarkNoDuplicateBanner;
+            Info.HowToFix = HowToFix.LandmarkNoDuplicateBanner;
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LandmarkNoDuplicateContentInfo.cs
+++ b/src/Rules/Library/LandmarkNoDuplicateContentInfo.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
     {
         public LandmarkNoDuplicateContentInfo()
         {
-            this.Info.Description = Descriptions.LandmarkNoDuplicateContentInfo;
-            this.Info.HowToFix = HowToFix.LandmarkNoDuplicateContentInfo;
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.LandmarkNoDuplicateContentInfo;
+            Info.HowToFix = HowToFix.LandmarkNoDuplicateContentInfo;
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ListItemSiblingsUnique.cs
+++ b/src/Rules/Library/ListItemSiblingsUnique.cs
@@ -20,10 +20,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ListItemSiblingsUnique()
         {
-            this.Info.Description = Descriptions.ListItemSiblingsUnique;
-            this.Info.HowToFix = HowToFix.ListItemSiblingsUnique;
-            this.Info.Standard = A11yCriteriaId.NameRoleValue;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            Info.Description = Descriptions.ListItemSiblingsUnique;
+            Info.HowToFix = HowToFix.ListItemSiblingsUnique;
+            Info.Standard = A11yCriteriaId.NameRoleValue;
+            Info.ErrorCode = EvaluationCode.Warning;
         }
 
         public override bool PassesTest(IA11yElement e)
@@ -36,7 +36,7 @@ namespace Axe.Windows.Rules.Library
                 & Name.Is(e.Name)
                 & LocalizedControlType.Is(e.LocalizedControlType));
             var count = siblings.GetValue(e);
-            if (count < 1) throw new AxeWindowsException(ErrorMessages.NoElementFound.WithParameters(this.Info.ID));
+            if (count < 1) throw new AxeWindowsException(ErrorMessages.NoElementFound.WithParameters(Info.ID));
 
             return count == 1;
         }

--- a/src/Rules/Library/LocalizedControlTypeExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/LocalizedControlTypeExcludesPrivateUnicodeCharacters.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public LocalizedControlTypeExcludesPrivateUnicodeCharacters()
         {
-            this.Info.Description = string.Format(CultureInfo.CurrentCulture, Descriptions.PropertyExcludesPrivateUnicodeCharacters, LocalizedControlType.PropertyDescription);
-            this.Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.PropertyExcludesPrivateUnicodeCharacters, LocalizedControlType.PropertyDescription);
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = string.Format(CultureInfo.CurrentCulture, Descriptions.PropertyExcludesPrivateUnicodeCharacters, LocalizedControlType.PropertyDescription);
+            Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.PropertyExcludesPrivateUnicodeCharacters, LocalizedControlType.PropertyDescription);
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LocalizedControlTypeIsNotCustom.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotCustom.cs
@@ -18,11 +18,11 @@ namespace Axe.Windows.Rules.Library
     {
         public LocalizedControlTypeIsNotCustom()
         {
-            this.Info.Description = Descriptions.LocalizedControlTypeNotCustom;
-            this.Info.HowToFix = HowToFix.LocalizedControlTypeNotCustom;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.LocalizedControlTypeNotCustom;
+            Info.HowToFix = HowToFix.LocalizedControlTypeNotCustom;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
@@ -18,11 +18,11 @@ namespace Axe.Windows.Rules.Library
     {
         public LocalizedControlTypeIsNotCustomWPFGridCell()
         {
-            this.Info.Description = Descriptions.LocalizedControlTypeNotCustom;
-            this.Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.LocalizedControlTypeNotCustomWPFGridCell, HowToFix.LocalizedControlTypeNotCustom);
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.LocalizedControlTypeNotCustom;
+            Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.LocalizedControlTypeNotCustomWPFGridCell, HowToFix.LocalizedControlTypeNotCustom);
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LocalizedControlTypeIsNotEmpty.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotEmpty.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public LocalizedControlTypeIsNotEmpty()
         {
-            this.Info.Description = Descriptions.LocalizedControlTypeNotEmpty;
-            this.Info.HowToFix = HowToFix.LocalizedControlTypeNotEmpty;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.LocalizedControlTypeNotEmpty;
+            Info.HowToFix = HowToFix.LocalizedControlTypeNotEmpty;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LocalizedControlTypeIsNotNull.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotNull.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public LocalizedControlTypeIsNotNull()
         {
-            this.Info.Description = Descriptions.LocalizedControlTypeNotNull;
-            this.Info.HowToFix = HowToFix.LocalizedControlTypeNotNull;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.LocalizedControlTypeNotNull;
+            Info.HowToFix = HowToFix.LocalizedControlTypeNotNull;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LocalizedControlTypeIsNotWhiteSpace.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotWhiteSpace.cs
@@ -14,11 +14,11 @@ namespace Axe.Windows.Rules.Library
     {
         public LocalizedControlTypeIsNotWhiteSpace()
         {
-            this.Info.Description = Descriptions.LocalizedControlTypeNotWhiteSpace;
-            this.Info.HowToFix = HowToFix.LocalizedControlTypeNotWhiteSpace;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.LocalizedControlTypeNotWhiteSpace;
+            Info.HowToFix = HowToFix.LocalizedControlTypeNotWhiteSpace;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LocalizedControlTypeIsReasonable.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsReasonable.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public LocalizedControlTypeIsReasonable()
         {
-            this.Info.Description = Descriptions.LocalizedControlTypeReasonable;
-            this.Info.HowToFix = HowToFix.LocalizedControlTypeReasonable;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            Info.Description = Descriptions.LocalizedControlTypeReasonable;
+            Info.HowToFix = HowToFix.LocalizedControlTypeReasonable;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_LocalizedControlTypePropertyId;
+            Info.ErrorCode = EvaluationCode.Warning;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters()
         {
-            this.Info.Description = string.Format(CultureInfo.CurrentCulture, Descriptions.PropertyExcludesPrivateUnicodeCharacters, LocalizedLandmarkType.PropertyDescription);
-            this.Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.PropertyExcludesPrivateUnicodeCharacters, LocalizedLandmarkType.PropertyDescription);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = string.Format(CultureInfo.CurrentCulture, Descriptions.PropertyExcludesPrivateUnicodeCharacters, LocalizedLandmarkType.PropertyDescription);
+            Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.PropertyExcludesPrivateUnicodeCharacters, LocalizedLandmarkType.PropertyDescription);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LocalizedLandmarkTypeIsReasonableLength.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeIsReasonableLength.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
 
         public LocalizedLandmarkTypeIsReasonableLength()
         {
-            this.Info.Description = Descriptions.LocalizedLandmarkTypeIsReasonableLength;
-            this.Info.HowToFix = HowToFix.LocalizedLandmarkTypeIsReasonableLength;
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.LocalizedLandmarkTypeIsReasonableLength;
+            Info.HowToFix = HowToFix.LocalizedLandmarkTypeIsReasonableLength;
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LocalizedLandmarkTypeNotCustom.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeNotCustom.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public LocalizedLandmarkTypeNotCustom()
         {
-            this.Info.Description = Descriptions.LocalizedLandmarkTypeNotCustom;
-            this.Info.HowToFix = HowToFix.LocalizedLandmarkTypeNotCustom;
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.LocalizedLandmarkTypeNotCustom;
+            Info.HowToFix = HowToFix.LocalizedLandmarkTypeNotCustom;
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LocalizedLandmarkTypeNotEmpty.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeNotEmpty.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public LocalizedLandmarkTypeNotEmpty()
         {
-            this.Info.Description = Descriptions.LocalizedLandmarkTypeNotEmpty;
-            this.Info.HowToFix = HowToFix.LocalizedLandmarkTypeNotEmpty;
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.LocalizedLandmarkTypeNotEmpty;
+            Info.HowToFix = HowToFix.LocalizedLandmarkTypeNotEmpty;
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LocalizedLandmarkTypeNotNull.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeNotNull.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public LocalizedLandmarkTypeNotNull()
         {
-            this.Info.Description = Descriptions.LocalizedLandmarkTypeNotNull;
-            this.Info.HowToFix = HowToFix.LocalizedLandmarkTypeNotNull;
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.LocalizedLandmarkTypeNotNull;
+            Info.HowToFix = HowToFix.LocalizedLandmarkTypeNotNull;
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/LocalizedLandmarkTypeNotWhiteSpace.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeNotWhiteSpace.cs
@@ -13,10 +13,10 @@ namespace Axe.Windows.Rules.Library
     {
         public LocalizedLandmarkTypeNotWhiteSpace()
         {
-            this.Info.Description = Descriptions.LocalizedLandmarkTypeNotWhiteSpace;
-            this.Info.HowToFix = HowToFix.LocalizedLandmarkTypeNotWhiteSpace;
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.LocalizedLandmarkTypeNotWhiteSpace;
+            Info.HowToFix = HowToFix.LocalizedLandmarkTypeNotWhiteSpace;
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameExcludesControlType.cs
+++ b/src/Rules/Library/NameExcludesControlType.cs
@@ -19,11 +19,11 @@ namespace Axe.Windows.Rules.Library
     {
         public NameExcludesControlType()
         {
-            this.Info.Description = Descriptions.NameExcludesControlType;
-            this.Info.HowToFix = HowToFix.NameExcludesControlType;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.NameExcludesControlType;
+            Info.HowToFix = HowToFix.NameExcludesControlType;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameExcludesLocalizedControlType.cs
+++ b/src/Rules/Library/NameExcludesLocalizedControlType.cs
@@ -16,11 +16,11 @@ namespace Axe.Windows.Rules.Library
     {
         public NameExcludesLocalizedControlType()
         {
-            this.Info.Description = Descriptions.NameExcludesLocalizedControlType;
-            this.Info.HowToFix = HowToFix.NameExcludesLocalizedControlType;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.NameExcludesLocalizedControlType;
+            Info.HowToFix = HowToFix.NameExcludesLocalizedControlType;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/NameExcludesPrivateUnicodeCharacters.cs
@@ -16,11 +16,11 @@ namespace Axe.Windows.Rules.Library
     {
         public NameExcludesPrivateUnicodeCharacters()
         {
-            this.Info.Description = string.Format(CultureInfo.CurrentCulture, Descriptions.PropertyExcludesPrivateUnicodeCharacters, Name.PropertyDescription);
-            this.Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.PropertyExcludesPrivateUnicodeCharacters, Name.PropertyDescription);
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = string.Format(CultureInfo.CurrentCulture, Descriptions.PropertyExcludesPrivateUnicodeCharacters, Name.PropertyDescription);
+            Info.HowToFix = string.Format(CultureInfo.CurrentCulture, HowToFix.PropertyExcludesPrivateUnicodeCharacters, Name.PropertyDescription);
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameIsEmptyButElementIsNotKeyboardFocusable.cs
+++ b/src/Rules/Library/NameIsEmptyButElementIsNotKeyboardFocusable.cs
@@ -17,11 +17,11 @@ namespace Axe.Windows.Rules.Library
     {
         public NameIsEmptyButElementIsNotKeyboardFocusable()
         {
-            this.Info.Description = Descriptions.NameEmptyButElementNotKeyboardFocusable;
-            this.Info.HowToFix = HowToFix.NameEmptyButElementNotKeyboardFocusable;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.NameEmptyButElementNotKeyboardFocusable;
+            Info.HowToFix = HowToFix.NameEmptyButElementNotKeyboardFocusable;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameIsInformative.cs
+++ b/src/Rules/Library/NameIsInformative.cs
@@ -16,11 +16,11 @@ namespace Axe.Windows.Rules.Library
     {
         public NameIsInformative()
         {
-            this.Info.Description = Descriptions.NameIsInformative;
-            this.Info.HowToFix = HowToFix.NameIsInformative;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.NameIsInformative;
+            Info.HowToFix = HowToFix.NameIsInformative;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameIsNotEmpty.cs
+++ b/src/Rules/Library/NameIsNotEmpty.cs
@@ -16,11 +16,11 @@ namespace Axe.Windows.Rules.Library
     {
         public NameIsNotEmpty()
         {
-            this.Info.Description = Descriptions.NameNotEmpty;
-            this.Info.HowToFix = HowToFix.NameNotEmpty;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.NameNotEmpty;
+            Info.HowToFix = HowToFix.NameNotEmpty;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameIsNotNull.cs
+++ b/src/Rules/Library/NameIsNotNull.cs
@@ -16,11 +16,11 @@ namespace Axe.Windows.Rules.Library
     {
         public NameIsNotNull()
         {
-            this.Info.Description = Descriptions.NameNotNull;
-            this.Info.HowToFix = HowToFix.NameNotNull;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.NameNotNull;
+            Info.HowToFix = HowToFix.NameNotNull;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameIsNotWhiteSpace.cs
+++ b/src/Rules/Library/NameIsNotWhiteSpace.cs
@@ -13,11 +13,11 @@ namespace Axe.Windows.Rules.Library
     {
         public NameIsNotWhiteSpace()
         {
-            this.Info.Description = Descriptions.NameNotWhiteSpace;
-            this.Info.HowToFix = HowToFix.NameNotWhiteSpace;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.NameNotWhiteSpace;
+            Info.HowToFix = HowToFix.NameNotWhiteSpace;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameIsNullButElementIsNotKeyboardFocusable.cs
+++ b/src/Rules/Library/NameIsNullButElementIsNotKeyboardFocusable.cs
@@ -16,11 +16,11 @@ namespace Axe.Windows.Rules.Library
     {
         public NameIsNullButElementIsNotKeyboardFocusable()
         {
-            this.Info.Description = Descriptions.NameNullButElementNotKeyboardFocusable;
-            this.Info.HowToFix = HowToFix.NameNullButElementNotKeyboardFocusable;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.NameNullButElementNotKeyboardFocusable;
+            Info.HowToFix = HowToFix.NameNullButElementNotKeyboardFocusable;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameIsReasonableLength.cs
+++ b/src/Rules/Library/NameIsReasonableLength.cs
@@ -18,10 +18,10 @@ namespace Axe.Windows.Rules.Library
         public NameIsReasonableLength()
         {
             Info.Description = Descriptions.NameReasonableLength;
-            this.Info.HowToFix = HowToFix.NameReasonableLength;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.HowToFix = HowToFix.NameReasonableLength;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameNoSiblingsOfSameType.cs
+++ b/src/Rules/Library/NameNoSiblingsOfSameType.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public NameNoSiblingsOfSameType()
         {
-            this.Info.Description = Descriptions.NameNoSiblingsOfSameType;
-            this.Info.HowToFix = HowToFix.NameNoSiblingsOfSameType;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.NameNoSiblingsOfSameType;
+            Info.HowToFix = HowToFix.NameNoSiblingsOfSameType;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameOnCustomWithParentWPFDataItem.cs
+++ b/src/Rules/Library/NameOnCustomWithParentWPFDataItem.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public NameOnCustomWithParentWPFDataItem()
         {
-            this.Info.Description = Descriptions.NameOnCustomWithParentWPFDataItem;
-            this.Info.HowToFix = HowToFix.NameOnCustomWithParentWPFDataItem;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.NameOnCustomWithParentWPFDataItem;
+            Info.HowToFix = HowToFix.NameOnCustomWithParentWPFDataItem;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameOnOptionalType.cs
+++ b/src/Rules/Library/NameOnOptionalType.cs
@@ -14,11 +14,11 @@ namespace Axe.Windows.Rules.Library
     {
         public NameOnOptionalType()
         {
-            this.Info.Description = Descriptions.NameOnOptionalType;
-            this.Info.HowToFix = HowToFix.NameOnOptionalType;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.NameOnOptionalType;
+            Info.HowToFix = HowToFix.NameOnOptionalType;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/NameWithValidBoundingRectangle.cs
+++ b/src/Rules/Library/NameWithValidBoundingRectangle.cs
@@ -14,11 +14,11 @@ namespace Axe.Windows.Rules.Library
     {
         public NameWithValidBoundingRectangle()
         {
-            this.Info.Description = Descriptions.NameWithValidBoundingRectangle;
-            this.Info.HowToFix = HowToFix.NameWithValidBoundingRectangle;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Warning;
+            Info.Description = Descriptions.NameWithValidBoundingRectangle;
+            Info.HowToFix = HowToFix.NameWithValidBoundingRectangle;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            Info.ErrorCode = EvaluationCode.Warning;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/OrientationPropertyExists.cs
+++ b/src/Rules/Library/OrientationPropertyExists.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public OrientationPropertyExists()
         {
-            this.Info.Description = Descriptions.OrientationPropertyExists;
-            this.Info.HowToFix = HowToFix.OrientationPropertyExists;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_OrientationPropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.OrientationPropertyExists;
+            Info.HowToFix = HowToFix.OrientationPropertyExists;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_OrientationPropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs
+++ b/src/Rules/Library/ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public ParentChildShouldNotHaveSameNameAndLocalizedControlType()
         {
-            this.Info.Description = Descriptions.ParentChildShouldNotHaveSameNameAndLocalizedControlType;
-            this.Info.HowToFix = HowToFix.ParentChildShouldNotHaveSameNameAndLocalizedControlType;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_NamePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ParentChildShouldNotHaveSameNameAndLocalizedControlType;
+            Info.HowToFix = HowToFix.ParentChildShouldNotHaveSameNameAndLocalizedControlType;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_NamePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/ProgressBarRangeValue.cs
+++ b/src/Rules/Library/ProgressBarRangeValue.cs
@@ -15,11 +15,11 @@ namespace Axe.Windows.Rules.Library
     {
         public ProgressBarRangeValue()
         {
-            this.Info.Description = Descriptions.ProgressBarRangeValue;
-            this.Info.HowToFix = HowToFix.ProgressBarRangeValue;
-            this.Info.Standard = A11yCriteriaId.ObjectInformation;
-            this.Info.PropertyID = PropertyType.UIA_IsRangeValuePatternAvailablePropertyId;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.ProgressBarRangeValue;
+            Info.HowToFix = HowToFix.ProgressBarRangeValue;
+            Info.Standard = A11yCriteriaId.ObjectInformation;
+            Info.PropertyID = PropertyType.UIA_IsRangeValuePatternAvailablePropertyId;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/SelectionItemPatternSingleSelection.cs
+++ b/src/Rules/Library/SelectionItemPatternSingleSelection.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
     {
         public SelectionItemPatternSingleSelection()
         {
-            this.Info.Description = Descriptions.SelectionItemPatternSingleSelection;
-            this.Info.HowToFix = HowToFix.SelectionItemPatternSingleSelection;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.SelectionItemPatternSingleSelection;
+            Info.HowToFix = HowToFix.SelectionItemPatternSingleSelection;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/SelectionPatternSelectionRequired.cs
+++ b/src/Rules/Library/SelectionPatternSelectionRequired.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
     {
         public SelectionPatternSelectionRequired()
         {
-            this.Info.Description = Descriptions.SelectionPatternSelectionRequired;
-            this.Info.HowToFix = HowToFix.SelectionPatternSelectionRequired;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.SelectionPatternSelectionRequired;
+            Info.HowToFix = HowToFix.SelectionPatternSelectionRequired;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/SelectionPatternSingleSelection.cs
+++ b/src/Rules/Library/SelectionPatternSingleSelection.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public SelectionPatternSingleSelection()
         {
-            this.Info.Description = Descriptions.SelectionPatternSingleSelection;
-            this.Info.HowToFix = HowToFix.SelectionPatternSingleSelection;
-            this.Info.Standard = A11yCriteriaId.AvailableActions;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.SelectionPatternSingleSelection;
+            Info.HowToFix = HowToFix.SelectionPatternSingleSelection;
+            Info.Standard = A11yCriteriaId.AvailableActions;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/SiblingUniqueAndFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndFocusable.cs
@@ -37,10 +37,10 @@ namespace Axe.Windows.Rules.Library
 
         public SiblingUniqueAndFocusable()
         {
-            this.Info.Description = Descriptions.SiblingUniqueAndFocusable;
-            this.Info.HowToFix = HowToFix.SiblingUniqueAndFocusable;
-            this.Info.Standard = A11yCriteriaId.NameRoleValue;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.SiblingUniqueAndFocusable;
+            Info.HowToFix = HowToFix.SiblingUniqueAndFocusable;
+            Info.Standard = A11yCriteriaId.NameRoleValue;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)
@@ -52,7 +52,7 @@ namespace Axe.Windows.Rules.Library
                 & Name.Is(e.Name)
                 & LocalizedControlType.Is(e.LocalizedControlType));
             var count = siblings.GetValue(e);
-            if (count < 1) throw new AxeWindowsException(ErrorMessages.NoElementFound.WithParameters(this.Info.ID));
+            if (count < 1) throw new AxeWindowsException(ErrorMessages.NoElementFound.WithParameters(Info.ID));
 
             return count == 1;
         }

--- a/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
@@ -36,10 +36,10 @@ namespace Axe.Windows.Rules.Library
 
         public SiblingUniqueAndNotFocusable()
         {
-            this.Info.Description = Descriptions.SiblingUniqueAndNotFocusable;
-            this.Info.HowToFix = HowToFix.SiblingUniqueAndNotFocusable;
-            this.Info.Standard = A11yCriteriaId.NameRoleValue;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.SiblingUniqueAndNotFocusable;
+            Info.HowToFix = HowToFix.SiblingUniqueAndNotFocusable;
+            Info.Standard = A11yCriteriaId.NameRoleValue;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)
@@ -51,7 +51,7 @@ namespace Axe.Windows.Rules.Library
                 & Name.Is(e.Name)
                 & LocalizedControlType.Is(e.LocalizedControlType));
             var count = siblings.GetValue(e);
-            if (count < 1) throw new AxeWindowsException(ErrorMessages.NoElementFound.WithParameters(this.Info.ID));
+            if (count < 1) throw new AxeWindowsException(ErrorMessages.NoElementFound.WithParameters(Info.ID));
 
             return count == 1;
         }

--- a/src/Rules/Library/SplitButtonInvokeAndTogglePatterns.cs
+++ b/src/Rules/Library/SplitButtonInvokeAndTogglePatterns.cs
@@ -14,10 +14,10 @@ namespace Axe.Windows.Rules.Library
     {
         public SplitButtonInvokeAndTogglePatterns()
         {
-            this.Info.Description = Descriptions.SplitButtonInvokeAndTogglePatterns;
-            this.Info.HowToFix = HowToFix.SplitButtonInvokeAndTogglePatterns;
-            this.Info.Standard = A11yCriteriaId.NameRoleValue;
-            this.Info.ErrorCode = EvaluationCode.Error;
+            Info.Description = Descriptions.SplitButtonInvokeAndTogglePatterns;
+            Info.HowToFix = HowToFix.SplitButtonInvokeAndTogglePatterns;
+            Info.Standard = A11yCriteriaId.NameRoleValue;
+            Info.ErrorCode = EvaluationCode.Error;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Button.cs
+++ b/src/Rules/Library/Structure/ContentView/Button.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewButtonStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.ButtonStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.ButtonStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.ButtonStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.ButtonStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Calendar.cs
+++ b/src/Rules/Library/Structure/ContentView/Calendar.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewCalendarStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.CalendarStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.CalendarStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.CalendarStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.CalendarStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/CheckBox.cs
+++ b/src/Rules/Library/Structure/ContentView/CheckBox.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewCheckBoxStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.CheckBoxStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.CheckBoxStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.CheckBoxStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.CheckBoxStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/ComboBox.cs
+++ b/src/Rules/Library/Structure/ContentView/ComboBox.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewComboBoxStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.ComboBoxStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.ComboBoxStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.ComboBoxStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.ComboBoxStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/DataGrid.cs
+++ b/src/Rules/Library/Structure/ContentView/DataGrid.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewDataGridStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.DataGridStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.DataGridStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.DataGridStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.DataGridStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Edit.cs
+++ b/src/Rules/Library/Structure/ContentView/Edit.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewEditStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.EditStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.EditStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.EditStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.EditStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Hyperlink.cs
+++ b/src/Rules/Library/Structure/ContentView/Hyperlink.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewHyperlinkStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.HyperlinkStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.HyperlinkStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.HyperlinkStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.HyperlinkStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/List.cs
+++ b/src/Rules/Library/Structure/ContentView/List.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewListStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.ListStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.ListStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.ListStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.ListStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/ListItem.cs
+++ b/src/Rules/Library/Structure/ContentView/ListItem.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewListItemStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.ListItemStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.ListItemStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.ListItemStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.ListItemStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Menu.cs
+++ b/src/Rules/Library/Structure/ContentView/Menu.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewMenuStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.MenuStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.MenuStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.MenuStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.MenuStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/ProgressBar.cs
+++ b/src/Rules/Library/Structure/ContentView/ProgressBar.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewProgressBarStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.ProgressBarStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.ProgressBarStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.ProgressBarStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.ProgressBarStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/RadioButton.cs
+++ b/src/Rules/Library/Structure/ContentView/RadioButton.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewRadioButtonStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.RadioButtonStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.RadioButtonStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.RadioButtonStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.RadioButtonStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Slider.cs
+++ b/src/Rules/Library/Structure/ContentView/Slider.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewSliderStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.SliderStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.SliderStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.SliderStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.SliderStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Spinner.cs
+++ b/src/Rules/Library/Structure/ContentView/Spinner.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewSpinnerStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.SpinnerStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.SpinnerStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.SpinnerStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.SpinnerStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/SplitButton.cs
+++ b/src/Rules/Library/Structure/ContentView/SplitButton.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewSplitButtonStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.SplitButtonStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.SplitButtonStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.SplitButtonStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.SplitButtonStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/StatusBar.cs
+++ b/src/Rules/Library/Structure/ContentView/StatusBar.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewStatusBarStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.StatusBarStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.StatusBarStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.StatusBarStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.StatusBarStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Tab.cs
+++ b/src/Rules/Library/Structure/ContentView/Tab.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewTabStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.TabStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.TabStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.TabStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.TabStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/Tree.cs
+++ b/src/Rules/Library/Structure/ContentView/Tree.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewTreeStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.TreeStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.TreeStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.TreeStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.TreeStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ContentView/TreeItem.cs
+++ b/src/Rules/Library/Structure/ContentView/TreeItem.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ContentViewTreeItemStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ContentView.TreeItemStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.TreeItemStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ContentView.TreeItemStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ContentView.TreeItemStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Button.cs
+++ b/src/Rules/Library/Structure/ControlView/Button.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewButtonStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.ButtonStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ButtonStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.ButtonStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ButtonStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Calendar.cs
+++ b/src/Rules/Library/Structure/ControlView/Calendar.cs
@@ -15,10 +15,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewCalendarStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.CalendarStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.CalendarStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.CalendarStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.CalendarStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/CheckBox.cs
+++ b/src/Rules/Library/Structure/ControlView/CheckBox.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewCheckBoxStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.CheckBoxStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.CheckBoxStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.CheckBoxStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.CheckBoxStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/ComboBox.cs
+++ b/src/Rules/Library/Structure/ControlView/ComboBox.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewComboBoxStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.ComboBoxStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ComboBoxStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.ComboBoxStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ComboBoxStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/DataGrid.cs
+++ b/src/Rules/Library/Structure/ControlView/DataGrid.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewDataGridStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.DataGridStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.DataGridStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.DataGridStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.DataGridStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Edit.cs
+++ b/src/Rules/Library/Structure/ControlView/Edit.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewEditStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.EditStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.EditStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.EditStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.EditStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Header.cs
+++ b/src/Rules/Library/Structure/ControlView/Header.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewHeaderStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.HeaderStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.HeaderStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.HeaderStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.HeaderStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/HeaderItem.cs
+++ b/src/Rules/Library/Structure/ControlView/HeaderItem.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewHeaderItemStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.HeaderItemStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.HeaderItemStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.HeaderItemStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.HeaderItemStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Hyperlink.cs
+++ b/src/Rules/Library/Structure/ControlView/Hyperlink.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewHyperlinkStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.HyperlinkStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.HyperlinkStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.HyperlinkStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.HyperlinkStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Image.cs
+++ b/src/Rules/Library/Structure/ControlView/Image.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewImageStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.ImageStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ImageStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.ImageStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ImageStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/List.cs
+++ b/src/Rules/Library/Structure/ControlView/List.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewListStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.ListStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ListStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.ListStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ListStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/ListItem.cs
+++ b/src/Rules/Library/Structure/ControlView/ListItem.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewListItemStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.ListItemStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ListItemStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.ListItemStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ListItemStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Menu.cs
+++ b/src/Rules/Library/Structure/ControlView/Menu.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewMenuStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.MenuStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.MenuStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.MenuStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.MenuStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/ProgressBar.cs
+++ b/src/Rules/Library/Structure/ControlView/ProgressBar.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewProgressBarStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.ProgressBarStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ProgressBarStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.ProgressBarStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ProgressBarStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/RadioButton.cs
+++ b/src/Rules/Library/Structure/ControlView/RadioButton.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewRadioButtonStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.RadioButtonStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.RadioButtonStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.RadioButtonStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.RadioButtonStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Scrollbar.cs
+++ b/src/Rules/Library/Structure/ControlView/Scrollbar.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewScrollbarStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.ScrollbarStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ScrollbarStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.ScrollbarStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ScrollbarStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/SemanticZoom.cs
+++ b/src/Rules/Library/Structure/ControlView/SemanticZoom.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewSemanticZoomStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.SemanticZoomStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.SemanticZoomStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.SemanticZoomStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.SemanticZoomStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Separator.cs
+++ b/src/Rules/Library/Structure/ControlView/Separator.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewSeparatorStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.SeparatorStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.SeparatorStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.SeparatorStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.SeparatorStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Slider.cs
+++ b/src/Rules/Library/Structure/ControlView/Slider.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewSliderStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.SliderStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.SliderStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.SliderStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.SliderStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Spinner.cs
+++ b/src/Rules/Library/Structure/ControlView/Spinner.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewSpinnerStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.SpinnerStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.SpinnerStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.SpinnerStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.SpinnerStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/SplitButton.cs
+++ b/src/Rules/Library/Structure/ControlView/SplitButton.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewSplitButtonStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.SplitButtonStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.SplitButtonStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.SplitButtonStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.SplitButtonStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/StatusBar.cs
+++ b/src/Rules/Library/Structure/ControlView/StatusBar.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewStatusBarStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.StatusBarStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.StatusBarStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.StatusBarStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.StatusBarStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Tab.cs
+++ b/src/Rules/Library/Structure/ControlView/Tab.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewTabStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.TabStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.TabStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.TabStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.TabStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Thumb.cs
+++ b/src/Rules/Library/Structure/ControlView/Thumb.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewThumbStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.ThumbStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ThumbStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.ThumbStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ThumbStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/ToolTip.cs
+++ b/src/Rules/Library/Structure/ControlView/ToolTip.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewToolTipStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.ToolTipStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ToolTipStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.ToolTipStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.ToolTipStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/Tree.cs
+++ b/src/Rules/Library/Structure/ControlView/Tree.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewTreeStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.TreeStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.TreeStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.TreeStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.TreeStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/Library/Structure/ControlView/TreeItem.cs
+++ b/src/Rules/Library/Structure/ControlView/TreeItem.cs
@@ -16,10 +16,10 @@ namespace Axe.Windows.Rules.Library
     {
         public ControlViewTreeItemStructure()
         {
-            this.Info.Description = Descriptions.Structure.WithParameters(ControlView.TreeItemStructure);
-            this.Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.TreeItemStructure);
-            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
-            this.Info.ErrorCode = EvaluationCode.NeedsReview;
+            Info.Description = Descriptions.Structure.WithParameters(ControlView.TreeItemStructure);
+            Info.HowToFix = HowToFix.Structure.WithParameters(ControlView.TreeItemStructure);
+            Info.Standard = A11yCriteriaId.InfoAndRelationships;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)

--- a/src/Rules/PropertyConditions/EnumProperty.cs
+++ b/src/Rules/PropertyConditions/EnumProperty.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules.Resources;
@@ -17,9 +17,9 @@ namespace Axe.Windows.Rules.PropertyConditions
         {
             if (!typeof(T).IsEnum) throw new InvalidOperationException(ErrorMessages.ExpectedEnumType);
 
-            this.PropertyID = propertyID;
-            this.Exists = CreatePropertyExistsCondition<int>(propertyID);
-            this.DoesNotExist = ~Exists;
+            PropertyID = propertyID;
+            Exists = CreatePropertyExistsCondition<int>(propertyID);
+            DoesNotExist = ~Exists;
         }
 
         private T GetPropertyValue(IA11yElement e)
@@ -34,7 +34,7 @@ namespace Axe.Windows.Rules.PropertyConditions
              * on a rule which may not care about the given enum value at all.
              */
 
-            if (!e.TryGetPropertyValue(this.PropertyID, out int i)) return default(T);
+            if (!e.TryGetPropertyValue(PropertyID, out int i)) return default(T);
             if (!Enum.IsDefined(typeof(T), i)) return default(T);
 
             return (T)Enum.ToObject(typeof(T), i);

--- a/src/Rules/PropertyConditions/IntProperty.cs
+++ b/src/Rules/PropertyConditions/IntProperty.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Rules.Extensions;
 using Axe.Windows.Rules.Resources;
@@ -27,8 +27,8 @@ namespace Axe.Windows.Rules.PropertyConditions
         public IntProperty(int propertyID, string propertyDescription)
             : base(e => e.GetPropertyValueOrDefault<int>(propertyID), propertyDescription)
         {
-            this.Exists = CreatePropertyExistsCondition<int>(propertyID);
-            this.DoesNotExist = ~Exists;
+            Exists = CreatePropertyExistsCondition<int>(propertyID);
+            DoesNotExist = ~Exists;
         }
     } // class
 } // namespace

--- a/src/Rules/PropertyConditions/StringProperty.cs
+++ b/src/Rules/PropertyConditions/StringProperty.cs
@@ -50,19 +50,19 @@ namespace Axe.Windows.Rules.PropertyConditions
         {
             GetStringPropertyValue = valueGetter;
             PropertyDescription = propertyDescription;
-            this.Null = CreateNullCondition();
-            this.Empty = CreateEmptyCondition();
-            this.NotNull = ~Null;
-            this.NotEmpty = ~Empty;
-            this.NullOrEmpty = Null | Empty;
-            this.NotNullOrEmpty = NotNull & NotEmpty;
-            this.WhiteSpace = CreateWhitespaceCondition();
-            this.NotWhiteSpace = ~WhiteSpace;
-            this.NullOrWhiteSpace = NullOrEmpty | WhiteSpace;
-            this.NotNullOrWhiteSpace = ~NullOrWhiteSpace;
-            this.IncludesPrivateUnicodeCharacters = CreateIncludesPrivateUnicodeCharactersCondition();
-            this.ExcludesPrivateUnicodeCharacters = ~IncludesPrivateUnicodeCharacters;
-            this.Length = CreateLengthCondition();
+            Null = CreateNullCondition();
+            Empty = CreateEmptyCondition();
+            NotNull = ~Null;
+            NotEmpty = ~Empty;
+            NullOrEmpty = Null | Empty;
+            NotNullOrEmpty = NotNull & NotEmpty;
+            WhiteSpace = CreateWhitespaceCondition();
+            NotWhiteSpace = ~WhiteSpace;
+            NullOrWhiteSpace = NullOrEmpty | WhiteSpace;
+            NotNullOrWhiteSpace = ~NullOrWhiteSpace;
+            IncludesPrivateUnicodeCharacters = CreateIncludesPrivateUnicodeCharactersCondition();
+            ExcludesPrivateUnicodeCharacters = ~IncludesPrivateUnicodeCharacters;
+            Length = CreateLengthCondition();
         }
 
         private Condition CreateNullCondition()
@@ -136,7 +136,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         {
             if (that == null) throw new ArgumentNullException(nameof(that));
 
-            return Condition.Create(e => this.IsEqualTo(e, that));
+            return Condition.Create(e => IsEqualTo(e, that));
         }
 
         public Condition IsNotEqualTo(StringProperty that)
@@ -149,7 +149,7 @@ namespace Axe.Windows.Rules.PropertyConditions
             if (e == null) throw new ArgumentNullException(nameof(e));
             if (that == null) throw new ArgumentNullException(nameof(that));
 
-            string s1 = this.GetStringPropertyValue(e);
+            string s1 = GetStringPropertyValue(e);
             if (string.IsNullOrWhiteSpace(s1)) return false;
 
             string s2 = that.GetStringPropertyValue(e);

--- a/src/Rules/Rule.cs
+++ b/src/Rules/Rule.cs
@@ -24,7 +24,7 @@ namespace Axe.Windows.Rules
         {
             // keep these two calls in the following order or the RuleInfo.Condition string won't get populated
 #pragma warning disable CA2214
-            this.Condition = CreateCondition();
+            Condition = CreateCondition();
 #pragma warning restore CA2214
 
             InitRuleInfo();
@@ -33,16 +33,16 @@ namespace Axe.Windows.Rules
         private void InitRuleInfo()
         {
             var info = GetRuleInfoFromAttributes();
-            if (info == null) throw new AxeWindowsException(ErrorMessages.MissingRuleInforAttribute.WithParameters(this.GetType().Name));
+            if (info == null) throw new AxeWindowsException(ErrorMessages.MissingRuleInforAttribute.WithParameters(GetType().Name));
 
-            info.Condition = this.Condition?.ToString();
+            info.Condition = Condition?.ToString();
 
-            this.Info = info;
+            Info = info;
         }
 
         private RuleInfo GetRuleInfoFromAttributes()
         {
-            var type = this.GetType();
+            var type = GetType();
 
             foreach (var a in type.GetCustomAttributes(true))
             {

--- a/src/Rules/RuleInfo.cs
+++ b/src/Rules/RuleInfo.cs
@@ -69,7 +69,7 @@ namespace Axe.Windows.Rules
         /// </summary>
         public override string ToString()
         {
-            return string.Format(CultureInfo.CurrentCulture, Descriptions.SummaryFormat, this.ID, this.Description, this.HowToFix, this.Condition);
+            return string.Format(CultureInfo.CurrentCulture, Descriptions.SummaryFormat, ID, Description, HowToFix, Condition);
         }
     } // class
 } // namespace

--- a/src/Rules/RuleProvider.cs
+++ b/src/Rules/RuleProvider.cs
@@ -25,7 +25,7 @@ namespace Axe.Windows.Rules
 
         public RuleProvider(IRuleFactory ruleFactory)
         {
-            this.RuleFactory = ruleFactory ?? throw new ArgumentNullException(nameof(ruleFactory));
+            RuleFactory = ruleFactory ?? throw new ArgumentNullException(nameof(ruleFactory));
         }
 
         private void InitAllRules()
@@ -51,7 +51,7 @@ namespace Axe.Windows.Rules
 
         public IRule GetRule(RuleId id)
         {
-            return AllRules.GetOrAdd(id, key => this.RuleFactory.CreateRule(key));
+            return AllRules.GetOrAdd(id, key => RuleFactory.CreateRule(key));
         }
 
         public IEnumerable<IRule> All


### PR DESCRIPTION
#### Details

Apply analyzer-led removal of unneeded `this.` prefixes in the `Rules` project. After locally making the changes in #796, the IDE highlighted the `this.` prefixes that were not needed.

##### Motivation

The code was originally written by folks who used `this.` _everywhere_ because that was the pattern in the team that they came from. Over time, that pattern has fallen by the wayside and now the code is very inconsistent. This PR is part of a series of PRs intended to increase the code consistency by removing unnecessary `this`. usage wherever possible.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
