### PR TITLE
chore: Provide consistent spacing after license header

### DIFF
--- a/src/Actions/Actions/PrivacyExtensions.cs
+++ b/src/Actions/Actions/PrivacyExtensions.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Win32;
 using System.Drawing;

--- a/src/Actions/AssemblyInfo.cs
+++ b/src/Actions/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;

--- a/src/Actions/Attributes/InteractionLevelAttribute.cs
+++ b/src/Actions/Attributes/InteractionLevelAttribute.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Actions.Enums;
 using System;
 

--- a/src/Actions/Contexts/ElementContext.cs
+++ b/src/Actions/Contexts/ElementContext.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Actions.Enums;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Desktop.Utility;

--- a/src/Actions/Contexts/ElementDataContext.cs
+++ b/src/Actions/Contexts/ElementDataContext.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Actions.Enums;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;

--- a/src/Actions/Misc/ExtensionMethods.cs
+++ b/src/Actions/Misc/ExtensionMethods.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Actions.Resources;
 using Axe.Windows.Core.Bases;

--- a/src/ActionsTests/Misc/ExtensionMethodsTests.cs
+++ b/src/ActionsTests/Misc/ExtensionMethodsTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Actions.Misc;
 using Axe.Windows.Core.Bases;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/Automation/AssemblyInfo.cs
+++ b/src/Automation/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;

--- a/src/Automation/AxeWindowsAutomationException.cs
+++ b/src/Automation/AxeWindowsAutomationException.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Automation.Resources;
 using System;
 using System.Runtime.Serialization;

--- a/src/Automation/Data/ElementInfo.cs
+++ b/src/Automation/Data/ElementInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections.Generic;
 
 namespace Axe.Windows.Automation

--- a/src/Automation/Data/ScanResult.cs
+++ b/src/Automation/Data/ScanResult.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules;
 
 namespace Axe.Windows.Automation

--- a/src/Automation/Data/WindowScanOutput.cs
+++ b/src/Automation/Data/WindowScanOutput.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections.Generic;
 
 namespace Axe.Windows.Automation

--- a/src/Automation/Enums/OutputFileFormat.cs
+++ b/src/Automation/Enums/OutputFileFormat.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.Automation

--- a/src/Automation/Interfaces/IScanResultsAssembler.cs
+++ b/src/Automation/Interfaces/IScanResultsAssembler.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 
 namespace Axe.Windows.Automation

--- a/src/Automation/OutputFileHelper.cs
+++ b/src/Automation/OutputFileHelper.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Automation.Resources;
 using Axe.Windows.Core.Exceptions;
 using Axe.Windows.Core.Misc;

--- a/src/Automation/ScanResultsAssembler.cs
+++ b/src/Automation/ScanResultsAssembler.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Automation.Resources;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;

--- a/src/Automation/ScanToolsBuilder.cs
+++ b/src/Automation/ScanToolsBuilder.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.Automation

--- a/src/Automation/ScannerFactory.cs
+++ b/src/Automation/ScannerFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.Automation

--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Automation;
 using Axe.Windows.Automation.Data;
 using Axe.Windows.UnitTestSharedLibrary;

--- a/src/AutomationTests/DummyDisposable.cs
+++ b/src/AutomationTests/DummyDisposable.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.AutomationTests

--- a/src/AutomationTests/OutputFileHelperTests.cs
+++ b/src/AutomationTests/OutputFileHelperTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Automation;
 using Axe.Windows.Automation.Resources;
 using Axe.Windows.SystemAbstractions;

--- a/src/AutomationTests/ScanResultsAssemblerTests.cs
+++ b/src/AutomationTests/ScanResultsAssemblerTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Automation;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;

--- a/src/CI/Program.cs
+++ b/src/CI/Program.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Automation;
 using System;
 

--- a/src/CLI/AssemblyInfo.cs
+++ b/src/CLI/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;

--- a/src/CLI/ScanDelay.cs
+++ b/src/CLI/ScanDelay.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using AxeWindowsCLI.Resources;
 using System;
 using System.Globalization;

--- a/src/Core/Attributes/PatternEventAttribute.cs
+++ b/src/Core/Attributes/PatternEventAttribute.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.Core.Attributes

--- a/src/Core/Attributes/PatternMethodAttribute.cs
+++ b/src/Core/Attributes/PatternMethodAttribute.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.Core.Attributes

--- a/src/Core/Bases/A11yElement.cs
+++ b/src/Core/Bases/A11yElement.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Exceptions;
 using Axe.Windows.Core.Misc;

--- a/src/Core/Bases/A11yElementData.cs
+++ b/src/Core/Bases/A11yElementData.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections.Generic;
 
 namespace Axe.Windows.Core.Bases

--- a/src/Core/Bases/A11yPattern.cs
+++ b/src/Core/Bases/A11yPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;

--- a/src/Core/Bases/A11yPatternProperty.cs
+++ b/src/Core/Bases/A11yPatternProperty.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Misc;
 using System;
 

--- a/src/Core/Bases/IA11yElement.cs
+++ b/src/Core/Bases/IA11yElement.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 using System;
 using System.Collections.Generic;

--- a/src/Core/Bases/IA11yEventMessage.cs
+++ b/src/Core/Bases/IA11yEventMessage.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections.Generic;
 
 namespace Axe.Windows.Core.Bases

--- a/src/Core/Exceptions/AxeWindowsException.cs
+++ b/src/Core/Exceptions/AxeWindowsException.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Runtime.Serialization;
 

--- a/src/Core/Exceptions/TreeNavigationFailedException.cs
+++ b/src/Core/Exceptions/TreeNavigationFailedException.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Runtime.Serialization;
 

--- a/src/Core/HelpLinks/HelpUrl.cs
+++ b/src/Core/HelpLinks/HelpUrl.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 
 namespace Axe.Windows.Core.HelpLinks

--- a/src/Core/Misc/BoundedCounter.cs
+++ b/src/Core/Misc/BoundedCounter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Resources;
 using System;
 

--- a/src/Core/Misc/ExtensionMethods.cs
+++ b/src/Core/Misc/ExtensionMethods.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;

--- a/src/Core/Misc/FileHelpers.cs
+++ b/src/Core/Misc/FileHelpers.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Newtonsoft.Json;
 using System;
 using System.IO;

--- a/src/Core/Misc/ListHelper.cs
+++ b/src/Core/Misc/ListHelper.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 

--- a/src/Core/Misc/PackageInfo.cs
+++ b/src/Core/Misc/PackageInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Reflection;
 

--- a/src/Core/Misc/Utility.cs
+++ b/src/Core/Misc/Utility.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Telemetry;
 using System;
 using System.Diagnostics;

--- a/src/Core/Results/RuleResult.cs
+++ b/src/Core/Results/RuleResult.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.HelpLinks;
 using Newtonsoft.Json;

--- a/src/Core/Results/ScanMetaInfo.cs
+++ b/src/Core/Results/ScanMetaInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Resources;

--- a/src/Core/Results/ScanResult.cs
+++ b/src/Core/Results/ScanResult.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.HelpLinks;

--- a/src/Core/Results/ScanResults.cs
+++ b/src/Core/Results/ScanResults.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Misc;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Core/Types/ControlType.cs
+++ b/src/Core/Types/ControlType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Text;
 
 using static System.FormattableString;

--- a/src/Core/Types/HeadingLevelType.cs
+++ b/src/Core/Types/HeadingLevelType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Text;
 
 using static System.FormattableString;

--- a/src/Core/Types/LandmarkType.cs
+++ b/src/Core/Types/LandmarkType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Text;
 
 using static System.FormattableString;

--- a/src/Core/Types/PatternType.cs
+++ b/src/Core/Types/PatternType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Text;
 
 namespace Axe.Windows.Core.Types

--- a/src/Core/Types/PlatformPropertyType.cs
+++ b/src/Core/Types/PlatformPropertyType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Text;
 
 namespace Axe.Windows.Core.Types

