### PR TITLE
chore: Increase timeout of test that causes pipeline issues

### DIFF
--- a/src/AutomationTests/OutputFileHelperTests.cs
+++ b/src/AutomationTests/OutputFileHelperTests.cs
@@ -17,8 +17,10 @@ namespace Axe.Windows.AutomationTests
         private static readonly ISystemDateTime InertDateTime = new Mock<ISystemDateTime>(MockBehavior.Strict).Object;
         private static readonly ISystemEnvironment InertEnvironment = new Mock<ISystemEnvironment>(MockBehavior.Strict).Object;
 
+        // There's no way this test should take 15 seconds, but it often gets flagged as timing out in the pipeline. This is
+        // probably just initialization time, but if increasing the timeout reduces pipeline noise, then it's a good change
         [TestMethod]
-        [Timeout(1000)]
+        [Timeout(15000)]
         [ExpectedException(typeof(ArgumentNullException))]
         public void OutputFileHelperCtor_NullSystem_ThrowsException()
         {


### PR DESCRIPTION
#### Details

The pipeline often times out in the `OutputFileHelperCtor_NullSystem_ThrowsException` test, which should take no time at all. This PR increases the timeout to 15 seconds, with a comment why it's there.

##### Motivation

Reduce pipeline flakiness

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
