### PR TITLE
chore: Remove unneeded "using System.Globalization" statements

### DIFF
--- a/src/Automation/AxeWindowsActions.cs
+++ b/src/Automation/AxeWindowsActions.cs
@@ -12,7 +12,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Desktop.Settings;
 using System;
 using System.Diagnostics;
-using System.Globalization;
 
 namespace Axe.Windows.Automation
 {

--- a/src/Automation/ScanResultsAssembler.cs
+++ b/src/Automation/ScanResultsAssembler.cs
@@ -7,7 +7,6 @@ using Axe.Windows.Core.Results;
 using Axe.Windows.Rules;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 
 namespace Axe.Windows.Automation

--- a/src/Automation/TargetElementLocator.cs
+++ b/src/Automation/TargetElementLocator.cs
@@ -8,7 +8,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Desktop.UIAutomation;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 
 namespace Axe.Windows.Automation

--- a/src/Core/Bases/A11yElement.cs
+++ b/src/Core/Bases/A11yElement.cs
@@ -10,7 +10,6 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/src/Core/Bases/A11yPattern.cs
+++ b/src/Core/Bases/A11yPattern.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Types;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 

--- a/src/Core/Bases/A11yPatternProperty.cs
+++ b/src/Core/Bases/A11yPatternProperty.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Misc;
 using System;
-using System.Globalization;
 
 namespace Axe.Windows.Core.Bases
 {

--- a/src/Core/Bases/A11yProperty.cs
+++ b/src/Core/Bases/A11yProperty.cs
@@ -9,7 +9,6 @@ using Axe.Windows.Win32;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Concurrent;
-using System.Globalization;
 
 namespace Axe.Windows.Core.Bases
 {

--- a/src/Desktop/ColorContrastAnalyzer/Color.cs
+++ b/src/Desktop/ColorContrastAnalyzer/Color.cs
@@ -3,7 +3,6 @@
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Desktop.Resources;
 using System;
-using System.Globalization;
 
 namespace Axe.Windows.Desktop.ColorContrastAnalyzer
 {

--- a/src/Desktop/UIAutomation/DesktopElement.cs
+++ b/src/Desktop/UIAutomation/DesktopElement.cs
@@ -7,7 +7,6 @@ using Axe.Windows.Telemetry;
 using Axe.Windows.Win32;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Runtime.InteropServices;
 using UIAutomationClient;
 

--- a/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
@@ -8,7 +8,6 @@ using Axe.Windows.Desktop.UIAutomation.CustomObjects;
 using Axe.Windows.Telemetry;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
 using UIAutomationClient;

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
@@ -7,7 +7,6 @@ using Axe.Windows.Desktop.Resources;
 using Axe.Windows.Telemetry;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
 using UIAutomationClient;

--- a/src/Rules/Conditions/AndCondition.cs
+++ b/src/Rules/Conditions/AndCondition.cs
@@ -4,7 +4,6 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/Conditions/NotCondition.cs
+++ b/src/Rules/Conditions/NotCondition.cs
@@ -4,7 +4,6 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/Conditions/OrCondition.cs
+++ b/src/Rules/Conditions/OrCondition.cs
@@ -4,7 +4,6 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/Conditions/StringDecoratorCondition.cs
+++ b/src/Rules/Conditions/StringDecoratorCondition.cs
@@ -3,7 +3,6 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using System;
-using System.Globalization;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/Library/ListItemSiblingsUnique.cs
+++ b/src/Rules/Library/ListItemSiblingsUnique.cs
@@ -7,7 +7,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;

--- a/src/Rules/Library/NameExcludesControlType.cs
+++ b/src/Rules/Library/NameExcludesControlType.cs
@@ -8,7 +8,6 @@ using Axe.Windows.Rules.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using System.Text.RegularExpressions;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 

--- a/src/Rules/Library/SiblingUniqueAndFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndFocusable.cs
@@ -7,7 +7,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Framework;

--- a/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
@@ -7,7 +7,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Framework;

--- a/src/Rules/Library/Structure/ContentView/Button.cs
+++ b/src/Rules/Library/Structure/ContentView/Button.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Calendar.cs
+++ b/src/Rules/Library/Structure/ContentView/Calendar.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 
 namespace Axe.Windows.Rules.Library
 {

--- a/src/Rules/Library/Structure/ContentView/CheckBox.cs
+++ b/src/Rules/Library/Structure/ContentView/CheckBox.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/ComboBox.cs
+++ b/src/Rules/Library/Structure/ContentView/ComboBox.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/DataGrid.cs
+++ b/src/Rules/Library/Structure/ContentView/DataGrid.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Edit.cs
+++ b/src/Rules/Library/Structure/ContentView/Edit.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Hyperlink.cs
+++ b/src/Rules/Library/Structure/ContentView/Hyperlink.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/List.cs
+++ b/src/Rules/Library/Structure/ContentView/List.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/ListItem.cs
+++ b/src/Rules/Library/Structure/ContentView/ListItem.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Menu.cs
+++ b/src/Rules/Library/Structure/ContentView/Menu.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/ProgressBar.cs
+++ b/src/Rules/Library/Structure/ContentView/ProgressBar.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/RadioButton.cs
+++ b/src/Rules/Library/Structure/ContentView/RadioButton.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Slider.cs
+++ b/src/Rules/Library/Structure/ContentView/Slider.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Spinner.cs
+++ b/src/Rules/Library/Structure/ContentView/Spinner.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/SplitButton.cs
+++ b/src/Rules/Library/Structure/ContentView/SplitButton.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/StatusBar.cs
+++ b/src/Rules/Library/Structure/ContentView/StatusBar.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Tab.cs
+++ b/src/Rules/Library/Structure/ContentView/Tab.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/Tree.cs
+++ b/src/Rules/Library/Structure/ContentView/Tree.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ContentView/TreeItem.cs
+++ b/src/Rules/Library/Structure/ContentView/TreeItem.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Button.cs
+++ b/src/Rules/Library/Structure/ControlView/Button.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Calendar.cs
+++ b/src/Rules/Library/Structure/ControlView/Calendar.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 
 namespace Axe.Windows.Rules.Library
 {

--- a/src/Rules/Library/Structure/ControlView/CheckBox.cs
+++ b/src/Rules/Library/Structure/ControlView/CheckBox.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/ComboBox.cs
+++ b/src/Rules/Library/Structure/ControlView/ComboBox.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/DataGrid.cs
+++ b/src/Rules/Library/Structure/ControlView/DataGrid.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Edit.cs
+++ b/src/Rules/Library/Structure/ControlView/Edit.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Header.cs
+++ b/src/Rules/Library/Structure/ControlView/Header.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/HeaderItem.cs
+++ b/src/Rules/Library/Structure/ControlView/HeaderItem.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Hyperlink.cs
+++ b/src/Rules/Library/Structure/ControlView/Hyperlink.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Image.cs
+++ b/src/Rules/Library/Structure/ControlView/Image.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/List.cs
+++ b/src/Rules/Library/Structure/ControlView/List.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/ListItem.cs
+++ b/src/Rules/Library/Structure/ControlView/ListItem.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Menu.cs
+++ b/src/Rules/Library/Structure/ControlView/Menu.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/ProgressBar.cs
+++ b/src/Rules/Library/Structure/ControlView/ProgressBar.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/RadioButton.cs
+++ b/src/Rules/Library/Structure/ControlView/RadioButton.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Scrollbar.cs
+++ b/src/Rules/Library/Structure/ControlView/Scrollbar.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/SemanticZoom.cs
+++ b/src/Rules/Library/Structure/ControlView/SemanticZoom.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Separator.cs
+++ b/src/Rules/Library/Structure/ControlView/Separator.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Slider.cs
+++ b/src/Rules/Library/Structure/ControlView/Slider.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Spinner.cs
+++ b/src/Rules/Library/Structure/ControlView/Spinner.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/SplitButton.cs
+++ b/src/Rules/Library/Structure/ControlView/SplitButton.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/StatusBar.cs
+++ b/src/Rules/Library/Structure/ControlView/StatusBar.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Tab.cs
+++ b/src/Rules/Library/Structure/ControlView/Tab.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Thumb.cs
+++ b/src/Rules/Library/Structure/ControlView/Thumb.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/ToolTip.cs
+++ b/src/Rules/Library/Structure/ControlView/ToolTip.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/Tree.cs
+++ b/src/Rules/Library/Structure/ControlView/Tree.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/Library/Structure/ControlView/TreeItem.cs
+++ b/src/Rules/Library/Structure/ControlView/TreeItem.cs
@@ -6,7 +6,6 @@ using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 
 namespace Axe.Windows.Rules.Library

--- a/src/Rules/PropertyConditions/Relationships.cs
+++ b/src/Rules/PropertyConditions/Relationships.cs
@@ -5,7 +5,6 @@ using Axe.Windows.Core.Exceptions;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.Resources;
 using System;
-using System.Globalization;
 using System.Linq;
 
 namespace Axe.Windows.Rules.PropertyConditions

--- a/src/Rules/Rule.cs
+++ b/src/Rules/Rule.cs
@@ -4,7 +4,6 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Exceptions;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.Resources;
-using System.Globalization;
 
 namespace Axe.Windows.Rules
 {

--- a/src/Rules/RuleRunner.cs
+++ b/src/Rules/RuleRunner.cs
@@ -7,7 +7,6 @@ using Axe.Windows.Rules.Resources;
 using Axe.Windows.Telemetry;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Threading;
 
 namespace Axe.Windows.Rules


### PR DESCRIPTION
#### Details

I noticed a lot of unneeded `using System.Globalization` statements. Some of these may be old, while others became superfluous during the localization feature. My methodology was to comment them all out using global search and replace, then restore the ones that were needed to build. At the end, the ones that were not needed were deleted.

##### Motivation

Keep the code clean

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
