### PR TITLE
chore: rename "ke" variables

### DIFF
--- a/src/CoreTests/Bases/A11yElementTests.cs
+++ b/src/CoreTests/Bases/A11yElementTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.UnitTestSharedLibrary;
@@ -27,7 +27,7 @@ namespace Axe.Windows.CoreTests.Bases
             {
                 Children = new List<A11yElement> { child }
             };
-            var result = parent.FindDescendant(ke => ke.UniqueId == 0);
+            var result = parent.FindDescendant(element => element.UniqueId == 0);
             Assert.AreEqual(result, child);
         }
 
@@ -43,7 +43,7 @@ namespace Axe.Windows.CoreTests.Bases
             {
                 Children = new List<A11yElement> { child },
             };
-            var result = parent.FindDescendant(ke => ke.UniqueId == 0);
+            var result = parent.FindDescendant(element => element.UniqueId == 0);
             Assert.IsNull(result);
         }
 
@@ -69,7 +69,7 @@ namespace Axe.Windows.CoreTests.Bases
                     }
                 }
             };
-            var result = parent.FindDescendant(ke => ke.UniqueId == 0);
+            var result = parent.FindDescendant(element => element.UniqueId == 0);
             Assert.AreEqual(result, grandChild);
         }
 
@@ -92,7 +92,7 @@ namespace Axe.Windows.CoreTests.Bases
             {
                 Children = new List<A11yElement> { child }
             };
-            var result = parent.FindDescendant(ke => ke.UniqueId == 0);
+            var result = parent.FindDescendant(element => element.UniqueId == 0);
             Assert.IsNull(result);
         }
 
@@ -102,13 +102,13 @@ namespace Axe.Windows.CoreTests.Bases
         [TestMethod()]
         public void GetPropertySafelyTest()
         {
-            A11yElement ke = Utility.LoadA11yElementsFromJSON("Resources/A11yElementTest.hier");
+            A11yElement element = Utility.LoadA11yElementsFromJSON("Resources/A11yElementTest.hier");
 
-            Assert.AreEqual("Text Editor", ke.Name);
-            ///Assert.AreEqual(ControlTypes.UIA_EditControlTypeId, ke.ControlTypeId);
-            Assert.AreEqual("edit", ke.LocalizedControlType);
-            Assert.AreEqual("[7,436C,50B051]", ke.RuntimeId);
-            Assert.AreEqual(17260, ke.ProcessId);
+            Assert.AreEqual("Text Editor", element.Name);
+            ///Assert.AreEqual(ControlTypes.UIA_EditControlTypeId, element.ControlTypeId);
+            Assert.AreEqual("edit", element.LocalizedControlType);
+            Assert.AreEqual("[7,436C,50B051]", element.RuntimeId);
+            Assert.AreEqual(17260, element.ProcessId);
 
             Assert.AreEqual(new Rectangle()
             {
@@ -116,11 +116,11 @@ namespace Axe.Windows.CoreTests.Bases
                 Y = 203,
                 Width = 1380,
                 Height = 1009
-            }, ke.BoundingRectangle);
+            }, element.BoundingRectangle);
 
-            Assert.IsTrue(ke.IsContentElement);
-            Assert.IsTrue(ke.IsControlElement);
-            Assert.IsTrue(ke.IsKeyboardFocusable);
+            Assert.IsTrue(element.IsContentElement);
+            Assert.IsTrue(element.IsControlElement);
+            Assert.IsTrue(element.IsKeyboardFocusable);
         }
     }
 }

