### PR TITLE
chore: Analyzer-led removal of unneeded "this." prefixes in the RulesTest project

### DIFF
--- a/src/RulesTest/Library/ButtonInvokeAndExpandCollapsePatternsTests.cs
+++ b/src/RulesTest/Library/ButtonInvokeAndExpandCollapsePatternsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -21,7 +21,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_AppBarControlTypeId;
 
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
 
@@ -54,7 +54,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_InvokePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
 
@@ -71,7 +71,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_TogglePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
 
@@ -89,7 +89,7 @@ namespace Axe.Windows.RulesTests.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_InvokePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsFalse(Rule.PassesTest(e));
         }
     }

--- a/src/RulesTest/Library/ButtonInvokeAndTogglePatternsTests.cs
+++ b/src/RulesTest/Library/ButtonInvokeAndTogglePatternsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -21,7 +21,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_AppBarControlTypeId;
 
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
 
@@ -54,7 +54,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_InvokePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
 
@@ -71,7 +71,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_TogglePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
 
@@ -89,7 +89,7 @@ namespace Axe.Windows.RulesTests.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_TogglePatternId));
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_InvokePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsFalse(Rule.PassesTest(e));
         }
     }

--- a/src/RulesTest/Library/ButtonShouldHavePatternsTests.cs
+++ b/src/RulesTest/Library/ButtonShouldHavePatternsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -23,7 +23,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
 
@@ -40,7 +40,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_InvokePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
 
@@ -57,7 +57,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_TogglePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
 
@@ -75,7 +75,7 @@ namespace Axe.Windows.RulesTests.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_TogglePatternId));
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_InvokePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
     }

--- a/src/RulesTest/Library/ButtonToggleAndExpandCollapsePatternsTests.cs
+++ b/src/RulesTest/Library/ButtonToggleAndExpandCollapsePatternsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -21,7 +21,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_AppBarControlTypeId;
 
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
 
@@ -54,7 +54,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_InvokePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
 
@@ -71,7 +71,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_TogglePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
 
@@ -89,7 +89,7 @@ namespace Axe.Windows.RulesTests.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_TogglePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsFalse(Rule.PassesTest(e));
         }
     }

--- a/src/RulesTest/Library/ControlShouldSupportExpandCollapsePatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportExpandCollapsePatternTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -24,7 +24,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.Children.Add(ec);
 
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.Children.Add(ec);
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsFalse(Rule.PassesTest(e));
         }
 
@@ -62,7 +62,7 @@ namespace Axe.Windows.RulesTests.Library
             e.Children.Add(ec);
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
 
@@ -83,7 +83,7 @@ namespace Axe.Windows.RulesTests.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
             ec.Parent = e;
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
             Assert.IsTrue(Rule.PassesTest(e));
         }
 
@@ -104,8 +104,8 @@ namespace Axe.Windows.RulesTests.Library
             e.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
             ec.Parent = e;
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
-            Assert.IsFalse(this.Rule.Condition.Matches(ec));
+            Assert.IsTrue(Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(ec));
             Assert.IsTrue(Rule.PassesTest(e));
         }
 
@@ -127,8 +127,8 @@ namespace Axe.Windows.RulesTests.Library
             ec.Patterns.Add(new Core.Bases.A11yPattern(e, PatternType.UIA_ExpandCollapsePatternId));
             ec.Parent = e;
 
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
-            Assert.IsTrue(this.Rule.Condition.Matches(ec));
+            Assert.IsFalse(Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(ec));
             Assert.IsTrue(Rule.PassesTest(ec));
         }
     }

