### PR TITLE
fix: Add MSAA role name to LegacyIAccessiblePattern.Role

### DIFF
--- a/src/Actions/Actions/SaveAction.cs
+++ b/src/Actions/Actions/SaveAction.cs
@@ -54,7 +54,11 @@ namespace Axe.Windows.Actions
         /// </summary>
         private static void SaveSnapshotFromElement(int? focusedElementId, A11yFileMode mode, ElementContext ec, Package package, A11yElement root, IActionContext actionContext)
         {
-            var json = JsonConvert.SerializeObject(root, Formatting.Indented);
+            var json = JsonConvert.SerializeObject(root, Formatting.Indented,
+                new JsonSerializerSettings
+                {
+                    NullValueHandling = NullValueHandling.Ignore,
+                });
             using (MemoryStream mStrm = new MemoryStream(Encoding.UTF8.GetBytes(json)))
             {
                 AddStream(package, mStrm, StreamName.ElementFileName);

--- a/src/Core/Bases/A11yPatternProperty.cs
+++ b/src/Core/Bases/A11yPatternProperty.cs
@@ -15,11 +15,13 @@ namespace Axe.Windows.Core.Bases
 
         public dynamic Value { get; set; }
 
+        public bool OmitQuotesFromString { get; set; }
+
         public string NodeValue
         {
             get
             {
-                if (Value is string)
+                if (Value is string && !OmitQuotesFromString)
                 {
                     return ExtensionMethods.WithParameters("{0} = \"{1}\"", Name, Value);
                 }

--- a/src/Core/Bases/A11yPatternProperty.cs
+++ b/src/Core/Bases/A11yPatternProperty.cs
@@ -15,13 +15,13 @@ namespace Axe.Windows.Core.Bases
 
         public dynamic Value { get; set; }
 
-        public bool OmitQuotesFromString { get; set; }
+        public bool? OmitQuotesFromString { get; set; }
 
         public string NodeValue
         {
             get
             {
-                if (Value is string && !OmitQuotesFromString)
+                if (Value is string && OmitQuotesFromString != true)
                 {
                     return ExtensionMethods.WithParameters("{0} = \"{1}\"", Name, Value);
                 }

--- a/src/Core/Bases/A11yProperty.cs
+++ b/src/Core/Bases/A11yProperty.cs
@@ -123,6 +123,9 @@ namespace Axe.Windows.Core.Bases
                     case PropertyType.UIA_LandmarkTypePropertyId:
                         txt = Value != 0 ? LandmarkType.GetInstance().GetNameById(Value) : null; // 0 is default value.
                         break;
+                    case PropertyType.UIA_LegacyIAccessiblePattern_RolePropertyId:
+                        txt = Value != 0 ? LegacyIAccessibleRoleType.GetInstance().GetNameById(Value) : null; // 0 is default value.
+                        break;
                     default:
                         if (TypeConverterMap.TryGetValue(Id, out ITypeConverter converter))
                         {

--- a/src/Core/Types/LegacyIAccessibleRoleType.cs
+++ b/src/Core/Types/LegacyIAccessibleRoleType.cs
@@ -99,7 +99,7 @@ namespace Axe.Windows.Core.Types
 #pragma warning restore CA1024 // Use properties where appropriate
 
         /// <summary>
-        /// private constructor since it would be singleton model
+        /// private constructor since this uses a singleton model
         /// </summary>
         private LegacyIAccessibleRoleType() : base("ROLE_SYSTEM_") { }
 

--- a/src/Core/Types/LegacyIAccessibleRoleType.cs
+++ b/src/Core/Types/LegacyIAccessibleRoleType.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+
+using static System.FormattableString;
+
+namespace Axe.Windows.Core.Types
+{
+    /// <summary>
+    /// Class for LegacyIAccessible.Role Types
+    /// </summary>
+    public class LegacyIAccessibleRoleType : TypeBase
+    {
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+        public const int ROLE_SYSTEM_TITLEBAR = 1;
+        public const int ROLE_SYSTEM_MENUBAR = 2;
+        public const int ROLE_SYSTEM_SCROLLBAR = 3;
+        public const int ROLE_SYSTEM_GRIP = 4;
+        public const int ROLE_SYSTEM_SOUND = 5;
+        public const int ROLE_SYSTEM_CURSOR = 6;
+        public const int ROLE_SYSTEM_CARET = 7;
+        public const int ROLE_SYSTEM_ALERT = 8;
+        public const int ROLE_SYSTEM_WINDOW = 9;
+        public const int ROLE_SYSTEM_CLIENT = 10;
+        public const int ROLE_SYSTEM_MENUPOPUP = 11;
+        public const int ROLE_SYSTEM_MENUITEM = 12;
+        public const int ROLE_SYSTEM_TOOLTIP = 13;
+        public const int ROLE_SYSTEM_APPLICATION = 14;
+        public const int ROLE_SYSTEM_DOCUMENT = 15;
+        public const int ROLE_SYSTEM_PANE = 16;
+        public const int ROLE_SYSTEM_CHART = 17;
+        public const int ROLE_SYSTEM_DIALOG = 18;
+        public const int ROLE_SYSTEM_BORDER = 19;
+        public const int ROLE_SYSTEM_GROUPING = 20;
+        public const int ROLE_SYSTEM_SEPARATOR = 21;
+        public const int ROLE_SYSTEM_TOOLBAR = 22;
+        public const int ROLE_SYSTEM_STATUSBAR = 23;
+        public const int ROLE_SYSTEM_TABLE = 24;
+        public const int ROLE_SYSTEM_COLUMNHEADER = 25;
+        public const int ROLE_SYSTEM_ROWHEADER = 26;
+        public const int ROLE_SYSTEM_COLUMN = 27;
+        public const int ROLE_SYSTEM_ROW = 28;
+        public const int ROLE_SYSTEM_CELL = 29;
+        public const int ROLE_SYSTEM_LINK = 30;
+        public const int ROLE_SYSTEM_HELPBALLOON = 31;
+        public const int ROLE_SYSTEM_CHARACTER = 32;
+        public const int ROLE_SYSTEM_LIST = 33;
+        public const int ROLE_SYSTEM_LISTITEM = 34;
+        public const int ROLE_SYSTEM_OUTLINE = 35;
+        public const int ROLE_SYSTEM_OUTLINEITEM = 36;
+        public const int ROLE_SYSTEM_PAGETAB = 37;
+        public const int ROLE_SYSTEM_PROPERTYPAGE = 38;
+        public const int ROLE_SYSTEM_INDICATOR = 39;
+        public const int ROLE_SYSTEM_GRAPHIC = 40;
+        public const int ROLE_SYSTEM_STATICTEXT = 41;
+        public const int ROLE_SYSTEM_TEXT = 42;
+        public const int ROLE_SYSTEM_PUSHBUTTON = 43;
+        public const int ROLE_SYSTEM_CHECKBUTTON = 44;
+        public const int ROLE_SYSTEM_RADIOBUTTON = 45;
+        public const int ROLE_SYSTEM_COMBOBOX = 46;
+        public const int ROLE_SYSTEM_DROPLIST = 47;
+        public const int ROLE_SYSTEM_PROGRESSBAR = 48;
+        public const int ROLE_SYSTEM_DIAL = 49;
+        public const int ROLE_SYSTEM_HOTKEYFIELD = 50;
+        public const int ROLE_SYSTEM_SLIDER = 51;
+        public const int ROLE_SYSTEM_SPINBUTTON = 52;
+        public const int ROLE_SYSTEM_DIAGRAM = 53;
+        public const int ROLE_SYSTEM_ANIMATION = 54;
+        public const int ROLE_SYSTEM_EQUATION = 55;
+        public const int ROLE_SYSTEM_BUTTONDROPDOWN = 56;
+        public const int ROLE_SYSTEM_BUTTONMENU = 57;
+        public const int ROLE_SYSTEM_BUTTONDROPDOWNGRID = 58;
+        public const int ROLE_SYSTEM_WHITESPACE = 59;
+        public const int ROLE_SYSTEM_PAGETABLIST = 60;
+        public const int ROLE_SYSTEM_CLOCK = 61;
+        public const int ROLE_SYSTEM_SPLITBUTTON = 62;
+        public const int ROLE_SYSTEM_IPADDRESS = 63;
+        public const int ROLE_SYSTEM_OUTLINEBUTTON = 64;
+#pragma warning restore CA1707 // Identifiers should not contain underscores
+
+        private static LegacyIAccessibleRoleType TheInstance;
+
+#pragma warning disable CA1024 // Use properties where appropriate
+        /// <summary>
+        /// static method to get an instance of this class
+        /// singleton
+        /// </summary>
+        /// <returns></returns>
+        public static LegacyIAccessibleRoleType GetInstance()
+        {
+            if (TheInstance == null)
+            {
+                TheInstance = new LegacyIAccessibleRoleType();
+            }
+
+            return TheInstance;
+        }
+#pragma warning restore CA1024 // Use properties where appropriate
+
+        /// <summary>
+        /// private constructor since it would be singleton model
+        /// </summary>
+        private LegacyIAccessibleRoleType() : base("ROLE_SYSTEM_") { }
+
+        /// <summary>
+        /// change name into right format in dictionary and list.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        protected override string GetNameInProperFormat(string name, int id)
+        {
+            StringBuilder sb = new StringBuilder(name);
+
+            sb.Append(Invariant($"({id})"));
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/CoreTests/Types/LegacyIAccessibleRuleTypeTests.cs
+++ b/src/CoreTests/Types/LegacyIAccessibleRuleTypeTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Core.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace Axe.Windows.CoreTests.Types
+{
+    [TestClass()]
+    public class LegacyIAccessibleRuleTypeTests
+    {
+        [TestMethod()]
+        [Timeout(1000)]
+        public void CheckExists()
+        {
+            Assert.AreEqual(true, LegacyIAccessibleRoleType.GetInstance().Exists(LegacyIAccessibleRoleType.ROLE_SYSTEM_OUTLINEBUTTON));
+            Assert.AreEqual(false, LegacyIAccessibleRoleType.GetInstance().Exists(0));
+        }
+
+        [TestMethod()]
+        [Timeout(1000)]
+        public void CheckGetNameById()
+        {
+            Assert.AreEqual("ROLE_SYSTEM_OUTLINEBUTTON(64)", LegacyIAccessibleRoleType.GetInstance().GetNameById(LegacyIAccessibleRoleType.ROLE_SYSTEM_OUTLINEBUTTON));
+        }
+
+        [TestMethod()]
+        [Timeout(1000)]
+        public void CheckHasExpectedValues()
+        {
+            var values = LegacyIAccessibleRoleType.GetInstance().Values;
+            var minValue = LegacyIAccessibleRoleType.ROLE_SYSTEM_TITLEBAR;
+            var maxValue = LegacyIAccessibleRoleType.ROLE_SYSTEM_OUTLINEBUTTON;
+
+            // Adding 1 because the true count of objects is max + 1 - min.
+            Assert.AreEqual(values.Count(), maxValue + 1 - minValue);
+
+            for (int i = minValue; i <= maxValue; ++i)
+            {
+                Assert.IsTrue(values.Contains(i), $"{nameof(ControlType)} does not contain the expected value {i}");
+            }
+        }
+    }
+}

--- a/src/Desktop/UIAutomation/Patterns/LegacyIAccessiblePattern.cs
+++ b/src/Desktop/UIAutomation/Patterns/LegacyIAccessiblePattern.cs
@@ -8,6 +8,7 @@ using Axe.Windows.Desktop.Utility;
 using Axe.Windows.Telemetry;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using UIAutomationClient;
 
 namespace Axe.Windows.Desktop.UIAutomation.Patterns
@@ -26,6 +27,16 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
             PopulateProperties();
         }
 
+        private string GetDecoratedRoleValue()
+        {
+            using (A11yProperty ruleProperty = new A11yProperty(PropertyType.UIA_LegacyIAccessiblePattern_RolePropertyId, _pattern.CurrentRole))
+            {
+                string decoratedRuleValue = ruleProperty.ToString();
+
+                return decoratedRuleValue ?? _pattern.CurrentRole.ToString(CultureInfo.InvariantCulture);
+            }
+        }
+
         private void PopulateProperties()
         {
             try
@@ -37,7 +48,7 @@ namespace Axe.Windows.Desktop.UIAutomation.Patterns
                 Properties.Add(new A11yPatternProperty() { Name = "Help", Value = _pattern.CurrentHelp });
                 Properties.Add(new A11yPatternProperty() { Name = "KeyboardShorcut", Value = _pattern.CurrentKeyboardShortcut });
                 Properties.Add(new A11yPatternProperty() { Name = "Name", Value = _pattern.CurrentName });
-                Properties.Add(new A11yPatternProperty() { Name = "Role", Value = _pattern.CurrentRole });
+                Properties.Add(new A11yPatternProperty() { Name = "Role", Value = GetDecoratedRoleValue(), OmitQuotesFromString = true });
                 Properties.Add(new A11yPatternProperty() { Name = "State", Value = _pattern.CurrentState });
                 Properties.Add(new A11yPatternProperty() { Name = "Value", Value = _pattern.CurrentValue });
 #pragma warning restore CA2000 // Properties are disposed in A11yPattern.Dispose()


### PR DESCRIPTION
#### Details

AIWin [#1454](https://github.com/microsoft/accessibility-insights-windows/issues/1454) requests that we add the enum name for MSAA role types. This change provides the mapping, and it will light up in AIWin after this change gets published and picked up.

We add the `LegacyIAccessibleRoleType` class to map from numeric values to MSAA role types. We then add this to `A11yProperty` to capture this on the element. Finally, we need to expose this via the `A11yPatternProperty`, which leverages the `LegacyIAccessibleRoleType` class to get the name. In order to avoid confusing quotation marks around the mapped role, we add `A11yPatternProperty.OmitQuotesFromString`, which gets set only for `LegacyIAccessiblePattern.Role`. When writing out the JSON file, we set the flag to omit null values, so `A11yPatterProperty.OmitQuotesFromString` only gets written to disk when it's specified.

Validated by building locally and testing against the pentest site provided in the AIWin issue.

Two notes:

1. If an `.a11ytest` file is created with the new build, then opened in a previous version of AIWin, the properties will contain the LegacyIAccessiblePattern.Role value in quotes. This is because older versions don't know about the `A11yPatternProperty.OmitQuotesFromString` property and include the quotes
2. Since AIWin displays the data stored in the `.a11ytest` file, existing `.a11ytest` files will continue to display just the number without the enum name
 
##### Motivation

Set things up to address AIWin [#1454](https://github.com/microsoft/accessibility-insights-windows/issues/1454)

##### Screenshots

Scenario | Before PR | After PR
--- | --- | ---
Live mode (pen test) | ![image](https://user-images.githubusercontent.com/45672944/200637655-90a4a029-093c-4590-be55-b574d50750fe.png) | ![image](https://user-images.githubusercontent.com/45672944/200638440-83e72f68-293f-4bd5-97a0-23f5c7c272ff.png)
Open old saved file | ![image](https://user-images.githubusercontent.com/45672944/200637885-1cefafb4-21aa-44f4-ae62-3a2c6779b550.png) | ![image](https://user-images.githubusercontent.com/45672944/200637392-af23c5f8-5012-4abd-a487-5b2993bfd0ee.png)
Open new saved file | ![image](https://user-images.githubusercontent.com/45672944/200638145-fa4a78bb-7508-4d2f-b433-dc3ce4e0d0f8.png) | ![image](https://user-images.githubusercontent.com/45672944/200637248-34c41862-f9ec-4460-9576-372a2311b3f8.png)


##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: AIWin [#1454](https://github.com/microsoft/accessibility-insights-windows/issues/1454)