--- a/src/Core/Types/PropertyType.cs
+++ b/src/Core/Types/PropertyType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Text;
 
 namespace Axe.Windows.Core.Types

--- a/src/Core/Types/TypeBase.cs
+++ b/src/Core/Types/TypeBase.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Resources;
 using System;
 using System.Collections.Generic;

--- a/src/CoreTests/Bases/A11yElementTests.cs
+++ b/src/CoreTests/Bases/A11yElementTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.UnitTestSharedLibrary;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/CoreTests/Bases/A11yPatternPropertyTests.cs
+++ b/src/CoreTests/Bases/A11yPatternPropertyTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.UnitTestSharedLibrary;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/CoreTests/Bases/A11yPatternTests.cs
+++ b/src/CoreTests/Bases/A11yPatternTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.UnitTestSharedLibrary;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/CoreTests/Misc/BoundedCounterTests.cs
+++ b/src/CoreTests/Misc/BoundedCounterTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Misc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;

--- a/src/CoreTests/Misc/MiscTests.cs
+++ b/src/CoreTests/Misc/MiscTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Results;

--- a/src/CoreTests/Misc/PackageInfoTests.cs
+++ b/src/CoreTests/Misc/PackageInfoTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Misc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Reflection;

--- a/src/CoreTests/Misc/UtilityTests.cs
+++ b/src/CoreTests/Misc/UtilityTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Misc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;

--- a/src/CoreTests/Results/ScanMetaInfoTests.cs
+++ b/src/CoreTests/Results/ScanMetaInfoTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Results;
 using Axe.Windows.Core.Types;

--- a/src/CoreTests/Types/ControlTypesTests.cs
+++ b/src/CoreTests/Types/ControlTypesTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;

--- a/src/CoreTests/Types/HeadingLevelTypeTests.cs
+++ b/src/CoreTests/Types/HeadingLevelTypeTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/CoreTests/Types/PatternTypesTests.cs
+++ b/src/CoreTests/Types/PatternTypesTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/CoreTests/Types/PropertyTypesTests.cs
+++ b/src/CoreTests/Types/PropertyTypesTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/CoreTests/Types/TypeBaseTests.cs
+++ b/src/CoreTests/Types/TypeBaseTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;

--- a/src/Desktop/AssemblyInfo.cs
+++ b/src/Desktop/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;

--- a/src/Desktop/ColorContrastAnalyzer/Color.cs
+++ b/src/Desktop/ColorContrastAnalyzer/Color.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Desktop.Resources;
 using System;

--- a/src/Desktop/ColorContrastAnalyzer/ColorContrastRunner.cs
+++ b/src/Desktop/ColorContrastAnalyzer/ColorContrastRunner.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Desktop/ColorContrastAnalyzer/ColorPair.cs
+++ b/src/Desktop/ColorContrastAnalyzer/ColorPair.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.Desktop.ColorContrastAnalyzer

--- a/src/Desktop/ColorContrastAnalyzer/ContrastTransition.cs
+++ b/src/Desktop/ColorContrastAnalyzer/ContrastTransition.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.Desktop.ColorContrastAnalyzer

--- a/src/Desktop/ColorContrastAnalyzer/CountMap.cs
+++ b/src/Desktop/ColorContrastAnalyzer/CountMap.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections.Generic;
 
 namespace Axe.Windows.Desktop.ColorContrastAnalyzer

--- a/src/Desktop/ColorContrastAnalyzer/ImageCollection.cs
+++ b/src/Desktop/ColorContrastAnalyzer/ImageCollection.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Desktop/Settings/SnapshotMetaInfo.cs
+++ b/src/Desktop/Settings/SnapshotMetaInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Desktop/Styles/ActiveEnd.cs
+++ b/src/Desktop/Styles/ActiveEnd.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/Styles/AnimationStyle.cs
+++ b/src/Desktop/Styles/AnimationStyle.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/Styles/BulletStyle.cs
+++ b/src/Desktop/Styles/BulletStyle.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/Styles/CapStyle.cs
+++ b/src/Desktop/Styles/CapStyle.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/Styles/CaretBidiMode.cs
+++ b/src/Desktop/Styles/CaretBidiMode.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/Styles/CaretPosition.cs
+++ b/src/Desktop/Styles/CaretPosition.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/Styles/FlowDirection.cs
+++ b/src/Desktop/Styles/FlowDirection.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/Styles/FontWeight.cs
+++ b/src/Desktop/Styles/FontWeight.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/Styles/HorizontalTextAlignment.cs
+++ b/src/Desktop/Styles/HorizontalTextAlignment.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/Styles/OutlineStyle.cs
+++ b/src/Desktop/Styles/OutlineStyle.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/Styles/SayAsInterpretAs.cs
+++ b/src/Desktop/Styles/SayAsInterpretAs.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/Styles/StyleId.cs
+++ b/src/Desktop/Styles/StyleId.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/Styles/TextDecorationLineStyle.cs
+++ b/src/Desktop/Styles/TextDecorationLineStyle.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/Types/AnnotationType.cs
+++ b/src/Desktop/Types/AnnotationType.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/Types/ChangeInfoType.cs
+++ b/src/Desktop/Types/ChangeInfoType.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/Types/EventType.cs
+++ b/src/Desktop/Types/EventType.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/Types/TextAttributeTemplate.cs
+++ b/src/Desktop/Types/TextAttributeTemplate.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.Styles;
 using System;

--- a/src/Desktop/Types/TextAttributeType.cs
+++ b/src/Desktop/Types/TextAttributeType.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System.Text;
 

--- a/src/Desktop/UIAutomation/A11yPatternFactory.cs
+++ b/src/Desktop/UIAutomation/A11yPatternFactory.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.UIAutomation.Patterns;

--- a/src/Desktop/UIAutomation/DesktopElement.cs
+++ b/src/Desktop/UIAutomation/DesktopElement.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/EventHandlers/ActiveTextPositionChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/ActiveTextPositionChangedEventListener.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Desktop.Types;
 using System.Collections.Generic;
 using UIAutomationClient;

--- a/src/Desktop/UIAutomation/EventHandlers/ChangesEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/ChangesEventListener.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Desktop.Types;
 using System.Collections.Generic;
 using UIAutomationClient;

--- a/src/Desktop/UIAutomation/EventHandlers/EventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventListener.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.EventHandlers

--- a/src/Desktop/UIAutomation/EventHandlers/EventListenerBase.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventListenerBase.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using UIAutomationClient;
 

--- a/src/Desktop/UIAutomation/EventHandlers/EventListenerFactory.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventListenerFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Desktop.Types;
 using Axe.Windows.Telemetry;

--- a/src/Desktop/UIAutomation/EventHandlers/EventMessage.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventMessage.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using System;
 using System.Collections.Generic;

--- a/src/Desktop/UIAutomation/EventHandlers/FocusChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/FocusChangedEventListener.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Desktop.Types;
 using System;
 using System.Threading;

--- a/src/Desktop/UIAutomation/EventHandlers/NotificationEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/NotificationEventListener.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Desktop.Types;
 using System.Collections.Generic;
 using UIAutomationClient;

--- a/src/Desktop/UIAutomation/EventHandlers/PropertyChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/PropertyChangedEventListener.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.Types;
 using System.Collections.Generic;

--- a/src/Desktop/UIAutomation/EventHandlers/StructureChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/StructureChangedEventListener.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Desktop.Types;
 using System.Collections.Generic;

--- a/src/Desktop/UIAutomation/EventHandlers/TextEditTextChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/TextEditTextChangedEventListener.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Desktop.Types;
 using System.Collections.Generic;
 using UIAutomationClient;

--- a/src/Desktop/UIAutomation/Patterns/AnnotationPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/AnnotationPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/CustomNavigationPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/CustomNavigationPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/DockPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/DockPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/DragPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/DragPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/DropTargetPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/DropTargetPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/ExpandCollapsePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ExpandCollapsePattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/GridItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/GridItemPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Exceptions;

