### PR TITLE
chore: Update private field names in RulesTest project

### DIFF
--- a/src/RulesTest/Library/ButtonInvokeAndExpandCollapsePatternsTests.cs
+++ b/src/RulesTest/Library/ButtonInvokeAndExpandCollapsePatternsTests.cs
@@ -8,7 +8,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class ButtonInvokeAndExpandCollapsePatternsTests
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ButtonInvokeAndExpandCollapsePatterns();
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ButtonInvokeAndExpandCollapsePatterns();
 
         /// <summary>
         /// Rule not applicable

--- a/src/RulesTest/Library/ButtonInvokeAndTogglePatternsTests.cs
+++ b/src/RulesTest/Library/ButtonInvokeAndTogglePatternsTests.cs
@@ -8,7 +8,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class ButtonInvokeAndTogglePatternsTests
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ButtonInvokeAndTogglePatterns();
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ButtonInvokeAndTogglePatterns();
 
         /// <summary>
         /// Rule not applicable

--- a/src/RulesTest/Library/ButtonShouldHavePatternsTests.cs
+++ b/src/RulesTest/Library/ButtonShouldHavePatternsTests.cs
@@ -8,7 +8,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class ButtonShouldHavePatternsTests
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ButtonShouldHavePatterns();
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ButtonShouldHavePatterns();
 
         /// <summary>
         /// Error

--- a/src/RulesTest/Library/ButtonToggleAndExpandCollapsePatternsTests.cs
+++ b/src/RulesTest/Library/ButtonToggleAndExpandCollapsePatternsTests.cs
@@ -8,7 +8,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class ButtonToggleAndExpandCollapsePatternsTests
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ButtonToggleAndExpandCollapsePatterns();
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ButtonToggleAndExpandCollapsePatterns();
 
         /// <summary>
         /// Rule not applicable