--- a/src/CoreTests/Bases/A11yPatternPropertyTests.cs
+++ b/src/CoreTests/Bases/A11yPatternPropertyTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.UnitTestSharedLibrary;
@@ -18,18 +18,18 @@ namespace Axe.Windows.CoreTests.Bases
         [TestMethod()]
         public void NodeValueTest()
         {
-            A11yElement ke = Utility.LoadA11yElementsFromJSON("Resources/A11yPatternTest.hier");
+            A11yElement element = Utility.LoadA11yElementsFromJSON("Resources/A11yPatternTest.hier");
 
-            Assert.AreEqual("CanSelectMultiple = False", ke.Patterns[0].Properties[0].NodeValue);
-            Assert.AreEqual("IsSelectionRequired = False", ke.Patterns[0].Properties[1].NodeValue);
+            Assert.AreEqual("CanSelectMultiple = False", element.Patterns[0].Properties[0].NodeValue);
+            Assert.AreEqual("IsSelectionRequired = False", element.Patterns[0].Properties[1].NodeValue);
 
-            Assert.AreEqual("HorizontallyScrollable = False", ke.Patterns[1].Properties[0].NodeValue);
-            Assert.AreEqual("HorizontalScrollPercent  = -1", ke.Patterns[1].Properties[1].NodeValue);
-            Assert.AreEqual("HorizontalViewSize = 100", ke.Patterns[1].Properties[2].NodeValue);
-            Assert.AreEqual("VerticallyScrollable = False", ke.Patterns[1].Properties[3].NodeValue);
-            Assert.AreEqual("VerticalScrollPercent = -1", ke.Patterns[1].Properties[4].NodeValue);
-            Assert.AreEqual("VerticalViewSize = 100", ke.Patterns[1].Properties[5].NodeValue);
-            Assert.AreEqual("ExpandCollapseState = 0", ke.Patterns[2].Properties[0].NodeValue);
+            Assert.AreEqual("HorizontallyScrollable = False", element.Patterns[1].Properties[0].NodeValue);
+            Assert.AreEqual("HorizontalScrollPercent  = -1", element.Patterns[1].Properties[1].NodeValue);
+            Assert.AreEqual("HorizontalViewSize = 100", element.Patterns[1].Properties[2].NodeValue);
+            Assert.AreEqual("VerticallyScrollable = False", element.Patterns[1].Properties[3].NodeValue);
+            Assert.AreEqual("VerticalScrollPercent = -1", element.Patterns[1].Properties[4].NodeValue);
+            Assert.AreEqual("VerticalViewSize = 100", element.Patterns[1].Properties[5].NodeValue);
+            Assert.AreEqual("ExpandCollapseState = 0", element.Patterns[2].Properties[0].NodeValue);
         }
     }
 }

--- a/src/CoreTests/Bases/A11yPatternTests.cs
+++ b/src/CoreTests/Bases/A11yPatternTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.UnitTestSharedLibrary;
@@ -18,13 +18,13 @@ namespace Axe.Windows.CoreTests.Bases
         [TestMethod()]
         public void ToStringTest()
         {
-            A11yElement ke = Utility.LoadA11yElementsFromJSON("Resources/A11yPatternTest.hier");
+            A11yElement element = Utility.LoadA11yElementsFromJSON("Resources/A11yPatternTest.hier");
 
-            Assert.AreEqual("SelectionPattern: False", ke.Patterns[0].ToString());
-            Assert.AreEqual("ScrollPattern: False", ke.Patterns[1].ToString());
-            Assert.AreEqual("ExpandCollapsePattern: 0", ke.Patterns[2].ToString());
-            Assert.AreEqual("ItemContainerPattern: ", ke.Patterns[3].ToString());
-            Assert.AreEqual("SynchronizedInputPattern: ", ke.Patterns[4].ToString());
+            Assert.AreEqual("SelectionPattern: False", element.Patterns[0].ToString());
+            Assert.AreEqual("ScrollPattern: False", element.Patterns[1].ToString());
+            Assert.AreEqual("ExpandCollapsePattern: 0", element.Patterns[2].ToString());
+            Assert.AreEqual("ItemContainerPattern: ", element.Patterns[3].ToString());
+            Assert.AreEqual("SynchronizedInputPattern: ", element.Patterns[4].ToString());
         }
     }
 }