--- a/src/Desktop/UIAutomation/Patterns/GridPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/GridPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/InvokePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/InvokePattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/ItemContainerPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ItemContainerPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/LegacyIAccessiblePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/LegacyIAccessiblePattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/MultipleViewPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/MultipleViewPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/ObjectModelPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ObjectModelPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/RangeValuePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/RangeValuePattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/ScrollItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ScrollItemPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/ScrollPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ScrollPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/SelectionItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SelectionItemPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/SelectionPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SelectionPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/SelectionPattern2.cs
+++ b/src/Desktop/UIAutomation/Patterns/SelectionPattern2.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/SpreadsheetItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SpreadsheetItemPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/SpreadsheetPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SpreadsheetPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/StylesPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/StylesPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using UIAutomationClient;

--- a/src/Desktop/UIAutomation/Patterns/SynchronizedInputPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/SynchronizedInputPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/TableItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TableItemPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/TablePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TablePattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/TextChildPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextChildPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/TextEditPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextEditPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/TextPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/TextPattern2.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextPattern2.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/TextRange.cs
+++ b/src/Desktop/UIAutomation/Patterns/TextRange.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Desktop.Utility;
 using Axe.Windows.Telemetry;

--- a/src/Desktop/UIAutomation/Patterns/TogglePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TogglePattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/TransformPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/TransformPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/TransformPattern2.cs
+++ b/src/Desktop/UIAutomation/Patterns/TransformPattern2.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/UnKnownPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/UnKnownPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 

--- a/src/Desktop/UIAutomation/Patterns/ValuePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/ValuePattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/VirtualizedItemPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/VirtualizedItemPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Patterns/WindowPattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/WindowPattern.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/UIAutomation/Support/TextRangeFinder.cs
+++ b/src/Desktop/UIAutomation/Support/TextRangeFinder.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Desktop.UIAutomation.Patterns;
 
 namespace Axe.Windows.Desktop.UIAutomation.Support

--- a/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/DesktopElementAncestry.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
+++ b/src/Desktop/UIAutomation/TreeWalkers/TreeWalkerForLive.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Desktop/Utility/ExtensionMethods.cs
+++ b/src/Desktop/Utility/ExtensionMethods.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;

--- a/src/Desktop/Utility/ProcessItem.cs
+++ b/src/Desktop/Utility/ProcessItem.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Diagnostics;
 

--- a/src/Desktop/Utility/StandardLinksHelper.cs
+++ b/src/Desktop/Utility/StandardLinksHelper.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Results;
 using Axe.Windows.Core.Types;
 using System;

--- a/src/Desktop/Utility/SupportedEvents.cs
+++ b/src/Desktop/Utility/SupportedEvents.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.Types;

--- a/src/DesktopTests/ColorContrastAnalyzer/ColorPairTests.cs
+++ b/src/DesktopTests/ColorContrastAnalyzer/ColorPairTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Desktop.ColorContrastAnalyzer;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/DesktopTests/ColorContrastAnalyzer/ColorTests.cs
+++ b/src/DesktopTests/ColorContrastAnalyzer/ColorTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Desktop.ColorContrastAnalyzer;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;

--- a/src/DesktopTests/ColorContrastAnalyzer/ImageTests.cs
+++ b/src/DesktopTests/ColorContrastAnalyzer/ImageTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Desktop.ColorContrastAnalyzer;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;

--- a/src/DesktopTests/Styles/StyleIdTests.cs
+++ b/src/DesktopTests/Styles/StyleIdTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Desktop.Styles;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/DesktopTests/Types/TextAttributeTemplateTests.cs
+++ b/src/DesktopTests/Types/TextAttributeTemplateTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Desktop.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;

--- a/src/DesktopTests/Utility/SupportedEventsTests.cs
+++ b/src/DesktopTests/Utility/SupportedEventsTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Axe.Windows.Desktop.Types;
 using Axe.Windows.Desktop.Utility;

--- a/src/RuleSelection/AssemblyInfo.cs
+++ b/src/RuleSelection/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;

--- a/src/RuleSelection/Interfaces/IReferenceLink.cs
+++ b/src/RuleSelection/Interfaces/IReferenceLink.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.Extensions.Interfaces.ReferenceLinks

--- a/src/RuleSelection/ReferenceLinks.cs
+++ b/src/RuleSelection/ReferenceLinks.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Extensions.Interfaces.ReferenceLinks;
 using Axe.Windows.Rules;
 

--- a/src/RuleSelection/RuleRunner.cs
+++ b/src/RuleSelection/RuleRunner.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.HelpLinks;

--- a/src/RuleSelectionTests/DefaultReferenceLinksTests.cs
+++ b/src/RuleSelectionTests/DefaultReferenceLinksTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules;
 using Axe.Windows.RuleSelection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RuleSelectionTests/ReferenceLinksTests.cs
+++ b/src/RuleSelectionTests/ReferenceLinksTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules;
 using Axe.Windows.RuleSelection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/Rules/AssemblyInfo.cs
+++ b/src/Rules/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;

--- a/src/Rules/Conditions/AndCondition.cs
+++ b/src/Rules/Conditions/AndCondition.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.Resources;

--- a/src/Rules/Conditions/Condition.cs
+++ b/src/Rules/Conditions/Condition.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules.Resources;
 using System.Threading;

--- a/src/Rules/Conditions/ConditionContext.cs
+++ b/src/Rules/Conditions/ConditionContext.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using System.Collections.Generic;
 

--- a/src/Rules/Conditions/ContextCondition.cs
+++ b/src/Rules/Conditions/ContextCondition.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using System;
 

--- a/src/Rules/Conditions/ControlTypeCondition.cs
+++ b/src/Rules/Conditions/ControlTypeCondition.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules.Resources;
 using System;

--- a/src/Rules/Conditions/DelegateCondition.cs
+++ b/src/Rules/Conditions/DelegateCondition.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using System;
 

--- a/src/Rules/Conditions/NotCondition.cs
+++ b/src/Rules/Conditions/NotCondition.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.Resources;

--- a/src/Rules/Conditions/OrCondition.cs
+++ b/src/Rules/Conditions/OrCondition.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.Resources;

--- a/src/Rules/Conditions/PatternCondition.cs
+++ b/src/Rules/Conditions/PatternCondition.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using System;

--- a/src/Rules/Conditions/RecursiveCondition.cs
+++ b/src/Rules/Conditions/RecursiveCondition.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using System;
 

--- a/src/Rules/Conditions/StringDecoratorCondition.cs
+++ b/src/Rules/Conditions/StringDecoratorCondition.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using System;

--- a/src/Rules/Conditions/TreeDescentCondition.cs
+++ b/src/Rules/Conditions/TreeDescentCondition.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using System;
 

--- a/src/Rules/Conditions/ValueCondition.cs
+++ b/src/Rules/Conditions/ValueCondition.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using System;
 

--- a/src/Rules/Extensions/ExtensionMethods.cs
+++ b/src/Rules/Extensions/ExtensionMethods.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/IRuleFactory.cs
+++ b/src/Rules/IRuleFactory.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 
 namespace Axe.Windows.Rules

