### PR TITLE
chore: Update private fields rules in editorconfig file

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -68,6 +68,34 @@ dotnet_naming_symbols.constant_fields.applicable_kinds            = field
 dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
 dotnet_naming_symbols.constant_fields.required_modifiers          = const
 
+# Define the 'private_fields' symbol group:
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+# Define the 'private_static_fields' symbol group
+dotnet_naming_symbols.private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_fields.required_modifiers = static
+
+# Define the 'underscored' naming style
+dotnet_naming_style.underscored.capitalization = camel_case
+dotnet_naming_style.underscored.required_prefix = _
+
+# Define the 'pascal_no_underscore' naming style
+dotnet_naming_style.pascal_no_underscore.capitalization = pascal_case
+dotnet_naming_style.pascal_no_underscore.required_prefix = 
+
+# Define the 'private_fields_underscored' naming rule
+dotnet_naming_rule.private_fields_underscored.symbols = private_fields
+dotnet_naming_rule.private_fields_underscored.style = underscored
+dotnet_naming_rule.private_fields_underscored.severity = error
+
+# Define the 'private_static_fields_none' naming rule
+dotnet_naming_rule.private_static_fields_none.symbols = private_static_fields
+dotnet_naming_rule.private_static_fields_none.capitalization = pascal_case
+dotnet_naming_rule.private_static_fields_none.style = pascal_no_underscore
+dotnet_naming_rule.private_static_fields_none.severity = error
+
 # SYMBOL GROUPS - Defining the 'method_symbols' symbol group.
 dotnet_naming_symbols.method_symbols.applicable_kinds           = method
 dotnet_naming_symbols.method_symbols.applicable_accessibilities = *


### PR DESCRIPTION
#### Details

Code standards for private members are very inconsistent through the code base. This PR adds the following checks to the `.editorconfig` file:

- Non-static private member names start with underscore and use camelCase
- Static private member names start don't have underscore and use PascalCase

This PR will be merged after all associated project-specific PR's are merged

##### Motivation

Improve code consistency and clarity

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
