### PR TITLE
chore: Miscellaneous cleanup

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -55,6 +55,7 @@ dotnet_style_prefer_auto_properties = true:silent
 dotnet_style_prefer_conditional_expression_over_assignment = true:silent
 dotnet_style_prefer_conditional_expression_over_return = true:silent
 dotnet_remove_unnecessary_suppression_exclusions=all
+dotnet_style_prefer_compound_assignment = false
 ###############################
 # Naming Conventions          #
 ###############################

--- a/src/Actions/Actions/CaptureAction.cs
+++ b/src/Actions/Actions/CaptureAction.cs
@@ -11,7 +11,6 @@ using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 
 namespace Axe.Windows.Actions
 {

--- a/src/Actions/Actions/DataManager.cs
+++ b/src/Actions/Actions/DataManager.cs
@@ -229,7 +229,7 @@ namespace Axe.Windows.Actions
                 {
                     // We need an immutable copy of the ecId values for cleanup
                     var ecIdList = ElementContexts.Keys.ToList();
-                    foreach(Guid ecId in ecIdList)
+                    foreach (Guid ecId in ecIdList)
                     {
                         RemoveDataContext(ecId, false);
                     }

--- a/src/Actions/Actions/ListenAction.cs
+++ b/src/Actions/Actions/ListenAction.cs
@@ -23,9 +23,9 @@ namespace Axe.Windows.Actions
         /// <summary>
         /// External event listener. it should be called if it is not null.
         /// </summary>
-        public HandleUIAutomationEventMessage ExternalListener { get; private set; }
+        public HandleUIAutomationEventMessage ExternalListener { get; }
 
-        public Guid Id { get; private set; }
+        public Guid Id { get; }
 
         bool IsRunning;
 

--- a/src/Actions/Actions/LoadActionParts.cs
+++ b/src/Actions/Actions/LoadActionParts.cs
@@ -15,12 +15,12 @@ namespace Axe.Windows.Actions
         /// <summary>
         /// Stored element
         /// </summary>
-        public A11yElement Element { get; private set; }
+        public A11yElement Element { get; }
 
         /// <summary>
         /// Stored screenshot
         /// </summary>
-        public Bitmap Bmp { get; private set; }
+        public Bitmap Bmp { get; }
 
         /// <summary>
         /// Synthesized screenshot
@@ -30,7 +30,7 @@ namespace Axe.Windows.Actions
         /// <summary>
         /// Metadata
         /// </summary>
-        public SnapshotMetaInfo MetaInfo { get; private set; }
+        public SnapshotMetaInfo MetaInfo { get; }
 
         /// <summary>
         /// Constructor

--- a/src/Actions/Actions/SelectAction.cs
+++ b/src/Actions/Actions/SelectAction.cs
@@ -65,7 +65,7 @@ namespace Axe.Windows.Actions
         /// </summary>
         public bool IsMouseSelectOn { get; set; }
 
-        public TreeTracker TreeTracker { get; private set; }
+        public TreeTracker TreeTracker { get; }
 
         // Backing object for POIElementContext - is disposed via POIElementContext property
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "_POIElementContext")]

--- a/src/Actions/Contexts/DefaultActionContext.cs
+++ b/src/Actions/Contexts/DefaultActionContext.cs
@@ -20,7 +20,7 @@ namespace Axe.Windows.Actions.Contexts
         public SelectAction SelectAction => SelectAction.GetDefaultInstance();
 
         public Registrar Registrar => DesktopDataContext.Registrar;
-        
+
         public DesktopDataContext DesktopDataContext => DesktopDataContext.DefaultContext;
 
         protected virtual void Dispose(bool disposing)

--- a/src/Actions/Contexts/ElementContext.cs
+++ b/src/Actions/Contexts/ElementContext.cs
@@ -21,12 +21,12 @@ namespace Axe.Windows.Actions.Contexts
         /// <summary>
         /// Element information
         /// </summary>
-        public A11yElement Element { get; private set; }
+        public A11yElement Element { get; }
 
         /// <summary>
         /// Indicate the Select Type (Live or Loaded)
         /// </summary>
-        public SelectType SelectType { get; private set; }
+        public SelectType SelectType { get; }
 
         /// <summary>
         /// Element Context Id