--- a/src/Rules/Library/BoundingRectangleCompletelyObscuresContainer.cs
+++ b/src/Rules/Library/BoundingRectangleCompletelyObscuresContainer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/BoundingRectangleContainedInParent.cs
+++ b/src/Rules/Library/BoundingRectangleContainedInParent.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/BoundingRectangleDataFormatCorrect.cs
+++ b/src/Rules/Library/BoundingRectangleDataFormatCorrect.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/BoundingRectangleNotAllZeros.cs
+++ b/src/Rules/Library/BoundingRectangleNotAllZeros.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/BoundingRectangleNotNull.cs
+++ b/src/Rules/Library/BoundingRectangleNotNull.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/BoundingRectangleNotNullListViewXAML.cs
+++ b/src/Rules/Library/BoundingRectangleNotNullListViewXAML.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/BoundingRectangleNotNullTextBlockXAML.cs
+++ b/src/Rules/Library/BoundingRectangleNotNullTextBlockXAML.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/BoundingRectangleNotValidButOffScreen.cs
+++ b/src/Rules/Library/BoundingRectangleNotValidButOffScreen.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/BoundingRectangleSizeReasonable.cs
+++ b/src/Rules/Library/BoundingRectangleSizeReasonable.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/ButtonInvokeAndExpandeCollapsePatterns.cs
+++ b/src/Rules/Library/ButtonInvokeAndExpandeCollapsePatterns.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ButtonInvokeAndTogglePatterns.cs
+++ b/src/Rules/Library/ButtonInvokeAndTogglePatterns.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ButtonShouldHavePatterns.cs
+++ b/src/Rules/Library/ButtonShouldHavePatterns.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ButtonToggleAndExpandeCollapsePatterns.cs
+++ b/src/Rules/Library/ButtonToggleAndExpandeCollapsePatterns.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ChildrenNotAllowedInContentView.cs
+++ b/src/Rules/Library/ChildrenNotAllowedInContentView.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;

--- a/src/Rules/Library/ClickablePointOffScreen.cs
+++ b/src/Rules/Library/ClickablePointOffScreen.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/ClickablePointOnScreen.cs
+++ b/src/Rules/Library/ClickablePointOnScreen.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/ClickablePointOnScreenWPF.cs
+++ b/src/Rules/Library/ClickablePointOnScreenWPF.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/ComboBoxShouldNotSupportScrollPattern.cs
+++ b/src/Rules/Library/ComboBoxShouldNotSupportScrollPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ControlShouldNotSupportInvokePattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportInvokePattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ControlShouldNotSupportScrollPattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportScrollPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ControlShouldNotSupportValuePattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportValuePattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ControlShouldNotSupportWindowPattern.cs
+++ b/src/Rules/Library/ControlShouldNotSupportWindowPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ControlShouldSupportExpandCollapsePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportExpandCollapsePattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ControlShouldSupportGridItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportGridItemPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ControlShouldSupportGridPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportGridPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/ControlShouldSupportInvokePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportInvokePattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ControlShouldSupportScrollItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportScrollItemPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ControlShouldSupportSelectionItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportSelectionItemPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ControlShouldSupportSelectionPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportSelectionPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ControlShouldSupportSetInfoWPF.cs
+++ b/src/Rules/Library/ControlShouldSupportSetInfoWPF.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;

--- a/src/Rules/Library/ControlShouldSupportSetInfoXAML.cs
+++ b/src/Rules/Library/ControlShouldSupportSetInfoXAML.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;

--- a/src/Rules/Library/ControlShouldSupportSpreadsheetItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportSpreadsheetItemPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ControlShouldSupportTableItemPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTableItemPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ControlShouldSupportTablePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTablePattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/ControlShouldSupportTextPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTextPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ControlShouldSupportTextPatternEditWinform.cs
+++ b/src/Rules/Library/ControlShouldSupportTextPatternEditWinform.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ControlShouldSupportTogglePattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTogglePattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ControlShouldSupportTransformPattern.cs
+++ b/src/Rules/Library/ControlShouldSupportTransformPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/EdgeBrowserHasBeenDeprecated.cs
+++ b/src/Rules/Library/EdgeBrowserHasBeenDeprecated.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;

--- a/src/Rules/Library/EditSupportsIncorrectRangeValuePattern.cs
+++ b/src/Rules/Library/EditSupportsIncorrectRangeValuePattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/FrameworkDoesNotSupportUIAutomation.cs
+++ b/src/Rules/Library/FrameworkDoesNotSupportUIAutomation.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;

--- a/src/Rules/Library/HeadingLevelDescendsWhenNested.cs
+++ b/src/Rules/Library/HeadingLevelDescendsWhenNested.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/HelpTextExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/HelpTextExcludesPrivateUnicodeCharacters.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/HelpTextNotEqualToName.cs
+++ b/src/Rules/Library/HelpTextNotEqualToName.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;

--- a/src/Rules/Library/HyperlinkNameShouldBeUnique.cs
+++ b/src/Rules/Library/HyperlinkNameShouldBeUnique.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/IsContentElementFalseOptional.cs
+++ b/src/Rules/Library/IsContentElementFalseOptional.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/IsContentElementPropertyExists.cs
+++ b/src/Rules/Library/IsContentElementPropertyExists.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/IsContentElementTrueOptional.cs
+++ b/src/Rules/Library/IsContentElementTrueOptional.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/IsControlElementPropertyExists.cs
+++ b/src/Rules/Library/IsControlElementPropertyExists.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/IsControlElementTrueOptional.cs
+++ b/src/Rules/Library/IsControlElementTrueOptional.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/IsControlElementTrueRequired.cs
+++ b/src/Rules/Library/IsControlElementTrueRequired.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/IsControlElementTrueRequiredButtonWPF.cs
+++ b/src/Rules/Library/IsControlElementTrueRequiredButtonWPF.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/IsControlElementTrueRequiredTextInEditXAML.cs
+++ b/src/Rules/Library/IsControlElementTrueRequiredTextInEditXAML.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/IsKeyboardFocusableDescendantTextPattern.cs
+++ b/src/Rules/Library/IsKeyboardFocusableDescendantTextPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/IsKeyboardFocusableFalseButDisabled.cs
+++ b/src/Rules/Library/IsKeyboardFocusableFalseButDisabled.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/IsKeyboardFocusableFalseButOffscreen.cs
+++ b/src/Rules/Library/IsKeyboardFocusableFalseButOffscreen.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/IsKeyboardFocusableForCustomShouldBeTrue.cs
+++ b/src/Rules/Library/IsKeyboardFocusableForCustomShouldBeTrue.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/IsKeyboardFocusableForListItemShouldBeTrue.cs
+++ b/src/Rules/Library/IsKeyboardFocusableForListItemShouldBeTrue.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/IsKeyboardFocusableOnEmptyContainer.cs
+++ b/src/Rules/Library/IsKeyboardFocusableOnEmptyContainer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/IsKeyboardFocusableShouldBeFalse.cs
+++ b/src/Rules/Library/IsKeyboardFocusableShouldBeFalse.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/IsKeyboardFocusableShouldBeTrue.cs
+++ b/src/Rules/Library/IsKeyboardFocusableShouldBeTrue.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/IsKeyboardFocusableTopLevelTextPattern.cs
+++ b/src/Rules/Library/IsKeyboardFocusableTopLevelTextPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ItemStatusExists.cs
+++ b/src/Rules/Library/ItemStatusExists.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/ItemTypeRecommended.cs
+++ b/src/Rules/Library/ItemTypeRecommended.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/LandmarkBannerIsTopLevel.cs
+++ b/src/Rules/Library/LandmarkBannerIsTopLevel.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/LandmarkComplementaryIsTopLevel.cs
+++ b/src/Rules/Library/LandmarkComplementaryIsTopLevel.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/LandmarkContentInfoIsTopLevel.cs
+++ b/src/Rules/Library/LandmarkContentInfoIsTopLevel.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/LandmarkMainIsTopLevel.cs
+++ b/src/Rules/Library/LandmarkMainIsTopLevel.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/LandmarkNoDuplicateBanner.cs
+++ b/src/Rules/Library/LandmarkNoDuplicateBanner.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/LandmarkNoDuplicateContentInfo.cs
+++ b/src/Rules/Library/LandmarkNoDuplicateContentInfo.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/ListItemSiblingsUnique.cs
+++ b/src/Rules/Library/ListItemSiblingsUnique.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Exceptions;