--- a/src/RulesTest/Library/ClickablePointOffScreenTests.cs
+++ b/src/RulesTest/Library/ClickablePointOffScreenTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
@@ -12,18 +12,18 @@ namespace Axe.Windows.RulesTests.Library
     public class ClickablePointOffScreenTests
     {
         private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ClickablePointOffScreen();
-        private Mock<IA11yElement> mockElement = new Mock<IA11yElement>(MockBehavior.Strict);
+        private Mock<IA11yElement> _mockElement = new Mock<IA11yElement>(MockBehavior.Strict);
         private delegate void TryGetDelegate(int propertyId, out Point value);
 
         [TestCleanup]
         public void TestCleanup()
         {
-            mockElement.Reset();
+            _mockElement.Reset();
         }
 
         private void SetupTryGetProperty(Point outVal)
         {
-            mockElement.Setup(m => m.TryGetPropertyValue<Point>(PropertyType.UIA_ClickablePointPropertyId, out It.Ref<Point>.IsAny))
+            _mockElement.Setup(m => m.TryGetPropertyValue<Point>(PropertyType.UIA_ClickablePointPropertyId, out It.Ref<Point>.IsAny))
                 .Callback(new TryGetDelegate((int _, out Point p) =>
                 {
                     p = outVal;
@@ -34,33 +34,33 @@ namespace Axe.Windows.RulesTests.Library
         [TestMethod]
         public void ClickablePointOffScreen_OnScreen_Warning()
         {
-            mockElement.Setup(m => m.IsOffScreen).Returns(false);
-            Assert.IsFalse(Rule.PassesTest(mockElement.Object));
-            mockElement.VerifyAll();
+            _mockElement.Setup(m => m.IsOffScreen).Returns(false);
+            Assert.IsFalse(Rule.PassesTest(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePointOffScreen_OffScreen_Pass()
         {
-            mockElement.Setup(m => m.IsOffScreen).Returns(true);
-            Assert.IsTrue(Rule.PassesTest(mockElement.Object));
-            mockElement.VerifyAll();
+            _mockElement.Setup(m => m.IsOffScreen).Returns(true);
+            Assert.IsTrue(Rule.PassesTest(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePointOffScreen_IsNotClickable_Matches()
         {
             SetupTryGetProperty(new Point(-100, -100));
-            Assert.IsTrue(Rule.Condition.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            Assert.IsTrue(Rule.Condition.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePointOffScreen_IsClickable_NoMatch()
         {
             SetupTryGetProperty(new Point(100, 100));
-            Assert.IsFalse(Rule.Condition.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            Assert.IsFalse(Rule.Condition.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/ClickablePointOnScreenTests.cs
+++ b/src/RulesTest/Library/ClickablePointOnScreenTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
@@ -12,18 +12,18 @@ namespace Axe.Windows.RulesTests.Library
     public class ClickablePointOnScreenTests
     {
         private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ClickablePointOnScreen();
-        private Mock<IA11yElement> mockElement = new Mock<IA11yElement>(MockBehavior.Strict);
+        private Mock<IA11yElement> _mockElement = new Mock<IA11yElement>(MockBehavior.Strict);
         private delegate void TryGetDelegate(int propertyId, out Point value);
 
         [TestCleanup]
         public void TestCleanup()
         {
-            mockElement.Reset();
+            _mockElement.Reset();
         }
 
         private void SetupTryGetProperty(Point outVal)
         {
-            mockElement.Setup(m => m.TryGetPropertyValue<Point>(PropertyType.UIA_ClickablePointPropertyId, out It.Ref<Point>.IsAny))
+            _mockElement.Setup(m => m.TryGetPropertyValue<Point>(PropertyType.UIA_ClickablePointPropertyId, out It.Ref<Point>.IsAny))
                 .Callback(new TryGetDelegate((int _, out Point p) =>
                 {
                     p = outVal;
@@ -34,54 +34,54 @@ namespace Axe.Windows.RulesTests.Library
         [TestMethod]
         public void ClickablePointOnScreen_OffScreen_Error()
         {
-            mockElement.Setup(m => m.IsOffScreen).Returns(true);
-            Assert.IsFalse(Rule.PassesTest(mockElement.Object));
-            mockElement.VerifyAll();
+            _mockElement.Setup(m => m.IsOffScreen).Returns(true);
+            Assert.IsFalse(Rule.PassesTest(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePointOnScreen_OnScreen_Pass()
         {
-            mockElement.Setup(m => m.IsOffScreen).Returns(false);
-            Assert.IsTrue(Rule.PassesTest(mockElement.Object));
-            mockElement.VerifyAll();
+            _mockElement.Setup(m => m.IsOffScreen).Returns(false);
+            Assert.IsTrue(Rule.PassesTest(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePointOnScreen_FocusableClickable_FrameworkIsNotWPF_Matches()
         {
             SetupTryGetProperty(new Point(100, 100));
-            mockElement.Setup(m => m.IsKeyboardFocusable).Returns(true);
-            mockElement.Setup(m => m.Framework).Returns("Anything but WPF");
-            Assert.IsTrue(Rule.Condition.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            _mockElement.Setup(m => m.IsKeyboardFocusable).Returns(true);
+            _mockElement.Setup(m => m.Framework).Returns("Anything but WPF");
+            Assert.IsTrue(Rule.Condition.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePointOnScreen_FocusableClickable_FrameworkIsWPF_NoMatches()
         {
             SetupTryGetProperty(new Point(100, 100));
-            mockElement.Setup(m => m.IsKeyboardFocusable).Returns(true);
-            mockElement.Setup(m => m.Framework).Returns("WPF");
-            Assert.IsFalse(Rule.Condition.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            _mockElement.Setup(m => m.IsKeyboardFocusable).Returns(true);
+            _mockElement.Setup(m => m.Framework).Returns("WPF");
+            Assert.IsFalse(Rule.Condition.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePointOnScreen_IsNotClickable_NoMatch()
         {
             SetupTryGetProperty(new Point(-100, -100));
-            mockElement.Setup(m => m.IsKeyboardFocusable).Returns(true);
-            Assert.IsFalse(Rule.Condition.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            _mockElement.Setup(m => m.IsKeyboardFocusable).Returns(true);
+            Assert.IsFalse(Rule.Condition.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePointOnScreen_IsNotFocusable_NoMatch()
         {
-            mockElement.Setup(m => m.IsKeyboardFocusable).Returns(false);
-            Assert.IsFalse(Rule.Condition.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            _mockElement.Setup(m => m.IsKeyboardFocusable).Returns(false);
+            Assert.IsFalse(Rule.Condition.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/ClickablePointOnScreenWPFTests.cs
+++ b/src/RulesTest/Library/ClickablePointOnScreenWPFTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
@@ -12,18 +12,18 @@ namespace Axe.Windows.RulesTests.Library
     public class ClickablePointOnScreenWPFTests
     {
         private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ClickablePointOnScreenWPF();
-        private Mock<IA11yElement> mockElement = new Mock<IA11yElement>(MockBehavior.Strict);
+        private Mock<IA11yElement> _mockElement = new Mock<IA11yElement>(MockBehavior.Strict);
         private delegate void TryGetDelegate(int propertyId, out Point value);
 
         [TestCleanup]
         public void TestCleanup()
         {
-            mockElement.Reset();
+            _mockElement.Reset();
         }
 
         private void SetupTryGetProperty(Point outVal)
         {
-            mockElement.Setup(m => m.TryGetPropertyValue<Point>(PropertyType.UIA_ClickablePointPropertyId, out It.Ref<Point>.IsAny))
+            _mockElement.Setup(m => m.TryGetPropertyValue<Point>(PropertyType.UIA_ClickablePointPropertyId, out It.Ref<Point>.IsAny))
                 .Callback(new TryGetDelegate((int _, out Point p) =>
                 {
                     p = outVal;
@@ -40,45 +40,45 @@ namespace Axe.Windows.RulesTests.Library
         [TestMethod]
         public void ClickablePointOnScreen_OffScreen_Error()
         {
-            mockElement.Setup(m => m.IsOffScreen).Returns(true);
-            Assert.IsFalse(Rule.PassesTest(mockElement.Object));
-            mockElement.VerifyAll();
+            _mockElement.Setup(m => m.IsOffScreen).Returns(true);
+            Assert.IsFalse(Rule.PassesTest(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePointOnScreen_OnScreen_Pass()
         {
-            mockElement.Setup(m => m.IsOffScreen).Returns(false);
-            Assert.IsTrue(Rule.PassesTest(mockElement.Object));
-            mockElement.VerifyAll();
+            _mockElement.Setup(m => m.IsOffScreen).Returns(false);
+            Assert.IsTrue(Rule.PassesTest(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePointOnScreen_FocusableClickable_FrameworkIsNotWPF_NoMatch()
         {
             SetupTryGetProperty(new Point(100, 100));
-            mockElement.Setup(m => m.IsKeyboardFocusable).Returns(true);
-            mockElement.Setup(m => m.Framework).Returns("Anything but WPF");
-            Assert.IsFalse(Rule.Condition.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            _mockElement.Setup(m => m.IsKeyboardFocusable).Returns(true);
+            _mockElement.Setup(m => m.Framework).Returns("Anything but WPF");
+            Assert.IsFalse(Rule.Condition.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePointOnScreen_FocusableClickable_FrameworkIsWPF_Matche()
         {
             SetupTryGetProperty(new Point(100, 100));
-            mockElement.Setup(m => m.IsKeyboardFocusable).Returns(true);
-            mockElement.Setup(m => m.Framework).Returns("WPF");
-            Assert.IsTrue(Rule.Condition.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            _mockElement.Setup(m => m.IsKeyboardFocusable).Returns(true);
+            _mockElement.Setup(m => m.Framework).Returns("WPF");
+            Assert.IsTrue(Rule.Condition.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePointOnScreen_IsNotFocusable_NoMatch()
         {
-            mockElement.Setup(m => m.IsKeyboardFocusable).Returns(false);
-            Assert.IsFalse(Rule.Condition.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            _mockElement.Setup(m => m.IsKeyboardFocusable).Returns(false);
+            Assert.IsFalse(Rule.Condition.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/ControlShouldSupportExpandCollapsePatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportExpandCollapsePatternTests.cs
@@ -8,7 +8,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class ControlShouldSupportExpandCollapsePatternTests
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportExpandCollapsePattern();
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportExpandCollapsePattern();
 
         /// <summary>
         /// Condition should not match since TreeItem doesn't have any childTreeItem

--- a/src/RulesTest/Library/ControlShouldSupportGridPatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportGridPatternTests.cs
@@ -10,7 +10,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class ControlShouldSupportGridPatternTests
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportGridPattern();
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportGridPattern();
 
         [TestMethod]
         public void HasGridPattern_Pass()

--- a/src/RulesTest/Library/ControlShouldSupportTablePatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTablePatternTests.cs
@@ -10,7 +10,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class ControlShouldSupportTablePatternTests
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportTablePattern();
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportTablePattern();
 
         [TestMethod]
         public void HasTablePattern_Pass()

--- a/src/RulesTest/Library/ControlShouldSupportTextPatternEditWinformTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTextPatternEditWinformTests.cs
@@ -11,7 +11,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class ControlShouldSupportTextPatternEditWinformTests
     {
-        private readonly Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportTextPatternEditWinform();
+        private static readonly Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportTextPatternEditWinform();
 
         [TestMethod]
         public void FrameworkIssueLink_IsNotNull()

--- a/src/RulesTest/Library/ControlShouldSupportTextPatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTextPatternTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -11,7 +11,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class ControlShouldSupportTextPatternTests
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportTextPattern();
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ControlShouldSupportTextPattern();
 
         [TestMethod]
         public void HasTextPattern_Pass()

--- a/src/RulesTest/Library/IsControlElementTrueRequiredButtonWPFTests.cs
+++ b/src/RulesTest/Library/IsControlElementTrueRequiredButtonWPFTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -11,7 +11,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class IsControlElementTrueRequiredButtonWPFTests
     {
-        private readonly Rectangle ValidRectangle = new Rectangle(100, 200, 300, 400); // Arbitrary values
+        private static readonly Rectangle ValidRectangle = new Rectangle(100, 200, 300, 400); // Arbitrary values
         private const int NonRequiredControlType = Axe.Windows.Core.Types.ControlType.UIA_PaneControlTypeId;
         private const int GenericRequiredControlType = Axe.Windows.Core.Types.ControlType.UIA_ComboBoxControlTypeId;
         private const int TextType = Axe.Windows.Core.Types.ControlType.UIA_TextControlTypeId;

--- a/src/RulesTest/Library/IsControlElementTrueRequiredTests.cs
+++ b/src/RulesTest/Library/IsControlElementTrueRequiredTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -11,7 +11,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class IsControlElementTrueRequiredTests
     {
-        private readonly Rectangle ValidRectangle = new Rectangle(100, 200, 300, 400); // Arbitrary values
+        private static readonly Rectangle ValidRectangle = new Rectangle(100, 200, 300, 400); // Arbitrary values
         private const int NonRequiredControlType = Axe.Windows.Core.Types.ControlType.UIA_PaneControlTypeId;
         private const int GenericRequiredControlType = Axe.Windows.Core.Types.ControlType.UIA_ComboBoxControlTypeId;
         private const int TextType = Axe.Windows.Core.Types.ControlType.UIA_TextControlTypeId;

--- a/src/RulesTest/Library/IsControlElementTrueRequiredTextInEditXAMLTests.cs
+++ b/src/RulesTest/Library/IsControlElementTrueRequiredTextInEditXAMLTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -11,7 +11,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class IsControlElementTrueRequiredTextInEditXAMLTests
     {
-        private readonly Rectangle ValidRectangle = new Rectangle(100, 200, 300, 400); // Arbitrary values
+        private static readonly Rectangle ValidRectangle = new Rectangle(100, 200, 300, 400); // Arbitrary values
         private const int NonRequiredControlType = Axe.Windows.Core.Types.ControlType.UIA_PaneControlTypeId;
         private const int GenericRequiredControlType = Axe.Windows.Core.Types.ControlType.UIA_ComboBoxControlTypeId;
         private const int TextType = Axe.Windows.Core.Types.ControlType.UIA_TextControlTypeId;

--- a/src/RulesTest/Library/LandmarkIsTopLevelTests.cs
+++ b/src/RulesTest/Library/LandmarkIsTopLevelTests.cs
@@ -8,16 +8,16 @@ namespace Axe.Windows.RulesTests.Library
 {
     public class LandmarkIsTopLevelTests
     {
-        private readonly Axe.Windows.Rules.IRule Rule = null;
-        private readonly int LandmarkType = 0;
-        private readonly string LocalizedLandmarkType = null;
+        private readonly Axe.Windows.Rules.IRule _rule = null;
+        private readonly int _landmarkType = 0;
+        private readonly string _localizedLandmarkType = null;
 
         protected LandmarkIsTopLevelTests(object rule, int landmarkType, string localizedLandmarkType)
         {
             // we must pass in an object because the IRule type is not exposed publicly and it causes a compiler error
-            Rule = (Axe.Windows.Rules.IRule)rule;
-            LandmarkType = landmarkType;
-            LocalizedLandmarkType = localizedLandmarkType;
+            _rule = (Axe.Windows.Rules.IRule)rule;
+            _landmarkType = landmarkType;
+            _localizedLandmarkType = localizedLandmarkType;
         }
 
         [TestMethod]
@@ -25,11 +25,11 @@ namespace Axe.Windows.RulesTests.Library
         {
             var e = new MockA11yElement();
             var parent = new MockA11yElement();
-            e.LandmarkType = LandmarkType;
-            e.LocalizedLandmarkType = LocalizedLandmarkType;
+            e.LandmarkType = _landmarkType;
+            e.LocalizedLandmarkType = _localizedLandmarkType;
             e.Parent = parent;
 
-            Assert.IsTrue(Rule.PassesTest(e));
+            Assert.IsTrue(_rule.PassesTest(e));
         }
 
         [TestMethod]
@@ -37,13 +37,13 @@ namespace Axe.Windows.RulesTests.Library
         {
             var e = new MockA11yElement();
             var parent = new MockA11yElement();
-            e.LandmarkType = LandmarkType;
-            e.LocalizedLandmarkType = LocalizedLandmarkType;
+            e.LandmarkType = _landmarkType;
+            e.LocalizedLandmarkType = _localizedLandmarkType;
             e.Parent = parent;
-            parent.LandmarkType = LandmarkType;
-            parent.LocalizedLandmarkType = LocalizedLandmarkType;
+            parent.LandmarkType = _landmarkType;
+            parent.LocalizedLandmarkType = _localizedLandmarkType;
 
-            Assert.IsFalse(Rule.PassesTest(e));
+            Assert.IsFalse(_rule.PassesTest(e));
         }
     } // class
 

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotCustomTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotCustomTests.cs
@@ -8,7 +8,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class LocalizedControlTypeIsNotCustomTests
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.LocalizedControlTypeIsNotCustom();
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.LocalizedControlTypeIsNotCustom();
 
         private MockA11yElement CreateElementExpectedToMatchCondition()
         {

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotCustomWPFGridCellTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotCustomWPFGridCellTests.cs
@@ -8,7 +8,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class LocalizedControlTypeIsNotCustomWPFGridCellTests
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.LocalizedControlTypeIsNotCustomWPFGridCell();
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.LocalizedControlTypeIsNotCustomWPFGridCell();
 
         private MockA11yElement CreateElementExpectedToMatchCondition()
         {

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotWhiteSpaceTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotWhiteSpaceTests.cs
@@ -7,7 +7,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class LocalizedControlTypeIsNotWhiteSpaceTests
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.LocalizedControlTypeIsNotWhiteSpace();
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.LocalizedControlTypeIsNotWhiteSpace();
 
         [TestMethod]
         public void TestLocalizedControlTypeNull()

--- a/src/RulesTest/Library/LocalizedControlTypeIsReasonableTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsReasonableTests.cs
@@ -8,7 +8,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class LocalizedControlTypeIsReasonableTests
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.LocalizedControlTypeIsReasonable();
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.LocalizedControlTypeIsReasonable();
 
         [TestMethod]
         public void TestControlTypeIdIsAppBarAndLocalizedControlTypeIsAppBar()

--- a/src/RulesTest/Library/LocalizedLandmarkTypeNotCustomTests.cs
+++ b/src/RulesTest/Library/LocalizedLandmarkTypeNotCustomTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -8,7 +8,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class LocalizedLandmarkTypeNotCustomTests
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.LocalizedLandmarkTypeNotCustom();
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.LocalizedLandmarkTypeNotCustom();
 
         [TestMethod]
         public void LocalizedLandmarkTypeNotCustom_Pass()

--- a/src/RulesTest/Library/NameIsNotWhiteSpaceTests.cs
+++ b/src/RulesTest/Library/NameIsNotWhiteSpaceTests.cs
@@ -7,7 +7,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class NameIsNotWhiteSpaceTests
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.NameIsNotWhiteSpace();
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.NameIsNotWhiteSpace();
 
         [TestMethod]
         public void TestNameNull()

--- a/src/RulesTest/Library/ProgressBarRangeValueTests.cs
+++ b/src/RulesTest/Library/ProgressBarRangeValueTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
@@ -11,21 +11,21 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class ProgressBarRangeValueTests
     {
-        private readonly Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ProgressBarRangeValue();
-        private Mock<IA11yElement> elementMock = null;
-        private Mock<IA11yPattern> patternMock = null;
+        private static readonly Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.ProgressBarRangeValue();
+        private Mock<IA11yElement> _elementMock = null;
+        private Mock<IA11yPattern> _patternMock = null;
 
         [TestInitialize]
         public void TestInitialize()
         {
-            patternMock = new Mock<IA11yPattern>(MockBehavior.Strict);
-            elementMock = new Mock<IA11yElement>(MockBehavior.Strict);
-            elementMock.Setup(e => e.GetPattern(PatternType.UIA_RangeValuePatternId)).Returns(patternMock.Object);
+            _patternMock = new Mock<IA11yPattern>(MockBehavior.Strict);
+            _elementMock = new Mock<IA11yElement>(MockBehavior.Strict);
+            _elementMock.Setup(e => e.GetPattern(PatternType.UIA_RangeValuePatternId)).Returns(_patternMock.Object);
         }
 
         private void AddPatternValue<T>(string name, T value)
         {
-            patternMock.Setup(p => p.GetValue<T>(name)).Returns(value);
+            _patternMock.Setup(p => p.GetValue<T>(name)).Returns(value);
         }
 
         [TestMethod]
@@ -35,10 +35,10 @@ namespace Axe.Windows.RulesTests.Library
             AddPatternValue("Minimum", 0);
             AddPatternValue("Maximum", 1);
 
-            Assert.IsTrue(Rule.PassesTest(elementMock.Object));
+            Assert.IsTrue(Rule.PassesTest(_elementMock.Object));
 
-            patternMock.Verify();
-            elementMock.Verify();
+            _patternMock.Verify();
+            _elementMock.Verify();
         }
 
         [TestMethod]
@@ -48,10 +48,10 @@ namespace Axe.Windows.RulesTests.Library
             AddPatternValue("Minimum", 1);
             AddPatternValue("Maximum", 1);
 
-            Assert.IsFalse(Rule.PassesTest(elementMock.Object));
+            Assert.IsFalse(Rule.PassesTest(_elementMock.Object));
 
-            patternMock.Verify();
-            elementMock.Verify();
+            _patternMock.Verify();
+            _elementMock.Verify();
         }
 
         [TestMethod]
@@ -61,10 +61,10 @@ namespace Axe.Windows.RulesTests.Library
             AddPatternValue("Minimum", 1);
             AddPatternValue("Maximum", 0);
 
-            Assert.IsFalse(Rule.PassesTest(elementMock.Object));
+            Assert.IsFalse(Rule.PassesTest(_elementMock.Object));
 
-            patternMock.Verify();
-            elementMock.Verify();
+            _patternMock.Verify();
+            _elementMock.Verify();
         }
 
         [TestMethod]
@@ -74,10 +74,10 @@ namespace Axe.Windows.RulesTests.Library
             AddPatternValue("Minimum", 0);
             AddPatternValue("Maximum", 1);
 
-            Assert.IsFalse(Rule.PassesTest(elementMock.Object));
+            Assert.IsFalse(Rule.PassesTest(_elementMock.Object));
 
-            patternMock.Verify();
-            elementMock.Verify();
+            _patternMock.Verify();
+            _elementMock.Verify();
         }
 
         [TestMethod]
@@ -90,13 +90,13 @@ namespace Axe.Windows.RulesTests.Library
         [TestMethod]
         public void ProgressBarRangeValue_NullPattern_ThrowsException()
         {
-            elementMock.Reset();
-            elementMock.Setup(e => e.GetPattern(PatternType.UIA_RangeValuePatternId)).Returns<IA11yPattern>(null);
+            _elementMock.Reset();
+            _elementMock.Setup(e => e.GetPattern(PatternType.UIA_RangeValuePatternId)).Returns<IA11yPattern>(null);
 
-            var ex = Assert.ThrowsException<ArgumentNullException>(() => Rule.PassesTest(elementMock.Object));
+            var ex = Assert.ThrowsException<ArgumentNullException>(() => Rule.PassesTest(_elementMock.Object));
             Assert.AreEqual("pattern", ex.ParamName);
 
-            elementMock.Verify();
+            _elementMock.Verify();
         }
 
         [TestMethod]
@@ -115,24 +115,24 @@ namespace Axe.Windows.RulesTests.Library
 
         private void TestControlTypeMatchesCondition(int controlType, bool expectedResult)
         {
-            elementMock.Setup(e => e.ControlTypeId).Returns(controlType);
+            _elementMock.Setup(e => e.ControlTypeId).Returns(controlType);
 
-            Assert.AreEqual(expectedResult, Rule.Condition.Matches(elementMock.Object));
+            Assert.AreEqual(expectedResult, Rule.Condition.Matches(_elementMock.Object));
 
-            elementMock.Verify();
-            patternMock.Verify();
+            _elementMock.Verify();
+            _patternMock.Verify();
         }
 
         [TestMethod]
         public void ProgressBarRangeValue_NoRangeValuePattern_NoMatch()
         {
-            elementMock.Reset();
-            elementMock.Setup(e => e.ControlTypeId).Returns(ControlType.ProgressBar);
-            elementMock.Setup(e => e.GetPattern(PatternType.UIA_RangeValuePatternId)).Returns<IA11yPattern>(null);
+            _elementMock.Reset();
+            _elementMock.Setup(e => e.ControlTypeId).Returns(ControlType.ProgressBar);
+            _elementMock.Setup(e => e.GetPattern(PatternType.UIA_RangeValuePatternId)).Returns<IA11yPattern>(null);
 
-            Assert.IsFalse(Rule.Condition.Matches(elementMock.Object));
+            Assert.IsFalse(Rule.Condition.Matches(_elementMock.Object));
 
-            elementMock.Verify();
+            _elementMock.Verify();
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/SelectionItemPatternSingleSelectionTests.cs
+++ b/src/RulesTest/Library/SelectionItemPatternSingleSelectionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
@@ -12,7 +12,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class SelectionItemPatternSingleSelectionTests
     {
-        private readonly Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.SelectionItemPatternSingleSelection();
+        private static readonly Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.SelectionItemPatternSingleSelection();
 
         private static Mock<IA11yElement> CreateMockElement(IA11yElement parent, int controlType, bool isSelected)
         {

--- a/src/RulesTest/Library/SplitButtonInvokeAndTogglePatternsTests.cs
+++ b/src/RulesTest/Library/SplitButtonInvokeAndTogglePatternsTests.cs
@@ -8,7 +8,7 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class SplitButtonInvokeAndTogglePatternsTests
     {
-        private Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.SplitButtonInvokeAndTogglePatterns();
+        private static Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.SplitButtonInvokeAndTogglePatterns();
 
         /// <summary>
         /// A splitbutton with both of Invoke and Toggle Patterns. error.

--- a/src/RulesTest/PropertyConditions/ClickablePointTests.cs
+++ b/src/RulesTest/PropertyConditions/ClickablePointTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
@@ -13,18 +13,18 @@ namespace Axe.Windows.RulesTests.Library
     [TestClass]
     public class ClickablePointTests
     {
-        private Mock<IA11yElement> mockElement = new Mock<IA11yElement>(MockBehavior.Strict);
+        private Mock<IA11yElement> _mockElement = new Mock<IA11yElement>(MockBehavior.Strict);
         private delegate void TryGetDelegate(int propertyId, out Point value);
 
         [TestCleanup]
         public void TestCleanup()
         {
-            mockElement.Reset();
+            _mockElement.Reset();
         }
 
         private void SetupTryGetProperty(Point outVal, bool retVal = true)
         {
-            mockElement.Setup(m => m.TryGetPropertyValue<Point>(PropertyType.UIA_ClickablePointPropertyId, out It.Ref<Point>.IsAny))
+            _mockElement.Setup(m => m.TryGetPropertyValue<Point>(PropertyType.UIA_ClickablePointPropertyId, out It.Ref<Point>.IsAny))
                 .Callback(new TryGetDelegate((int _, out Point p) =>
                 {
                     p = outVal;
@@ -36,48 +36,48 @@ namespace Axe.Windows.RulesTests.Library
         public void ClickablePoint_OnScreen_True()
         {
             SetupTryGetProperty(new Point(100, 100));
-            Assert.IsTrue(ClickablePoint.OnScreen.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            Assert.IsTrue(ClickablePoint.OnScreen.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePoint_OnScreen_OffLeft_False()
         {
             SetupTryGetProperty(new Point(-100, 100));
-            Assert.IsFalse(ClickablePoint.OnScreen.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            Assert.IsFalse(ClickablePoint.OnScreen.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePoint_OnScreen_OffRightt_False()
         {
             SetupTryGetProperty(new Point(10000, 100));
-            Assert.IsFalse(ClickablePoint.OnScreen.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            Assert.IsFalse(ClickablePoint.OnScreen.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePoint_OnScreen_OffTop_False()
         {
             SetupTryGetProperty(new Point(100, -100));
-            Assert.IsFalse(ClickablePoint.OnScreen.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            Assert.IsFalse(ClickablePoint.OnScreen.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePoint_OnScreen_OffBottom_False()
         {
             SetupTryGetProperty(new Point(100, 10000));
-            Assert.IsFalse(ClickablePoint.OnScreen.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            Assert.IsFalse(ClickablePoint.OnScreen.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePoint_OnScreen_NoProperty_False()
         {
             SetupTryGetProperty(new Point(100, 100), false);
-            Assert.IsFalse(ClickablePoint.OnScreen.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            Assert.IsFalse(ClickablePoint.OnScreen.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
@@ -90,48 +90,48 @@ namespace Axe.Windows.RulesTests.Library
         public void ClickablePoint_OffScreen_False()
         {
             SetupTryGetProperty(new Point(100, 100));
-            Assert.IsFalse(ClickablePoint.OffScreen.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            Assert.IsFalse(ClickablePoint.OffScreen.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePoint_OffScreen_OffLeft_True()
         {
             SetupTryGetProperty(new Point(-100, 100));
-            Assert.IsTrue(ClickablePoint.OffScreen.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            Assert.IsTrue(ClickablePoint.OffScreen.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePoint_OffScreen_OffRightt_True()
         {
             SetupTryGetProperty(new Point(10000, 100));
-            Assert.IsTrue(ClickablePoint.OffScreen.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            Assert.IsTrue(ClickablePoint.OffScreen.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePoint_OffScreen_OffTop_True()
         {
             SetupTryGetProperty(new Point(100, -100));
-            Assert.IsTrue(ClickablePoint.OffScreen.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            Assert.IsTrue(ClickablePoint.OffScreen.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePoint_OffScreen_OffBottom_True()
         {
             SetupTryGetProperty(new Point(100, 10000));
-            Assert.IsTrue(ClickablePoint.OffScreen.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            Assert.IsTrue(ClickablePoint.OffScreen.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]
         public void ClickablePoint_OffScreen_NoProperty_False()
         {
             SetupTryGetProperty(new Point(100, 100), false);
-            Assert.IsFalse(ClickablePoint.OffScreen.Matches(mockElement.Object));
-            mockElement.VerifyAll();
+            Assert.IsFalse(ClickablePoint.OffScreen.Matches(_mockElement.Object));
+            _mockElement.VerifyAll();
         }
 
         [TestMethod]

--- a/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
+++ b/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
@@ -11,13 +11,13 @@ namespace Axe.Windows.RulesTests.PropertyConditions
     [TestClass]
     public class ElementGroupsTests
     {
-        private readonly int[] AllowSameNameAndControlTypeTypes = null;
-        private readonly IEnumerable<int> DisallowSameNameAndControlTypeTypes = null;
+        private readonly int[] _allowSameNameAndControlTypeTypes = null;
+        private readonly IEnumerable<int> _disallowSameNameAndControlTypeTypes = null;
 
         public ElementGroupsTests()
         {
-            AllowSameNameAndControlTypeTypes = new int[] { AppBar, Custom, Header, MenuBar, SemanticZoom, StatusBar, TitleBar, Text };
-            DisallowSameNameAndControlTypeTypes = ControlType.All.Difference(AllowSameNameAndControlTypeTypes);
+            _allowSameNameAndControlTypeTypes = new int[] { AppBar, Custom, Header, MenuBar, SemanticZoom, StatusBar, TitleBar, Text };
+            _disallowSameNameAndControlTypeTypes = ControlType.All.Difference(_allowSameNameAndControlTypeTypes);
         }
 
         [TestMethod]
@@ -25,7 +25,7 @@ namespace Axe.Windows.RulesTests.PropertyConditions
         {
             var e = new MockA11yElement();
 
-            foreach (var t in AllowSameNameAndControlTypeTypes)
+            foreach (var t in _allowSameNameAndControlTypeTypes)
             {
                 e.ControlTypeId = t;
                 Assert.IsTrue(ElementGroups.AllowSameNameAndControlType.Matches(e));
@@ -37,7 +37,7 @@ namespace Axe.Windows.RulesTests.PropertyConditions
         {
             var e = new MockA11yElement();
 
-            foreach (var t in DisallowSameNameAndControlTypeTypes)
+            foreach (var t in _disallowSameNameAndControlTypeTypes)
             {
                 e.ControlTypeId = t;
                 Assert.IsFalse(ElementGroups.AllowSameNameAndControlType.Matches(e));
@@ -49,7 +49,7 @@ namespace Axe.Windows.RulesTests.PropertyConditions
         {
             var e = new MockA11yElement();
 
-            e.ControlTypeId = DisallowSameNameAndControlTypeTypes.First();
+            e.ControlTypeId = _disallowSameNameAndControlTypeTypes.First();
 
             var tenChars = "1234567890";
             for (int i = 0; i < 5; ++i)

--- a/src/RulesTest/PropertyConditions/NameTests.cs
+++ b/src/RulesTest/PropertyConditions/NameTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -13,13 +13,13 @@ namespace Axe.Windows.RulesTests.PropertyConditions
     [TestClass]
     public class NameTests
     {
-        private readonly IEnumerable<int> RequiredTypes = null;
-        private readonly IEnumerable<int> OptionalTypes = null;
-        private readonly IEnumerable<int> ExcludedTypes = null;
+        private readonly IEnumerable<int> _requiredTypes = null;
+        private readonly IEnumerable<int> _optionalTypes = null;
+        private readonly IEnumerable<int> _excludedTypes = null;
 
         public NameTests()
         {
-            RequiredTypes = new List<int>
+            _requiredTypes = new List<int>
             {
                 Calendar, CheckBox, ComboBox,
                 DataGrid, DataItem, Document,
@@ -32,18 +32,18 @@ namespace Axe.Windows.RulesTests.PropertyConditions
                 ToolTip, Tree, TreeItem, Window
             };
 
-            OptionalTypes = new List<int> { Group, Pane };
+            _optionalTypes = new List<int> { Group, Pane };
 
             int[] specialTests =
             {
                 Button, Custom, Header, Image, StatusBar, Text
             };
 
-            var temp = new List<int>(RequiredTypes);
-            temp.AddRange(OptionalTypes);
+            var temp = new List<int>(_requiredTypes);
+            temp.AddRange(_optionalTypes);
             temp.AddRange(specialTests);
 
-            ExcludedTypes = ControlType.All.Difference(temp);
+            _excludedTypes = ControlType.All.Difference(temp);
         }
 
         [TestMethod]
@@ -51,7 +51,7 @@ namespace Axe.Windows.RulesTests.PropertyConditions
         {
             using (var e = new MockA11yElement())
             {
-                foreach (var controlType in RequiredTypes)
+                foreach (var controlType in _requiredTypes)
                 {
                     e.ControlTypeId = controlType;
                     Assert.IsTrue(Misc.NameRequired.Matches(e));
@@ -64,7 +64,7 @@ namespace Axe.Windows.RulesTests.PropertyConditions
         {
             using (var e = new MockA11yElement())
             {
-                foreach (var controlType in OptionalTypes)
+                foreach (var controlType in _optionalTypes)
                 {
                     e.ControlTypeId = controlType;
                     Assert.IsTrue(Misc.NameOptional.Matches(e));
@@ -77,7 +77,7 @@ namespace Axe.Windows.RulesTests.PropertyConditions
         {
             using (var e = new MockA11yElement())
             {
-                foreach (var controlType in ExcludedTypes)
+                foreach (var controlType in _excludedTypes)
                 {
                     e.ControlTypeId = controlType;
                     Assert.IsFalse(Misc.NameRequired.Matches(e));


### PR DESCRIPTION
#### Details

Code standards are very inconsistent throughout the code base. This PR contains the changes needed to make the `RulesTests` project consistent after locally applying #810. The renames were all done through the IDE, and in most cases the IDE-suggested name was used. In cases where the IDE-supplied name seemed odd, I chose a name that seemed appropriate. There were also several cases where the simplest fix was to make a member static.

##### Motivation

Improve code consistency and clarity

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
A separate PR will be used to normalize the use of the `readonly` keyword in this project

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