--- a/src/RulesTest/Library/ControlShouldSupportGridPatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportGridPatternTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
@@ -39,7 +39,7 @@ namespace Axe.Windows.RulesTests.Library
         [TestMethod]
         public void CheckPropertyIdIsSet()
         {
-            Assert.AreEqual(PropertyType.UIA_IsGridPatternAvailablePropertyId, this.Rule.Info.PropertyID);
+            Assert.AreEqual(PropertyType.UIA_IsGridPatternAvailablePropertyId, Rule.Info.PropertyID);
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/ControlShouldSupportTablePatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTablePatternTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
@@ -39,7 +39,7 @@ namespace Axe.Windows.RulesTests.Library
         [TestMethod]
         public void CheckPropertyIdIsSet()
         {
-            Assert.AreEqual(PropertyType.UIA_IsTablePatternAvailablePropertyId, this.Rule.Info.PropertyID);
+            Assert.AreEqual(PropertyType.UIA_IsTablePatternAvailablePropertyId, Rule.Info.PropertyID);
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/LandmarkIsTopLevelTests.cs
+++ b/src/RulesTest/Library/LandmarkIsTopLevelTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Core.Types;
@@ -15,9 +15,9 @@ namespace Axe.Windows.RulesTests.Library
         protected LandmarkIsTopLevelTests(object rule, int landmarkType, string localizedLandmarkType)
         {
             // we must pass in an object because the IRule type is not exposed publicly and it causes a compiler error
-            this.Rule = (Axe.Windows.Rules.IRule)rule;
-            this.LandmarkType = landmarkType;
-            this.LocalizedLandmarkType = localizedLandmarkType;
+            Rule = (Axe.Windows.Rules.IRule)rule;
+            LandmarkType = landmarkType;
+            LocalizedLandmarkType = localizedLandmarkType;
         }
 
         [TestMethod]
@@ -25,8 +25,8 @@ namespace Axe.Windows.RulesTests.Library
         {
             var e = new MockA11yElement();
             var parent = new MockA11yElement();
-            e.LandmarkType = this.LandmarkType;
-            e.LocalizedLandmarkType = this.LocalizedLandmarkType;
+            e.LandmarkType = LandmarkType;
+            e.LocalizedLandmarkType = LocalizedLandmarkType;
             e.Parent = parent;
 
             Assert.IsTrue(Rule.PassesTest(e));
@@ -37,11 +37,11 @@ namespace Axe.Windows.RulesTests.Library
         {
             var e = new MockA11yElement();
             var parent = new MockA11yElement();
-            e.LandmarkType = this.LandmarkType;
-            e.LocalizedLandmarkType = this.LocalizedLandmarkType;
+            e.LandmarkType = LandmarkType;
+            e.LocalizedLandmarkType = LocalizedLandmarkType;
             e.Parent = parent;
-            parent.LandmarkType = this.LandmarkType;
-            parent.LocalizedLandmarkType = this.LocalizedLandmarkType;
+            parent.LandmarkType = LandmarkType;
+            parent.LocalizedLandmarkType = LocalizedLandmarkType;
 
             Assert.IsFalse(Rule.PassesTest(e));
         }

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotCustomTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotCustomTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
@@ -25,7 +25,7 @@ namespace Axe.Windows.RulesTests.Library
         {
             var e = CreateElementExpectedToMatchCondition();
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
         }
 
         [TestMethod]
@@ -38,7 +38,7 @@ namespace Axe.Windows.RulesTests.Library
                 Except(custom))
             {
                 e.ControlTypeId = ct;
-                Assert.IsFalse(this.Rule.Condition.Matches(e));
+                Assert.IsFalse(Rule.Condition.Matches(e));
             }
         }
 
@@ -48,7 +48,7 @@ namespace Axe.Windows.RulesTests.Library
             var e = CreateElementExpectedToMatchCondition();
             e.IsKeyboardFocusable = false;
 
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         [TestMethod]
@@ -57,7 +57,7 @@ namespace Axe.Windows.RulesTests.Library
             var e = CreateElementExpectedToMatchCondition();
             e.LocalizedControlType = string.Empty;
 
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         [TestMethod]
@@ -66,7 +66,7 @@ namespace Axe.Windows.RulesTests.Library
             var e = CreateElementExpectedToMatchCondition();
             e.LocalizedControlType = null;
 
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         [TestMethod]
@@ -79,7 +79,7 @@ namespace Axe.Windows.RulesTests.Library
             e.ClassName = "DataGridDetailsPresenter";
             e.Parent = parent;
 
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         [TestMethod]
@@ -89,7 +89,7 @@ namespace Axe.Windows.RulesTests.Library
             e.ClassName = "DataGridCell";
             e.Framework = Core.Enums.FrameworkId.WPF;
 
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotCustomWPFGridCellTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotCustomWPFGridCellTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
@@ -27,7 +27,7 @@ namespace Axe.Windows.RulesTests.Library
         {
             var e = CreateElementExpectedToMatchCondition();
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
         }
 
         [TestMethod]
@@ -39,7 +39,7 @@ namespace Axe.Windows.RulesTests.Library
             foreach (var ct in ControlType.All.Except(custom))
             {
                 e.ControlTypeId = ct;
-                Assert.IsFalse(this.Rule.Condition.Matches(e));
+                Assert.IsFalse(Rule.Condition.Matches(e));
             }
         }
 