--- a/src/Rules/Library/LocalizedControlTypeExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/LocalizedControlTypeExcludesPrivateUnicodeCharacters.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/LocalizedControlTypeIsNotCustom.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotCustom.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotCustomWPFGridCell.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/LocalizedControlTypeIsNotEmpty.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotEmpty.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/LocalizedControlTypeIsNotNull.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotNull.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/LocalizedControlTypeIsNotWhiteSpace.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsNotWhiteSpace.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/LocalizedControlTypeIsReasonable.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsReasonable.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeExcludesPrivateUnicodeCharacters.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;

--- a/src/Rules/Library/LocalizedLandmarkTypeIsReasonableLength.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeIsReasonableLength.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;

--- a/src/Rules/Library/LocalizedLandmarkTypeNotCustom.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeNotCustom.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/LocalizedLandmarkTypeNotEmpty.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeNotEmpty.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/LocalizedLandmarkTypeNotNull.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeNotNull.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/LocalizedLandmarkTypeNotWhiteSpace.cs
+++ b/src/Rules/Library/LocalizedLandmarkTypeNotWhiteSpace.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;

--- a/src/Rules/Library/NameExcludesControlType.cs
+++ b/src/Rules/Library/NameExcludesControlType.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/NameExcludesLocalizedControlType.cs
+++ b/src/Rules/Library/NameExcludesLocalizedControlType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/NameExcludesPrivateUnicodeCharacters.cs
+++ b/src/Rules/Library/NameExcludesPrivateUnicodeCharacters.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/NameIsEmptyButElementIsNotKeyboardFocusable.cs
+++ b/src/Rules/Library/NameIsEmptyButElementIsNotKeyboardFocusable.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/NameIsInformative.cs
+++ b/src/Rules/Library/NameIsInformative.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/NameIsNotEmpty.cs
+++ b/src/Rules/Library/NameIsNotEmpty.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/NameIsNotNull.cs
+++ b/src/Rules/Library/NameIsNotNull.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/NameIsNotWhiteSpace.cs
+++ b/src/Rules/Library/NameIsNotWhiteSpace.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/NameIsNullButElementIsNotKeyboardFocusable.cs
+++ b/src/Rules/Library/NameIsNullButElementIsNotKeyboardFocusable.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/NameIsReasonableLength.cs
+++ b/src/Rules/Library/NameIsReasonableLength.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/NameNoSiblingsOfSameType.cs
+++ b/src/Rules/Library/NameNoSiblingsOfSameType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/NameOnCustomWithParentWPFDataItem.cs
+++ b/src/Rules/Library/NameOnCustomWithParentWPFDataItem.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/NameOnOptionalType.cs
+++ b/src/Rules/Library/NameOnOptionalType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/NameWithValidBoundingRectangle.cs
+++ b/src/Rules/Library/NameWithValidBoundingRectangle.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/OrientationPropertyExists.cs
+++ b/src/Rules/Library/OrientationPropertyExists.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs
+++ b/src/Rules/Library/ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/ProgressBarRangeValue.cs
+++ b/src/Rules/Library/ProgressBarRangeValue.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/SelectionItemPatternSingleSelection.cs
+++ b/src/Rules/Library/SelectionItemPatternSingleSelection.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/SelectionPatternSelectionRequired.cs
+++ b/src/Rules/Library/SelectionPatternSelectionRequired.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/Rules/Library/SelectionPatternSingleSelection.cs
+++ b/src/Rules/Library/SelectionPatternSingleSelection.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/SiblingUniqueAndFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndFocusable.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Exceptions;

--- a/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndNotFocusable.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Exceptions;

--- a/src/Rules/Library/SplitButtonInvokeAndTogglePatterns.cs
+++ b/src/Rules/Library/SplitButtonInvokeAndTogglePatterns.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/Rules/Library/Structure/ContentView/Button.cs
+++ b/src/Rules/Library/Structure/ContentView/Button.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/Calendar.cs
+++ b/src/Rules/Library/Structure/ContentView/Calendar.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/CheckBox.cs
+++ b/src/Rules/Library/Structure/ContentView/CheckBox.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/ComboBox.cs
+++ b/src/Rules/Library/Structure/ContentView/ComboBox.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/DataGrid.cs
+++ b/src/Rules/Library/Structure/ContentView/DataGrid.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/Edit.cs
+++ b/src/Rules/Library/Structure/ContentView/Edit.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/Hyperlink.cs
+++ b/src/Rules/Library/Structure/ContentView/Hyperlink.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/List.cs
+++ b/src/Rules/Library/Structure/ContentView/List.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/ListItem.cs
+++ b/src/Rules/Library/Structure/ContentView/ListItem.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/Menu.cs
+++ b/src/Rules/Library/Structure/ContentView/Menu.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/ProgressBar.cs
+++ b/src/Rules/Library/Structure/ContentView/ProgressBar.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/RadioButton.cs
+++ b/src/Rules/Library/Structure/ContentView/RadioButton.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/Slider.cs
+++ b/src/Rules/Library/Structure/ContentView/Slider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/Spinner.cs
+++ b/src/Rules/Library/Structure/ContentView/Spinner.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/SplitButton.cs
+++ b/src/Rules/Library/Structure/ContentView/SplitButton.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/StatusBar.cs
+++ b/src/Rules/Library/Structure/ContentView/StatusBar.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/Tab.cs
+++ b/src/Rules/Library/Structure/ContentView/Tab.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/Tree.cs
+++ b/src/Rules/Library/Structure/ContentView/Tree.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ContentView/TreeItem.cs
+++ b/src/Rules/Library/Structure/ContentView/TreeItem.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/Button.cs
+++ b/src/Rules/Library/Structure/ControlView/Button.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/Calendar.cs
+++ b/src/Rules/Library/Structure/ControlView/Calendar.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/CheckBox.cs
+++ b/src/Rules/Library/Structure/ControlView/CheckBox.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/ComboBox.cs
+++ b/src/Rules/Library/Structure/ControlView/ComboBox.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/DataGrid.cs
+++ b/src/Rules/Library/Structure/ControlView/DataGrid.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/Edit.cs
+++ b/src/Rules/Library/Structure/ControlView/Edit.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/Header.cs
+++ b/src/Rules/Library/Structure/ControlView/Header.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/HeaderItem.cs
+++ b/src/Rules/Library/Structure/ControlView/HeaderItem.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/Hyperlink.cs
+++ b/src/Rules/Library/Structure/ControlView/Hyperlink.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/Image.cs
+++ b/src/Rules/Library/Structure/ControlView/Image.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/List.cs
+++ b/src/Rules/Library/Structure/ControlView/List.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/ListItem.cs
+++ b/src/Rules/Library/Structure/ControlView/ListItem.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/Menu.cs
+++ b/src/Rules/Library/Structure/ControlView/Menu.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/ProgressBar.cs
+++ b/src/Rules/Library/Structure/ControlView/ProgressBar.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/RadioButton.cs
+++ b/src/Rules/Library/Structure/ControlView/RadioButton.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/Scrollbar.cs
+++ b/src/Rules/Library/Structure/ControlView/Scrollbar.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/SemanticZoom.cs
+++ b/src/Rules/Library/Structure/ControlView/SemanticZoom.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/Separator.cs
+++ b/src/Rules/Library/Structure/ControlView/Separator.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/Slider.cs
+++ b/src/Rules/Library/Structure/ControlView/Slider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/Spinner.cs
+++ b/src/Rules/Library/Structure/ControlView/Spinner.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/SplitButton.cs
+++ b/src/Rules/Library/Structure/ControlView/SplitButton.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/StatusBar.cs
+++ b/src/Rules/Library/Structure/ControlView/StatusBar.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/Tab.cs
+++ b/src/Rules/Library/Structure/ControlView/Tab.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/Thumb.cs
+++ b/src/Rules/Library/Structure/ControlView/Thumb.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/ToolTip.cs
+++ b/src/Rules/Library/Structure/ControlView/ToolTip.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/Tree.cs
+++ b/src/Rules/Library/Structure/ControlView/Tree.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Library/Structure/ControlView/TreeItem.cs
+++ b/src/Rules/Library/Structure/ControlView/TreeItem.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Misc/Helpers.cs
+++ b/src/Rules/Misc/Helpers.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using System;
 using UIAutomationClient;