--- a/src/CoreTests/Bases/A11yPropertyTests.cs
+++ b/src/CoreTests/Bases/A11yPropertyTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Core.Bases;
@@ -22,25 +22,25 @@ namespace Axe.Windows.CoreTests.Bases
         [TestMethod()]
         public void ToStringTest()
         {
-            A11yElement ke = Utility.LoadA11yElementsFromJSON("Resources/A11yPropertyTest.hier");
+            A11yElement element = Utility.LoadA11yElementsFromJSON("Resources/A11yPropertyTest.hier");
             string kpVal;
 
-            kpVal = ke.Properties[PropertyType.UIA_ControlTypePropertyId].ToString();
+            kpVal = element.Properties[PropertyType.UIA_ControlTypePropertyId].ToString();
             Assert.AreEqual("Text(50020)", kpVal);
 
-            kpVal = ke.Properties[PropertyType.UIA_RuntimeIdPropertyId].ToString();
+            kpVal = element.Properties[PropertyType.UIA_RuntimeIdPropertyId].ToString();
             Assert.AreEqual("[7,1F48,24D4850]", kpVal);
 
-            kpVal = ke.Properties[PropertyType.UIA_BoundingRectanglePropertyId].ToString();
+            kpVal = element.Properties[PropertyType.UIA_BoundingRectanglePropertyId].ToString();
             Assert.AreEqual("[l=1285,t=91,r=1368,b=116]", kpVal);
 
-            kpVal = ke.Properties[PropertyType.UIA_OrientationPropertyId].ToString();
+            kpVal = element.Properties[PropertyType.UIA_OrientationPropertyId].ToString();
             Assert.AreEqual("None(0)", kpVal);
 
-            kpVal = ke.Properties[PropertyType.UIA_LabeledByPropertyId].ToString();
+            kpVal = element.Properties[PropertyType.UIA_LabeledByPropertyId].ToString();
             Assert.AreEqual("Test", kpVal);
 
-            kpVal = ke.Properties[PropertyType.UIA_HasKeyboardFocusPropertyId].ToString();
+            kpVal = element.Properties[PropertyType.UIA_HasKeyboardFocusPropertyId].ToString();
             Assert.AreEqual("False", kpVal);
         }
 

--- a/src/CoreTests/Misc/MiscTests.cs
+++ b/src/CoreTests/Misc/MiscTests.cs
@@ -22,8 +22,8 @@ namespace Axe.Windows.CoreTests.Misc
         [TestMethod()]
         public void GetStatusCounts()
         {
-            A11yElement ke = UnitTestSharedLibrary.Utility.LoadA11yElementsFromJSON("Snapshots/Taskbar.snapshot");
-            foreach (var item in ke.ScanResults.Items)
+            A11yElement element = UnitTestSharedLibrary.Utility.LoadA11yElementsFromJSON("Snapshots/Taskbar.snapshot");
+            foreach (var item in element.ScanResults.Items)
             {
                 item.Items = new System.Collections.Generic.List<RuleResult>();
                 RuleResult r = new RuleResult
@@ -32,11 +32,11 @@ namespace Axe.Windows.CoreTests.Misc
                 };
                 item.Items.Add(r);
             };
-            foreach (var c in ke.Children)
+            foreach (var c in element.Children)
             {
                 Utility.PopulateChildrenTests(c);
             };
-            var statuses = (from child in ke.Children
+            var statuses = (from child in element.Children
                             select child.TestStatus);
             int[] statusCounts = statuses.GetStatusCounts();
             Assert.AreEqual(3, statusCounts[(int)ScanStatus.Fail]);

--- a/src/UnitTestSharedLibrary/Utility.cs
+++ b/src/UnitTestSharedLibrary/Utility.cs
@@ -56,23 +56,23 @@ namespace Axe.Windows.UnitTestSharedLibrary
         ///     pass if the control is a button (any predicate would work)
         ///     and returns number that should pass
         /// </summary>
-        /// <param name="ke"></param>
+        /// <param name="element"></param>
         /// <returns></returns>
-        public static void PopulateChildrenTests(A11yElement ke)
+        public static void PopulateChildrenTests(A11yElement element)
         {
-            if (ke == null) throw new ArgumentNullException(nameof(ke));
+            if (element == null) throw new ArgumentNullException(nameof(element));
 
-            foreach (var item in ke.ScanResults.Items)
+            foreach (var item in element.ScanResults.Items)
             {
                 item.Items = new List<RuleResult>
                 {
                     new RuleResult
                     {
-                        Status = ke.ControlTypeId == Axe.Windows.Core.Types.ControlType.UIA_ButtonControlTypeId ? ScanStatus.Pass : ScanStatus.Fail
+                        Status = element.ControlTypeId == Axe.Windows.Core.Types.ControlType.UIA_ButtonControlTypeId ? ScanStatus.Pass : ScanStatus.Fail
                     }
                 };
             };
-            foreach (var c in ke.Children)
+            foreach (var c in element.Children)
             {
                 PopulateChildrenTests(c);
             };


### PR DESCRIPTION
#### Details

There are several places where the test code has things like `A11yElement ke`, which seems like a very odd naming choice. The `A11yElement` class was renamed in 2019, and `ke` was derived from the old class name. This PR renames all instances of `ke` to `element`.

##### Motivation

Clean up remnants of old code

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