--- a/src/Actions/Trackers/BaseTracker.cs
+++ b/src/Actions/Trackers/BaseTracker.cs
@@ -18,8 +18,6 @@ namespace Axe.Windows.Actions.Trackers
     {
         internal Action<A11yElement> SetElement;
 
-        internal int ProcessId;
-
         internal bool IsStarted;
 
         /// <summary>

--- a/src/Automation/Data/Config.cs
+++ b/src/Automation/Data/Config.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Axe.Windows.Actions;
-
 namespace Axe.Windows.Automation
 {
     /// <summary>

--- a/src/Automation/Data/ScanOptions.cs
+++ b/src/Automation/Data/ScanOptions.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Threading;
-
 namespace Axe.Windows.Automation.Data
 {
     /// <summary>

--- a/src/Automation/Interfaces/IScanner.cs
+++ b/src/Automation/Interfaces/IScanner.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Automation.Data;
-using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -3,11 +3,9 @@
 using Axe.Windows.Automation;
 using Axe.Windows.Automation.Data;
 using Axe.Windows.UnitTestSharedLibrary;
-using Microsoft.VisualStudio.TestPlatform.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -27,8 +25,6 @@ namespace Axe.Windows.AutomationTests
         const int WindowsFormsControlSamplerKnownErrorCount = 6;
         const int WpfControlSamplerKnownErrorCount = 7;
         const int WindowsFormsMultiWindowSamplerAppAllErrorCount = 12;
-        const int WindowsFormsMultiWindowSamplerSingleWindowAllErrorCount = 6;
-
         readonly string WildlifeManagerAppPath = Path.GetFullPath("../../../../../tools/WildlifeManager/WildlifeManager.exe");
         readonly string Win32ControlSamplerAppPath = Path.GetFullPath("../../../../../tools/Win32ControlSampler/Win32ControlSampler.exe");
         readonly string WindowsFormsControlSamplerAppPath = Path.GetFullPath("../../../../../tools/WindowsFormsControlSampler/WindowsFormsControlSampler.exe");
@@ -70,7 +66,7 @@ namespace Axe.Windows.AutomationTests
             }
         }
 
-        List<Process> TestProcesses = new List<Process>();
+        readonly List<Process> TestProcesses = new List<Process>();
 
         [TestCleanup]
         public void Cleanup()

--- a/src/AutomationTests/SnapshotCommandTests.cs
+++ b/src/AutomationTests/SnapshotCommandTests.cs
@@ -9,7 +9,6 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection.Metadata.Ecma335;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/CLITests/TextWriterVerifier.cs
+++ b/src/CLITests/TextWriterVerifier.cs
@@ -108,7 +108,6 @@ namespace AxeWindowsCLITests
             Assert.AreEqual(verified, _actualWriteCalls.Count);
         }
 