--- a/src/Rules/PropertyConditions/BoolProperties.cs
+++ b/src/Rules/PropertyConditions/BoolProperties.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;

--- a/src/Rules/PropertyConditions/BoundingRectangle.cs
+++ b/src/Rules/PropertyConditions/BoundingRectangle.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.Extensions;

--- a/src/Rules/PropertyConditions/ClickablePoint.cs
+++ b/src/Rules/PropertyConditions/ClickablePoint.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.Extensions;

--- a/src/Rules/PropertyConditions/ContentView.cs
+++ b/src/Rules/PropertyConditions/ContentView.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules.Resources;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;

--- a/src/Rules/PropertyConditions/Context.cs
+++ b/src/Rules/PropertyConditions/Context.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 
 namespace Axe.Windows.Rules.PropertyConditions

--- a/src/Rules/PropertyConditions/ControlView.cs
+++ b/src/Rules/PropertyConditions/ControlView.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules.Resources;
 using static Axe.Windows.Rules.PropertyConditions.BoolProperties;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;

--- a/src/Rules/PropertyConditions/ElementGroups.cs
+++ b/src/Rules/PropertyConditions/ElementGroups.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Types;

--- a/src/Rules/PropertyConditions/EnumProperty.cs
+++ b/src/Rules/PropertyConditions/EnumProperty.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules.Resources;
 using System;

--- a/src/Rules/PropertyConditions/Framework.cs
+++ b/src/Rules/PropertyConditions/Framework.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 
 namespace Axe.Windows.Rules.PropertyConditions

--- a/src/Rules/PropertyConditions/IntProperties.cs
+++ b/src/Rules/PropertyConditions/IntProperties.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.Resources;

--- a/src/Rules/PropertyConditions/IntProperty.cs
+++ b/src/Rules/PropertyConditions/IntProperty.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules.Extensions;
 using Axe.Windows.Rules.Resources;
 using static Axe.Windows.Rules.PropertyConditions.General;

--- a/src/Rules/PropertyConditions/Landmarks.cs
+++ b/src/Rules/PropertyConditions/Landmarks.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.Resources;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;

--- a/src/Rules/PropertyConditions/Patterns.cs
+++ b/src/Rules/PropertyConditions/Patterns.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using System;

--- a/src/Rules/PropertyConditions/PlatformProperties.cs
+++ b/src/Rules/PropertyConditions/PlatformProperties.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using System;

--- a/src/Rules/PropertyConditions/Relationships.cs
+++ b/src/Rules/PropertyConditions/Relationships.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Exceptions;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/PropertyConditions/ScrollPattern.cs
+++ b/src/Rules/PropertyConditions/ScrollPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using System;

--- a/src/Rules/PropertyConditions/SelectionItemPattern .cs
+++ b/src/Rules/PropertyConditions/SelectionItemPattern .cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using System;

--- a/src/Rules/PropertyConditions/SelectionPattern.cs
+++ b/src/Rules/PropertyConditions/SelectionPattern.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using System;

--- a/src/Rules/PropertyConditions/StringProperties.cs
+++ b/src/Rules/PropertyConditions/StringProperties.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.Resources;
 

--- a/src/Rules/PropertyConditions/StringProperty.cs
+++ b/src/Rules/PropertyConditions/StringProperty.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.Resources;

--- a/src/Rules/PropertyConditions/UWP.cs
+++ b/src/Rules/PropertyConditions/UWP.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using static Axe.Windows.Rules.PropertyConditions.Framework;
 using static Axe.Windows.Rules.PropertyConditions.Relationships;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;

--- a/src/Rules/Rule.cs
+++ b/src/Rules/Rule.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Exceptions;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/RuleFactory.cs
+++ b/src/Rules/RuleFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;
 using System;

--- a/src/Rules/RuleInfo.cs
+++ b/src/Rules/RuleInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;
 using System;

--- a/src/Rules/RuleProvider.cs
+++ b/src/Rules/RuleProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 using System;
 using System.Collections.Concurrent;

--- a/src/Rules/RuleRunner.cs
+++ b/src/Rules/RuleRunner.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;

--- a/src/Rules/Rules.cs
+++ b/src/Rules/Rules.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using System;

--- a/src/Rules/RunResult.cs
+++ b/src/Rules/RunResult.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 
 namespace Axe.Windows.Rules

--- a/src/RulesMD/Helpers.cs
+++ b/src/RulesMD/Helpers.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules;
 using Axe.Windows.RuleSelection.Resources;
 

--- a/src/RulesMD/Properties/AssemblyInfo.cs
+++ b/src/RulesMD/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;

--- a/src/RulesTest/AllRules.test.cs
+++ b/src/RulesTest/AllRules.test.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/RulesTest/Conditions/AndConditionTests.cs
+++ b/src/RulesTest/Conditions/AndConditionTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/RulesTest/Conditions/ConditionTests.cs
+++ b/src/RulesTest/Conditions/ConditionTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/RulesTest/Conditions/ControlTypeConditionTests.cs
+++ b/src/RulesTest/Conditions/ControlTypeConditionTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/RulesTest/Conditions/NotConditionTests.cs
+++ b/src/RulesTest/Conditions/NotConditionTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/RulesTest/Conditions/OrConditionTests.cs
+++ b/src/RulesTest/Conditions/OrConditionTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/RulesTest/Conditions/PatternConditionTests.cs
+++ b/src/RulesTest/Conditions/PatternConditionTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RulesTest/Conditions/TreeDescentConditionTests.cs
+++ b/src/RulesTest/Conditions/TreeDescentConditionTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using Condition = Axe.Windows.Rules.Condition;

--- a/src/RulesTest/ControlType.cs
+++ b/src/RulesTest/ControlType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/RulesTest/Extensions.cs
+++ b/src/RulesTest/Extensions.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/RulesTest/Library/BoundingRectangleCompletelyObscuresContainerTests.cs
+++ b/src/RulesTest/Library/BoundingRectangleCompletelyObscuresContainerTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/RulesTest/Library/BoundingRectangleContainedInParentTests.cs
+++ b/src/RulesTest/Library/BoundingRectangleContainedInParentTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/RulesTest/Library/BoundingRectangleDataFormatCorrectTests.cs
+++ b/src/RulesTest/Library/BoundingRectangleDataFormatCorrectTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RulesTest/Library/BoundingRectangleNotAllZerosTests.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotAllZerosTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 

--- a/src/RulesTest/Library/BoundingRectangleNotValidButOffScreenTests.cs
+++ b/src/RulesTest/Library/BoundingRectangleNotValidButOffScreenTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTests.Library

--- a/src/RulesTest/Library/BoundingRectangleSizeReasonableTests.cs
+++ b/src/RulesTest/Library/BoundingRectangleSizeReasonableTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Drawing;

--- a/src/RulesTest/Library/ButtonInvokeAndExpandCollapsePatternsTests.cs
+++ b/src/RulesTest/Library/ButtonInvokeAndExpandCollapsePatternsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/RulesTest/Library/ButtonInvokeAndTogglePatternsTests.cs
+++ b/src/RulesTest/Library/ButtonInvokeAndTogglePatternsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/RulesTest/Library/ButtonShouldHavePatternsTests.cs
+++ b/src/RulesTest/Library/ButtonShouldHavePatternsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/RulesTest/Library/ButtonToggleAndExpandCollapsePatternsTests.cs
+++ b/src/RulesTest/Library/ButtonToggleAndExpandCollapsePatternsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/RulesTest/Library/ClickablePointOffScreenTests.cs
+++ b/src/RulesTest/Library/ClickablePointOffScreenTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RulesTest/Library/ClickablePointOnScreenTests.cs
+++ b/src/RulesTest/Library/ClickablePointOnScreenTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RulesTest/Library/ClickablePointOnScreenWPFTests.cs
+++ b/src/RulesTest/Library/ClickablePointOnScreenWPFTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RulesTest/Library/ComboBoxShouldNotSupportScrollPatternTests.cs
+++ b/src/RulesTest/Library/ComboBoxShouldNotSupportScrollPatternTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;