@@ -49,7 +49,7 @@ namespace Axe.Windows.RulesTests.Library
             var e = CreateElementExpectedToMatchCondition();
             e.IsKeyboardFocusable = false;
 
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         [TestMethod]
@@ -58,7 +58,7 @@ namespace Axe.Windows.RulesTests.Library
             var e = CreateElementExpectedToMatchCondition();
             e.LocalizedControlType = string.Empty;
 
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         [TestMethod]
@@ -67,7 +67,7 @@ namespace Axe.Windows.RulesTests.Library
             var e = CreateElementExpectedToMatchCondition();
             e.LocalizedControlType = null;
 
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         [TestMethod]
@@ -76,7 +76,7 @@ namespace Axe.Windows.RulesTests.Library
             var e = CreateElementExpectedToMatchCondition();
             e.ClassName = string.Empty;
 
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         [TestMethod]
@@ -85,7 +85,7 @@ namespace Axe.Windows.RulesTests.Library
             var e = CreateElementExpectedToMatchCondition();
             e.Framework = string.Empty;
 
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotWhiteSpaceTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotWhiteSpaceTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -14,7 +14,7 @@ namespace Axe.Windows.RulesTests.Library
         {
             var e = new MockA11yElement();
             e.LocalizedControlType = null;
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         [TestMethod]
@@ -22,7 +22,7 @@ namespace Axe.Windows.RulesTests.Library
         {
             var e = new MockA11yElement();
             e.LocalizedControlType = "";
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         [TestMethod]
@@ -30,7 +30,7 @@ namespace Axe.Windows.RulesTests.Library
         {
             var e = new MockA11yElement();
             e.LocalizedControlType = " ";
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/LocalizedControlTypeIsReasonableTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsReasonableTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.RulesTests.ControlType;
@@ -35,7 +35,7 @@ namespace Axe.Windows.RulesTests.Library
         {
             var e = new MockA11yElement();
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_CustomControlTypeId;
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/NameIsNotWhiteSpaceTests.cs
+++ b/src/RulesTest/Library/NameIsNotWhiteSpaceTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -14,7 +14,7 @@ namespace Axe.Windows.RulesTests.Library
         {
             var e = new MockA11yElement();
             e.Name = null;
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         [TestMethod]
@@ -22,7 +22,7 @@ namespace Axe.Windows.RulesTests.Library
         {
             var e = new MockA11yElement();
             e.Name = "";
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         [TestMethod]
@@ -30,7 +30,7 @@ namespace Axe.Windows.RulesTests.Library
         {
             var e = new MockA11yElement();
             e.Name = " ";
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
         }
 
         [TestMethod]
@@ -38,7 +38,7 @@ namespace Axe.Windows.RulesTests.Library
         {
             var e = new MockA11yElement();
             e.Name = "   ";
-            Assert.IsFalse(this.Rule.PassesTest(e));
+            Assert.IsFalse(Rule.PassesTest(e));
         }
 
         [TestMethod]

--- a/src/RulesTest/Library/SplitButtonInvokeAndTogglePatternsTests.cs
+++ b/src/RulesTest/Library/SplitButtonInvokeAndTogglePatternsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -63,7 +63,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_TreeItemControlTypeId;
 
-            Assert.IsFalse(this.Rule.Condition.Matches(e));
+            Assert.IsFalse(Rule.Condition.Matches(e));
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace Axe.Windows.RulesTests.Library
 
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_SplitButtonControlTypeId;
 
-            Assert.IsTrue(this.Rule.Condition.Matches(e));
+            Assert.IsTrue(Rule.Condition.Matches(e));
         }
     }
 }

--- a/src/RulesTest/MockA11yElement.cs
+++ b/src/RulesTest/MockA11yElement.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -20,14 +20,14 @@ namespace Axe.Windows.RulesTests
 
         private void SetProperty(int id, dynamic value)
         {
-            if (this.Properties.ContainsKey(id))
+            if (Properties.ContainsKey(id))
             {
-                this.Properties[id].Value = value;
+                Properties[id].Value = value;
                 return;
             }
 
             var property = new A11yProperty { Id = id, Value = value };
-            this.Properties[id] = property;
+            Properties[id] = property;
         }
 
         public new string Name

--- a/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
+++ b/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -16,8 +16,8 @@ namespace Axe.Windows.RulesTests.PropertyConditions
 
         public ElementGroupsTests()
         {
-            this.AllowSameNameAndControlTypeTypes = new int[] { AppBar, Custom, Header, MenuBar, SemanticZoom, StatusBar, TitleBar, Text };
-            this.DisallowSameNameAndControlTypeTypes = ControlType.All.Difference(AllowSameNameAndControlTypeTypes);
+            AllowSameNameAndControlTypeTypes = new int[] { AppBar, Custom, Header, MenuBar, SemanticZoom, StatusBar, TitleBar, Text };
+            DisallowSameNameAndControlTypeTypes = ControlType.All.Difference(AllowSameNameAndControlTypeTypes);
         }
 
         [TestMethod]
@@ -25,7 +25,7 @@ namespace Axe.Windows.RulesTests.PropertyConditions
         {
             var e = new MockA11yElement();
 
-            foreach (var t in this.AllowSameNameAndControlTypeTypes)
+            foreach (var t in AllowSameNameAndControlTypeTypes)
             {
                 e.ControlTypeId = t;
                 Assert.IsTrue(ElementGroups.AllowSameNameAndControlType.Matches(e));
@@ -37,7 +37,7 @@ namespace Axe.Windows.RulesTests.PropertyConditions
         {
             var e = new MockA11yElement();
 
-            foreach (var t in this.DisallowSameNameAndControlTypeTypes)
+            foreach (var t in DisallowSameNameAndControlTypeTypes)
             {
                 e.ControlTypeId = t;
                 Assert.IsFalse(ElementGroups.AllowSameNameAndControlType.Matches(e));
@@ -49,7 +49,7 @@ namespace Axe.Windows.RulesTests.PropertyConditions
         {
             var e = new MockA11yElement();
 
-            e.ControlTypeId = this.DisallowSameNameAndControlTypeTypes.First();
+            e.ControlTypeId = DisallowSameNameAndControlTypeTypes.First();
 
             var tenChars = "1234567890";
             for (int i = 0; i < 5; ++i)


### PR DESCRIPTION
#### Details

Apply analyzer-led removal of unneeded `this.` prefixes in the `RulesTest` project. After locally making the changes in #796, the IDE highlighted the `this.` prefixes that were not needed.

##### Motivation

The code was originally written by folks who used `this.` _everywhere_ because that was the pattern in the team that they came from. Over time, that pattern has fallen by the wayside and now the code is very inconsistent. This PR is part of a series of PRs intended to increase the code consistency by removing unnecessary `this`. usage wherever possible.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