-
         private void AddWriteCall(string format, WriteSource source)
         {
             _actualWriteCalls.Add(new WriteCall(format, source));

--- a/src/Core/Bases/A11yPattern.cs
+++ b/src/Core/Bases/A11yPattern.cs
@@ -49,7 +49,7 @@ namespace Axe.Windows.Core.Bases
         /// Pattern method list
         /// </summary>
         [JsonIgnore]
-        public IList<MethodInfo> Methods { get; private set; }
+        public IList<MethodInfo> Methods { get; }
 
         /// <summary>
         /// Constructor

--- a/src/Core/Results/ScanResult.cs
+++ b/src/Core/Results/ScanResult.cs
@@ -92,7 +92,6 @@ namespace Axe.Windows.Core.Results
         /// </summary>
         public ScanResult()
         {
-
         }
 
         /// <summary>

--- a/src/Core/Results/ScanResults.cs
+++ b/src/Core/Results/ScanResults.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.Core.Results
         /// <summary>
         /// Items with ScanResult
         /// </summary>
-        public IList<ScanResult> Items { get; private set; }
+        public IList<ScanResult> Items { get; }
 
         /// <summary>
         /// Aggregated status

--- a/src/Core/Types/TypeBase.cs
+++ b/src/Core/Types/TypeBase.cs
@@ -14,7 +14,7 @@ namespace Axe.Windows.Core.Types
     public abstract class TypeBase
     {
         const string DefaultNamePattern = "UIA_";
-        protected Dictionary<int, string> Dic { get; private set; }
+        protected Dictionary<int, string> Dic { get; }
         private readonly string _namePattern;
 
         protected TypeBase() : this(DefaultNamePattern) { }

--- a/src/CoreTests/Bases/A11yElementTests.cs
+++ b/src/CoreTests/Bases/A11yElementTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.UnitTestSharedLibrary;
@@ -14,7 +14,6 @@ namespace Axe.Windows.CoreTests.Bases
     [TestClass()]
     public class A11yElementTests
     {
-
         [TestMethod()]
         [Timeout(2000)]
         public void FindDescendent_SimpleCondition_ReturnsChild()

--- a/src/CoreTests/CustomObjects/Converters/DoubleConverterTests.cs
+++ b/src/CoreTests/CustomObjects/Converters/DoubleConverterTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Core.CustomObjects.Converters;
-
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 

--- a/src/CoreTests/CustomObjects/Converters/EnumConverterTests.cs
+++ b/src/CoreTests/CustomObjects/Converters/EnumConverterTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Core.CustomObjects.Converters;
-
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;

--- a/src/CoreTests/CustomObjects/Converters/IntConverterTests.cs
+++ b/src/CoreTests/CustomObjects/Converters/IntConverterTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Core.CustomObjects.Converters;
-
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 

--- a/src/CoreTests/CustomObjects/Converters/PointConverterTests.cs
+++ b/src/CoreTests/CustomObjects/Converters/PointConverterTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Core.CustomObjects.Converters;
-
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 

--- a/src/Desktop/ColorContrastAnalyzer/Color.cs
+++ b/src/Desktop/ColorContrastAnalyzer/Color.cs
@@ -11,7 +11,6 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
      */
     public class Color
     {
-
         /**
          * The luminance difference that will determine whether two colors are the same.
          * This helps deal with Anti-Aliasing in determining transitions for detecting text.

--- a/src/Desktop/ColorContrastAnalyzer/ContrastTransition.cs
+++ b/src/Desktop/ColorContrastAnalyzer/ContrastTransition.cs
@@ -43,7 +43,6 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
 
             if (size > _colorContrastConfig.MaxTextThickness || (size > 1 && StartingColor.Equals(color)))
             {
-
                 if (StartingColor.Equals(color))
                 {
                     IsConnecting = true;

--- a/src/Desktop/ColorContrastAnalyzer/Pixel.cs
+++ b/src/Desktop/ColorContrastAnalyzer/Pixel.cs
@@ -5,9 +5,9 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
 {
     public class Pixel
     {
-        public int Row { get; private set; }
-        public int Column { get; private set; }
-        public Color Color { get; private set; }
+        public int Row { get; }
+        public int Column { get; }
+        public Color Color { get; }
 
         public Pixel(Color color, int row, int column)
         {

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -98,7 +98,7 @@ namespace Axe.Windows.Desktop.UIAutomation
         {
             foreach (var list in elementLists)
             {
-                foreach(var element in list)
+                foreach (var element in list)
                 {
                     Marshal.ReleaseComObject(element);
                 }

--- a/src/Desktop/UIAutomation/EventHandlers/ActiveTextPositionChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/ActiveTextPositionChangedEventListener.cs
@@ -53,7 +53,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
         protected override void Dispose(bool disposing)
         {
-            if (!disposedValue)
+            if (!DisposedValue)
             {
                 if (disposing)
                 {

--- a/src/Desktop/UIAutomation/EventHandlers/ChangesEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/ChangesEventListener.cs
@@ -63,7 +63,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
         protected override void Dispose(bool disposing)
         {
-            if (!disposedValue)
+            if (!DisposedValue)
             {
                 if (disposing)
                 {

--- a/src/Desktop/UIAutomation/EventHandlers/EventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventListener.cs
@@ -41,7 +41,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
         protected override void Dispose(bool disposing)
         {
-            if (!disposedValue)
+            if (!DisposedValue)
             {
                 if (disposing)
                 {

--- a/src/Desktop/UIAutomation/EventHandlers/EventListenerBase.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventListenerBase.cs
@@ -13,11 +13,11 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
     public abstract class EventListenerBase : IDisposable
     {
-        public int EventId { get; private set; }
-        public IUIAutomationElement Element { get; private set; }
+        public int EventId { get; }
+        public IUIAutomationElement Element { get; }
 
-        public HandleUIAutomationEventMessage ListenEventMessage { get; private set; }
-        public TreeScope Scope { get; private set; }
+        public HandleUIAutomationEventMessage ListenEventMessage { get; }
+        public TreeScope Scope { get; }
         public bool IsHooked { get; protected set; }
         private CUIAutomation UIAutomation;
         private CUIAutomation8 UIAutomation8;

--- a/src/Desktop/UIAutomation/EventHandlers/EventListenerBase.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventListenerBase.cs
@@ -65,11 +65,11 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         }
 
         #region IDisposable Support
-        protected bool disposedValue { get; private set; } // To detect redundant calls
+        protected bool DisposedValue { get; private set; } // To detect redundant calls
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposedValue)
+            if (!DisposedValue)
             {
                 if (disposing)
                 {
@@ -80,7 +80,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     }
                 }
 
-                disposedValue = true;
+                DisposedValue = true;
             }
         }
 

--- a/src/Desktop/UIAutomation/EventHandlers/EventListenerFactory.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventListenerFactory.cs
@@ -25,9 +25,9 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
         public NotificationEventListener EventListenerNotification { get; private set; }
         public TextEditTextChangedEventListener EventListenerTextEditTextChanged { get; private set; }
         public ActiveTextPositionChangedEventListener EventListenerActiveTextPositionChanged { get; private set; }
-        public Dictionary<int, EventListener> EventListeners { get; private set; }
+        public Dictionary<int, EventListener> EventListeners { get; }
 
-        public TreeScope Scope { get; private set; }
+        public TreeScope Scope { get; }
         public CUIAutomation UIAutomation { get; private set; }
         public CUIAutomation8 UIAutomation8 { get; private set; }
 

--- a/src/Desktop/UIAutomation/EventHandlers/FocusChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/FocusChangedEventListener.cs
@@ -9,7 +9,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 {
     public class FocusChangedEventListener : IDisposable, IUIAutomationFocusChangedEventHandler
     {
-        public HandleUIAutomationEventMessage ListenEventMessage { get; private set; }
+        public HandleUIAutomationEventMessage ListenEventMessage { get; }
 
         /// <summary>
         /// indicate whether event handler is hooked or not.

--- a/src/Desktop/UIAutomation/EventHandlers/NotificationEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/NotificationEventListener.cs
@@ -53,7 +53,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
         protected override void Dispose(bool disposing)
         {
-            if (!disposedValue)
+            if (!DisposedValue)
             {
                 if (disposing)
                 {

--- a/src/Desktop/UIAutomation/EventHandlers/PropertyChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/PropertyChangedEventListener.cs
@@ -54,7 +54,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
         protected override void Dispose(bool disposing)
         {
-            if (!disposedValue)
+            if (!DisposedValue)
             {
                 if (disposing)
                 {

--- a/src/Desktop/UIAutomation/EventHandlers/StructureChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/StructureChangedEventListener.cs
@@ -46,7 +46,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
         protected override void Dispose(bool disposing)
         {
-            if (!disposedValue)
+            if (!DisposedValue)
             {
                 if (disposing)
                 {

--- a/src/Desktop/UIAutomation/EventHandlers/StructureChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/StructureChangedEventListener.cs
@@ -7,7 +7,6 @@ using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 {
-
     public class StructureChangedEventListener : EventListenerBase, IUIAutomationStructureChangedEventHandler
     {
         /// <summary>

--- a/src/Desktop/UIAutomation/EventHandlers/TextEditTextChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/TextEditTextChangedEventListener.cs
@@ -64,7 +64,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
 
         protected override void Dispose(bool disposing)
         {
-            if (!disposedValue)
+            if (!DisposedValue)
             {
                 if (disposing)
                 {

--- a/src/Desktop/UIAutomation/Patterns/CustomNavigationPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/CustomNavigationPattern.cs
@@ -8,7 +8,6 @@ using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
 {
-
     /// <summary>
     /// CustomNavigation Pattern
     /// https://msdn.microsoft.com/en-us/library/windows/desktop/dn858171(v=vs.85).aspx

--- a/src/Desktop/UIAutomation/Patterns/TextRange.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextRange.cs
@@ -25,7 +25,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
         /// <summary>
         /// TextPattern which this Range was from
         /// </summary>
-        public TextPattern TextPattern { get; private set; }
+        public TextPattern TextPattern { get; }
 
         public TextRange(IUIAutomationTextRange tr, TextPattern tp)
         {

--- a/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
@@ -22,14 +22,14 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// <summary>
         /// Oldest in Ancestry
         /// </summary>
-        public A11yElement First { get; private set; }
+        public A11yElement First { get; }
 
         /// <summary>
         /// Last in Ancestry
         /// </summary>
-        public A11yElement Last { get; private set; }
+        public A11yElement Last { get; }
 
-        public IList<A11yElement> Items { get; private set; }
+        public IList<A11yElement> Items { get; }
 
         private readonly IUIAutomationTreeWalker TreeWalker;
 

--- a/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
@@ -4,7 +4,6 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Desktop.Resources;
-using Axe.Windows.Desktop.UIAutomation.CustomObjects;
 using Axe.Windows.Telemetry;
 using System;
 using System.Collections.Generic;

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
@@ -29,7 +29,7 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// <summary>
         /// List to keep all elements in tree walking(Ancestors, self and children)
         /// </summary>
-        public IList<A11yElement> Elements { get; private set; }
+        public IList<A11yElement> Elements { get; }
 
         /// <summary>
         /// Top root node in whole hierarchy

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -34,11 +34,11 @@ namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers
         /// </summary>
         public IList<A11yElement> Elements { get; }
 
-        public TimeSpan LastWalkTime { get; private set; }
+        public TimeSpan LastWalkTime { get; }
 
         public TreeViewMode WalkerMode { get; private set; }
 
-        public A11yElement SelectedElement { get; private set; }
+        public A11yElement SelectedElement { get; }
 
         public A11yElement TopMostElement { get; private set; }
 

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForTest.cs
@@ -4,14 +4,12 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;
-using Axe.Windows.Desktop.UIAutomation.CustomObjects;
 using Axe.Windows.RuleSelection;
 using Axe.Windows.Telemetry;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading;
 using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.TreeWalkers

--- a/src/Desktop/Utility/ProcessItem.cs
+++ b/src/Desktop/Utility/ProcessItem.cs
@@ -9,9 +9,9 @@ namespace Axe.Windows.Desktop.Utility
 {
     public class ProcessItem
     {
-        public IntPtr HWnd { get; private set; }
-        public int ProcessID { get; private set; }
-        public string MainWindowTitle { get; private set; }
+        public IntPtr HWnd { get; }
+        public int ProcessID { get; }
+        public string MainWindowTitle { get; }
 
         public ProcessItem(Process p)
         {

--- a/src/RuleSelection/ReferenceLink.cs
+++ b/src/RuleSelection/ReferenceLink.cs
@@ -8,8 +8,8 @@ namespace Axe.Windows.RuleSelection
 {
     class ReferenceLink : IReferenceLink
     {
-        public string ShortDescription { get; private set; }
-        public Uri Uri { get; private set; }
+        public string ShortDescription { get; }
+        public Uri Uri { get; }
 
         public ReferenceLink(string shortDescription, string url)
         {

--- a/src/Rules/Conditions/ConditionContext.cs
+++ b/src/Rules/Conditions/ConditionContext.cs
@@ -13,6 +13,6 @@ namespace Axe.Windows.Rules
     /// </summary>
     class ConditionContext
     {
-        public Stack<IA11yElement> ReferenceElements { get; private set; } = new Stack<IA11yElement>();
+        public Stack<IA11yElement> ReferenceElements { get; } = new Stack<IA11yElement>();
     } // class
 } // namespace

--- a/src/Rules/Library/BoundingRectangleSizeReasonable.cs
+++ b/src/Rules/Library/BoundingRectangleSizeReasonable.cs
@@ -7,9 +7,9 @@ using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
+using static Axe.Windows.Rules.PropertyConditions.Framework;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
-using static Axe.Windows.Rules.PropertyConditions.Framework;
 
 namespace Axe.Windows.Rules.Library
 {

--- a/src/Rules/Library/IsContentElementFalseOptional.cs
+++ b/src/Rules/Library/IsContentElementFalseOptional.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
@@ -15,7 +15,6 @@ namespace Axe.Windows.Rules.Library
     {
         public IsContentElementFalseOptional()
         {
-
             Info.Description = Descriptions.IsContentElementFalseOptional;
             Info.HowToFix = HowToFix.IsContentElementFalseOptional;
             Info.Standard = A11yCriteriaId.ObjectInformation;

--- a/src/Rules/Rule.cs
+++ b/src/Rules/Rule.cs
@@ -17,7 +17,7 @@ namespace Axe.Windows.Rules
     abstract class Rule : IRule
     {
         public RuleInfo Info { get; private set; }
-        public Condition Condition { get; private set; }
+        public Condition Condition { get; }
 
         protected Rule()
         {

--- a/src/RulesTest/Library/BoundingRectangleSizeReasonableTests.cs
+++ b/src/RulesTest/Library/BoundingRectangleSizeReasonableTests.cs
@@ -44,7 +44,7 @@ namespace Axe.Windows.RulesTests.Library
                 Assert.IsFalse(Rule.Condition.Matches(e));
             } // using
         }
-        
+
         [TestMethod]
         public void TestBoundingRectangleSizeReasonableTelerikSparklineColumnUWPFail()
         {

--- a/src/RulesTest/Library/ControlShouldSupportExpandCollapsePatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportExpandCollapsePatternTests.cs
@@ -109,7 +109,6 @@ namespace Axe.Windows.RulesTests.Library
             Assert.IsTrue(Rule.PassesTest(e));
         }
 
-
         /// <summary>
         /// Condition should match since SplitButton is child of a Pane
         /// and ExpandCollapse is supported. so scan succeeds

--- a/src/RulesTest/Library/FrameworkDoesNotSupportUIAutomationTests.cs
+++ b/src/RulesTest/Library/FrameworkDoesNotSupportUIAutomationTests.cs
@@ -9,7 +9,6 @@ using Moq;
 namespace Axe.Windows.RulesTests.Library
 {
     [TestClass]
-
     public class FrameworkDoesNotSupportUIAutomationTests
     {
         private static readonly Rules.IRule Rule = new Rules.Library.FrameworkDoesNotSupportUIAutomation();

--- a/src/RulesTest/Library/IsControlElementTrueRequiredButtonWPFTests.cs
+++ b/src/RulesTest/Library/IsControlElementTrueRequiredButtonWPFTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Bases;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -16,7 +16,6 @@ namespace Axe.Windows.RulesTests.Library
         private const int GenericRequiredControlType = Axe.Windows.Core.Types.ControlType.UIA_ComboBoxControlTypeId;
         private const int TextType = Axe.Windows.Core.Types.ControlType.UIA_TextControlTypeId;
         private const int ButtonType = Axe.Windows.Core.Types.ControlType.UIA_ButtonControlTypeId;
-        private const int EditType = Axe.Windows.Core.Types.ControlType.UIA_EditControlTypeId;
 
         private static Rules.IRule Rule = new Rules.Library.IsControlElementTrueRequiredButtonWPF();
         private Mock<IA11yElement> _elementMock;

--- a/src/RulesTest/RuleRunnerTests.cs
+++ b/src/RulesTest/RuleRunnerTests.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Axe.Windows.RulesTests
 {


### PR DESCRIPTION
#### Details

A few general cleanup changes:
1. Disable the `dotnet_style_prefer_compound_assignment` rule in .editorconfig, since it's a C# 8.0 feature and .NET standard 2.0 assumes C# 7.3 support
2. Remove private setters that aren't needed. Omitting the private setter means that the property can only be set in the constructor. Methodology was to remove _all_ private setters, then bring back the ones that the compiler said we need
3. Rename the `EventListenerBase.disposedValue` property to `DisposedValue` (it's protected, so the .editorconfig rule didn't catch it). This updated its usage in all derived classes, as well.
4. Remove some unreferenced fields (called out by the IDE)
5. Remove extra newlines that are floating around
6. Run the IDE's code cleanup agent to tidy up using blocks, adjust whitespace in lines, etc. This always cuts a little too deep with the Custom Actions, so some of these changes were manually backed out to allow the build to succeed

##### Motivation

After this, I think we're .editorconfig clean

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