--- a/src/RulesTest/Library/ControlShouldNotSupportInvokePatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldNotSupportInvokePatternTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;

--- a/src/RulesTest/Library/ControlShouldNotSupportScrollPatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldNotSupportScrollPatternTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;

--- a/src/RulesTest/Library/ControlShouldSupportExpandCollapsePatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportExpandCollapsePatternTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/RulesTest/Library/ControlShouldSupportGridPatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportGridPatternTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RulesTest/Library/ControlShouldSupportSetInfoWPFTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportSetInfoWPFTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;

--- a/src/RulesTest/Library/ControlShouldSupportSetInfoXAMLTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportSetInfoXAMLTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;

--- a/src/RulesTest/Library/ControlShouldSupportTablePatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTablePatternTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RulesTest/Library/ControlShouldSupportTextPatternEditWinformTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTextPatternEditWinformTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/RulesTest/Library/ControlShouldSupportTextPatternTests.cs
+++ b/src/RulesTest/Library/ControlShouldSupportTextPatternTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/RulesTest/Library/HeadingLevelDescendsWhenNestedTests.cs
+++ b/src/RulesTest/Library/HeadingLevelDescendsWhenNestedTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/RulesTest/Library/HelpTextExcludesPrivateUnicodeCharactersTests.cs
+++ b/src/RulesTest/Library/HelpTextExcludesPrivateUnicodeCharactersTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 

--- a/src/RulesTest/Library/HyperlinkNameShouldBeUniqueTests.cs
+++ b/src/RulesTest/Library/HyperlinkNameShouldBeUniqueTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 

--- a/src/RulesTest/Library/IsControlElementTrueRequiredButtonWPFTests.cs
+++ b/src/RulesTest/Library/IsControlElementTrueRequiredButtonWPFTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;

--- a/src/RulesTest/Library/IsControlElementTrueRequiredTests.cs
+++ b/src/RulesTest/Library/IsControlElementTrueRequiredTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;

--- a/src/RulesTest/Library/IsControlElementTrueRequiredTextInEditXAMLTests.cs
+++ b/src/RulesTest/Library/IsControlElementTrueRequiredTextInEditXAMLTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;

--- a/src/RulesTest/Library/IsKeyboardFocusableOnEmptyContainerTests.cs
+++ b/src/RulesTest/Library/IsKeyboardFocusableOnEmptyContainerTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTests.Library

--- a/src/RulesTest/Library/IsKeyboardFocusableShouldBeTrueTests.cs
+++ b/src/RulesTest/Library/IsKeyboardFocusableShouldBeTrueTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 

--- a/src/RulesTest/Library/IsKeyboardFocusableTopLevelTextPatternTests.cs
+++ b/src/RulesTest/Library/IsKeyboardFocusableTopLevelTextPatternTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RulesTest/Library/ListItemSiblingUniqueTests.cs
+++ b/src/RulesTest/Library/ListItemSiblingUniqueTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 

--- a/src/RulesTest/Library/LocalizedControlTypeExcludesPrivateUnicodeCharactersTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeExcludesPrivateUnicodeCharactersTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotCustomTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotCustomTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotCustomWPFGridCellTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotCustomWPFGridCellTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotEmptyTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotEmptyTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTests.Library

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotNullTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotNullTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTests.Library

--- a/src/RulesTest/Library/LocalizedControlTypeIsNotWhiteSpaceTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsNotWhiteSpaceTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTests.Library

--- a/src/RulesTest/Library/LocalizedControlTypeIsReasonableTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsReasonableTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.RulesTests.ControlType;
 

--- a/src/RulesTest/Library/LocalizedLandmarkTypeExcludesPrivateUnicodeCharactersTests.cs
+++ b/src/RulesTest/Library/LocalizedLandmarkTypeExcludesPrivateUnicodeCharactersTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 

--- a/src/RulesTest/Library/LocalizedLandmarkTypeNotCustomTests.cs
+++ b/src/RulesTest/Library/LocalizedLandmarkTypeNotCustomTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/RulesTest/Library/NameExcludesControlTypeTests.cs
+++ b/src/RulesTest/Library/NameExcludesControlTypeTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using static Axe.Windows.RulesTests.ControlType;

--- a/src/RulesTest/Library/NameExcludesLocalizedControlTypeTests.cs
+++ b/src/RulesTest/Library/NameExcludesLocalizedControlTypeTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;

--- a/src/RulesTest/Library/NameExcludesPrivateUnicodeCharactersTests.cs
+++ b/src/RulesTest/Library/NameExcludesPrivateUnicodeCharactersTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 

--- a/src/RulesTest/Library/NameIsEmptyButElementIsNotKeyboardFocusableTests.cs
+++ b/src/RulesTest/Library/NameIsEmptyButElementIsNotKeyboardFocusableTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Drawing;

--- a/src/RulesTest/Library/NameIsInformativeTests.cs
+++ b/src/RulesTest/Library/NameIsInformativeTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTests.Library

--- a/src/RulesTest/Library/NameIsNotEmptyTests.cs
+++ b/src/RulesTest/Library/NameIsNotEmptyTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 using static Axe.Windows.RulesTests.ControlType;

--- a/src/RulesTest/Library/NameIsNotNullTests.cs
+++ b/src/RulesTest/Library/NameIsNotNullTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 using static Axe.Windows.RulesTests.ControlType;

--- a/src/RulesTest/Library/NameIsNotWhiteSpaceTests.cs
+++ b/src/RulesTest/Library/NameIsNotWhiteSpaceTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTests.Library

--- a/src/RulesTest/Library/NameIsNullButElementIsNotKeyboardFocusableTests.cs
+++ b/src/RulesTest/Library/NameIsNullButElementIsNotKeyboardFocusableTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Drawing;

--- a/src/RulesTest/Library/NameIsReasonableLengthTests.cs
+++ b/src/RulesTest/Library/NameIsReasonableLengthTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Text;

--- a/src/RulesTest/Library/ParentChildShouldNotHaveSameNameAndLocalizedControlTypeTests.cs
+++ b/src/RulesTest/Library/ParentChildShouldNotHaveSameNameAndLocalizedControlTypeTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.RulesTests.Library

--- a/src/RulesTest/Library/ProgressBarRangeValueTests.cs
+++ b/src/RulesTest/Library/ProgressBarRangeValueTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RulesTest/Library/SelectionItemPatternSingleSelectionTests.cs
+++ b/src/RulesTest/Library/SelectionItemPatternSingleSelectionTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/RulesTest/Library/SelectionPatternSelectionRequiredTests.cs
+++ b/src/RulesTest/Library/SelectionPatternSelectionRequiredTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/RulesTest/Library/SiblingUniqueAndFocusableTests.cs
+++ b/src/RulesTest/Library/SiblingUniqueAndFocusableTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;

--- a/src/RulesTest/Library/SiblingUniqueAndNotFocusableTests.cs
+++ b/src/RulesTest/Library/SiblingUniqueAndNotFocusableTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
 

--- a/src/RulesTest/Library/SplitButtonInvokeAndTogglePatternsTests.cs
+++ b/src/RulesTest/Library/SplitButtonInvokeAndTogglePatternsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/RulesTest/Library/Structure/ContentView/SpinnerTests.cs
+++ b/src/RulesTest/Library/Structure/ContentView/SpinnerTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/RulesTest/Library/Structure/ControlView/ScrollbarTests.cs
+++ b/src/RulesTest/Library/Structure/ControlView/ScrollbarTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;

--- a/src/RulesTest/Library/Structure/ControlView/SpinnerTests.cs
+++ b/src/RulesTest/Library/Structure/ControlView/SpinnerTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/RulesTest/Library/UWPTests.cs
+++ b/src/RulesTest/Library/UWPTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RulesTest/MockA11yElement.cs
+++ b/src/RulesTest/MockA11yElement.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/RulesTest/MonsterTest.cs
+++ b/src/RulesTest/MonsterTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.UnitTestSharedLibrary;

--- a/src/RulesTest/PropertyConditions/BoolPropertiesTests.cs
+++ b/src/RulesTest/PropertyConditions/BoolPropertiesTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RulesTest/PropertyConditions/BoundingRectangleTests.cs
+++ b/src/RulesTest/PropertyConditions/BoundingRectangleTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RulesTest/PropertyConditions/ClickablePointTests.cs
+++ b/src/RulesTest/PropertyConditions/ClickablePointTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/RulesTest/PropertyConditions/ContentViewTests.cs
+++ b/src/RulesTest/PropertyConditions/ContentViewTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.RulesTests.ControlType;

--- a/src/RulesTest/PropertyConditions/ControlViewTests.cs
+++ b/src/RulesTest/PropertyConditions/ControlViewTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.RulesTests.ControlType;

--- a/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
+++ b/src/RulesTest/PropertyConditions/ElementGroupsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;

--- a/src/RulesTest/PropertyConditions/EnumPropertyTests.cs
+++ b/src/RulesTest/PropertyConditions/EnumPropertyTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/RulesTest/PropertyConditions/IntPropertiesTests.cs
+++ b/src/RulesTest/PropertyConditions/IntPropertiesTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RulesTest/PropertyConditions/IntPropertyTests.cs
+++ b/src/RulesTest/PropertyConditions/IntPropertyTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/RulesTest/PropertyConditions/LandmarksTests.cs
+++ b/src/RulesTest/PropertyConditions/LandmarksTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RulesTest/PropertyConditions/NameTests.cs
+++ b/src/RulesTest/PropertyConditions/NameTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Types;

--- a/src/RulesTest/PropertyConditions/PatternsTests.cs
+++ b/src/RulesTest/PropertyConditions/PatternsTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RulesTest/PropertyConditions/PlatformPropertiesTests.cs
+++ b/src/RulesTest/PropertyConditions/PlatformPropertiesTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/RulesTest/PropertyConditions/RelationshipsTests.cs
+++ b/src/RulesTest/PropertyConditions/RelationshipsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules;
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/RulesTest/PropertyConditions/ScrollPatternTests.cs
+++ b/src/RulesTest/PropertyConditions/ScrollPatternTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/RulesTest/PropertyConditions/SelectionItemPatternTests.cs
+++ b/src/RulesTest/PropertyConditions/SelectionItemPatternTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/RulesTest/PropertyConditions/SelectionPatternTests.cs
+++ b/src/RulesTest/PropertyConditions/SelectionPatternTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;

--- a/src/RulesTest/PropertyConditions/StringPropertiesTests.cs
+++ b/src/RulesTest/PropertyConditions/StringPropertiesTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;

--- a/src/RulesTest/PropertyConditions/ValueConditionTests.cs
+++ b/src/RulesTest/PropertyConditions/ValueConditionTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;

--- a/src/RulesTest/RuleRunnerTests.cs
+++ b/src/RulesTest/RuleRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules;

--- a/src/RulesTest/RulesProviderTests.cs
+++ b/src/RulesTest/RulesProviderTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/SystemAbstractions/Abstractions/ISystemDateTime.cs
+++ b/src/SystemAbstractions/Abstractions/ISystemDateTime.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.SystemAbstractions

--- a/src/SystemAbstractions/Abstractions/ISystemIODirectory.cs
+++ b/src/SystemAbstractions/Abstractions/ISystemIODirectory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.IO;
 
 namespace Axe.Windows.SystemAbstractions

--- a/src/SystemAbstractions/AssemblyInfo.cs
+++ b/src/SystemAbstractions/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Reflection;
 using System.Runtime.CompilerServices;
 

--- a/src/SystemAbstractions/Concretions/Microsoft.cs
+++ b/src/SystemAbstractions/Concretions/Microsoft.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.SystemAbstractions

--- a/src/SystemAbstractions/Concretions/MicrosoftWin32.cs
+++ b/src/SystemAbstractions/Concretions/MicrosoftWin32.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.SystemAbstractions

--- a/src/SystemAbstractions/Concretions/MicrosoftWin32Registry.cs
+++ b/src/SystemAbstractions/Concretions/MicrosoftWin32Registry.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.Win32;
 
 namespace Axe.Windows.SystemAbstractions

--- a/src/SystemAbstractions/Concretions/System.cs
+++ b/src/SystemAbstractions/Concretions/System.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.SystemAbstractions

--- a/src/SystemAbstractions/Concretions/SystemDateTime.cs
+++ b/src/SystemAbstractions/Concretions/SystemDateTime.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.SystemAbstractions

--- a/src/SystemAbstractions/Concretions/SystemEnvironment.cs
+++ b/src/SystemAbstractions/Concretions/SystemEnvironment.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.SystemAbstractions

--- a/src/SystemAbstractions/Concretions/SystemIO.cs
+++ b/src/SystemAbstractions/Concretions/SystemIO.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.SystemAbstractions

--- a/src/SystemAbstractions/Concretions/SystemIODirectory.cs
+++ b/src/SystemAbstractions/Concretions/SystemIODirectory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.IO;
 
 namespace Axe.Windows.SystemAbstractions

--- a/src/SystemAbstractionsTests/MicrosoftUnitTests.cs
+++ b/src/SystemAbstractionsTests/MicrosoftUnitTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.SystemAbstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Win32;

--- a/src/SystemAbstractionsTests/SystemUnitTests.cs
+++ b/src/SystemAbstractionsTests/SystemUnitTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.SystemAbstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/Telemetry/AssemblyInfo.cs
+++ b/src/Telemetry/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Reflection;
 using System.Runtime.CompilerServices;
 

--- a/src/Telemetry/ExcludedException.cs
+++ b/src/Telemetry/ExcludedException.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.Telemetry

--- a/src/Telemetry/ExcludingExceptionWrapper.cs
+++ b/src/Telemetry/ExcludingExceptionWrapper.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Axe.Windows.Telemetry

--- a/src/Telemetry/IAxeWindowsTelemetry.cs
+++ b/src/Telemetry/IAxeWindowsTelemetry.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 

--- a/src/Telemetry/Logger.cs
+++ b/src/Telemetry/Logger.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/TelemetryTests/ExcludingExceptionWrapperUnitTests.cs
+++ b/src/TelemetryTests/ExcludingExceptionWrapperUnitTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Telemetry;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;

--- a/src/TelemetryTests/LoggerTests.cs
+++ b/src/TelemetryTests/LoggerTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Telemetry;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;

--- a/src/UnitTestSharedLibrary/Utility.cs
+++ b/src/UnitTestSharedLibrary/Utility.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Results;
 using Newtonsoft.Json;

--- a/src/Win32/AssemblyInfo.cs
+++ b/src/Win32/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/src/Win32/HighContrast.cs
+++ b/src/Win32/HighContrast.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/Win32/HighContrastData.cs
+++ b/src/Win32/HighContrastData.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/Win32/NativeMethods.cs
+++ b/src/Win32/NativeMethods.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Drawing;
 using System.Runtime.InteropServices;

--- a/src/Win32/Win32Helper.cs
+++ b/src/Win32/Win32Helper.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.SystemAbstractions;
 using System;
 

--- a/src/Win32Tests/Win32ApisTests.cs
+++ b/src/Win32Tests/Win32ApisTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Axe.Windows.SystemAbstractions;
 using Axe.Windows.Win32;
 using Microsoft.VisualStudio.TestTools.UnitTesting;


### PR DESCRIPTION
#### Details

This PR ensures that we have a newline between the license header and the first using line. It was done via a global search & replace across the entire solution, so it should have captured all remaining files that didn't have the newline.

I can split this up into per-project PR's if desired, but since the reviews are so straightforward I started with a single PR

##### Motivation

Code consistency

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
