### PR TITLE
chore: Consistently follow IDE0049

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -32,8 +32,8 @@ dotnet_style_qualification_for_property = false:error
 dotnet_style_qualification_for_method = false:error
 dotnet_style_qualification_for_event = false:error
 # Language keywords vs BCL types preferences
-dotnet_style_predefined_type_for_locals_parameters_members = true:silent
-dotnet_style_predefined_type_for_member_access = true:silent
+dotnet_style_predefined_type_for_locals_parameters_members = true:error
+dotnet_style_predefined_type_for_member_access = true:error
 # Parentheses preferences
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent

--- a/src/AutomationTests/OutputFileHelperTests.cs
+++ b/src/AutomationTests/OutputFileHelperTests.cs
@@ -91,7 +91,7 @@ namespace Axe.Windows.AutomationTests
             var phonyDirectory = "flub";
             Action action = () => new OutputFileHelper(phonyDirectory, mockSystem.Object);
             var ex = Assert.ThrowsException<AxeWindowsAutomationException>(action);
-            Assert.AreEqual(String.Format(CultureInfo.InvariantCulture, ErrorMessages.ErrorDirectoryInvalid, phonyDirectory), ex.Message);
+            Assert.AreEqual(string.Format(CultureInfo.InvariantCulture, ErrorMessages.ErrorDirectoryInvalid, phonyDirectory), ex.Message);
 
             mockSystem.VerifyAll();
             mockIO.VerifyAll();

--- a/src/Core/Bases/A11yElement.cs
+++ b/src/Core/Bases/A11yElement.cs
@@ -500,7 +500,7 @@ namespace Axe.Windows.Core.Bases
         /// </summary>
         /// <param name="condition">a function that returns true if the given descendant element meets a set of criteria</param>
         /// <returns>an <see cref="IA11yElement"/> object representing the matching descendant if one exists; otherwise, false</returns>
-        public A11yElement FindDescendant(Func<A11yElement, Boolean> condition)
+        public A11yElement FindDescendant(Func<A11yElement, bool> condition)
         {
             if (condition == null) throw new ArgumentNullException(nameof(condition));
 

--- a/src/Core/Bases/A11yProperty.cs
+++ b/src/Core/Bases/A11yProperty.cs
@@ -132,9 +132,9 @@ namespace Axe.Windows.Core.Bases
                         {
                             txt = ((int[])Value).ConvertInt32ArrayToString();
                         }
-                        else if (Value is Double[])
+                        else if (Value is double[])
                         {
-                            txt = ((Double[])Value).ConvertDoubleArrayToString();
+                            txt = ((double[])Value).ConvertDoubleArrayToString();
                         }
                         else
                         {

--- a/src/Core/Bases/A11yProperty.cs
+++ b/src/Core/Bases/A11yProperty.cs
@@ -128,9 +128,9 @@ namespace Axe.Windows.Core.Bases
                         {
                             txt = converter.Render(Value);
                         }
-                        else if (Value is Int32[])
+                        else if (Value is int[])
                         {
-                            txt = ((Int32[])Value).ConvertInt32ArrayToString();
+                            txt = ((int[])Value).ConvertInt32ArrayToString();
                         }
                         else if (Value is Double[])
                         {

--- a/src/Core/CustomObjects/Converters/EnumTypeConverter.cs
+++ b/src/Core/CustomObjects/Converters/EnumTypeConverter.cs
@@ -21,7 +21,7 @@ namespace Axe.Windows.Core.CustomObjects.Converters
             int raw = (int)value;
             if (_values.TryGetValue(raw, out string friendlyName))
                 return $"{friendlyName} ({raw})";
-            return String.Format(CultureInfo.CurrentCulture, DisplayStrings.UnknownFormat, raw);
+            return string.Format(CultureInfo.CurrentCulture, DisplayStrings.UnknownFormat, raw);
         }
     }
 }

--- a/src/Core/CustomObjects/Converters/PointTypeConverter.cs
+++ b/src/Core/CustomObjects/Converters/PointTypeConverter.cs
@@ -13,7 +13,7 @@ namespace Axe.Windows.Core.CustomObjects.Converters
         {
             if (value == null) throw new ArgumentNullException(nameof(value));
             double[] arr = (double[])value;
-            return String.Format(CultureInfo.CurrentCulture, DisplayStrings.PointFormat, arr[0], arr[1]);
+            return string.Format(CultureInfo.CurrentCulture, DisplayStrings.PointFormat, arr[0], arr[1]);
         }
     }
 }

--- a/src/Core/Misc/ExtensionMethods.cs
+++ b/src/Core/Misc/ExtensionMethods.cs
@@ -93,7 +93,7 @@ namespace Axe.Windows.Core.Misc
         /// </summary>
         /// <param name="array"></param>
         /// <returns></returns>
-        public static string ConvertIntArrayToString(Int32[] array)
+        public static string ConvertIntArrayToString(int[] array)
         {
             StringBuilder sb = new StringBuilder();
 
@@ -168,7 +168,7 @@ namespace Axe.Windows.Core.Misc
             return ConvertDoubleArrayToString((Double[])array);
         }
 
-        public static string ConvertInt32ArrayToString(Int32[] array)
+        public static string ConvertInt32ArrayToString(int[] array)
         {
             if (array != null && array.Length != 0)
             {
@@ -195,7 +195,7 @@ namespace Axe.Windows.Core.Misc
 
         public static string ConvertInt32ArrayToString(this Array array)
         {
-            return ConvertInt32ArrayToString((Int32[])array);
+            return ConvertInt32ArrayToString((int[])array);
         }
 
         /// <summary>

--- a/src/Core/Misc/ExtensionMethods.cs
+++ b/src/Core/Misc/ExtensionMethods.cs
@@ -139,7 +139,7 @@ namespace Axe.Windows.Core.Misc
             return sb.ToString();
         }
 
-        public static string ConvertDoubleArrayToString(Double[] array)
+        public static string ConvertDoubleArrayToString(double[] array)
         {
             if (array != null && array.Length != 0)
             {
@@ -165,7 +165,7 @@ namespace Axe.Windows.Core.Misc
 
         public static string ConvertDoubleArrayToString(this Array array)
         {
-            return ConvertDoubleArrayToString((Double[])array);
+            return ConvertDoubleArrayToString((double[])array);
         }
 
         public static string ConvertInt32ArrayToString(int[] array)

--- a/src/Core/Misc/ExtensionMethods.cs
+++ b/src/Core/Misc/ExtensionMethods.cs
@@ -601,7 +601,7 @@ namespace Axe.Windows.Core.Misc
 
         public static string ToLeftTopRightBottomString(this Rectangle r)
         {
-            return String.Format(CultureInfo.CurrentCulture, DisplayStrings.LeftTopRightBottomFormat, r.Left, r.Top, r.Right, r.Bottom);
+            return string.Format(CultureInfo.CurrentCulture, DisplayStrings.LeftTopRightBottomFormat, r.Left, r.Top, r.Right, r.Bottom);
         }
 
         /// <summary>

--- a/src/Core/Misc/PackageInfo.cs
+++ b/src/Core/Misc/PackageInfo.cs
@@ -14,7 +14,7 @@ namespace Axe.Windows.Core.Misc
         private static readonly Lazy<Assembly> ThisAssembly = new Lazy<Assembly>(() => Assembly.GetExecutingAssembly(), true);
         private static readonly Lazy<string> LazyInformationalVersion = new Lazy<string>(GetInformationalVersion, true);
 
-        private static String GetInformationalVersion()
+        private static string GetInformationalVersion()
         {
             var attribute = ThisAssembly.Value.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
 

--- a/src/CoreTests/CustomObjects/ConfigTests.cs
+++ b/src/CoreTests/CustomObjects/ConfigTests.cs
@@ -54,7 +54,7 @@ namespace Axe.Windows.CoreTests.CustomObjects
         {
             try
             {
-                Config.ReadFromText(String.Empty);
+                Config.ReadFromText(string.Empty);
                 Assert.Fail("Failed to throw exception.");
             }
             catch (Exception) { }

--- a/src/CoreTests/CustomObjects/Converters/StringConverterTests.cs
+++ b/src/CoreTests/CustomObjects/Converters/StringConverterTests.cs
@@ -25,7 +25,7 @@ namespace Axe.Windows.CoreTests.CustomObjects.Converters
         [TestMethod, Timeout(1000)]
         public void EmptyRenderTest()
         {
-            Assert.AreEqual(String.Empty, new StringTypeConverter().Render(String.Empty));
+            Assert.AreEqual(string.Empty, new StringTypeConverter().Render(string.Empty));
         }
     }
 }

--- a/src/Desktop/ColorContrastAnalyzer/Color.cs
+++ b/src/Desktop/ColorContrastAnalyzer/Color.cs
@@ -121,7 +121,7 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
                 Math.Pow((colorRatio + 0.055) / 1.055, 2.4);
         }
 
-        public override bool Equals(Object obj)
+        public override bool Equals(object obj)
         {
             //Check for null and compare run-time types.
             if ((obj == null) || !GetType().Equals(obj.GetType()))

--- a/src/Desktop/ColorContrastAnalyzer/ColorPair.cs
+++ b/src/Desktop/ColorContrastAnalyzer/ColorPair.cs
@@ -55,7 +55,7 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
         /**
          * True when the pair of colors are not visually different.
          */
-        public Boolean AreVisuallySimilarColors()
+        public bool AreVisuallySimilarColors()
         {
             return LighterColor.IsSimilarColor(DarkerColor);
         }
@@ -63,7 +63,7 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
         /**
          * True when a pair of colors have visibly similar pairs of colors.
          */
-        public Boolean IsVisiblySimilarTo(ColorPair otherPair)
+        public bool IsVisiblySimilarTo(ColorPair otherPair)
         {
             if (otherPair == null) throw new ArgumentNullException(nameof(otherPair));
 

--- a/src/Desktop/ColorContrastAnalyzer/ColorPair.cs
+++ b/src/Desktop/ColorContrastAnalyzer/ColorPair.cs
@@ -38,7 +38,7 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
             }
         }
 
-        public override bool Equals(Object obj)
+        public override bool Equals(object obj)
         {
             //Check for null and compare run-time types.
             if ((obj == null) || !GetType().Equals(obj.GetType()))

--- a/src/Desktop/ColorContrastAnalyzer/ContrastTransition.cs
+++ b/src/Desktop/ColorContrastAnalyzer/ContrastTransition.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-
 namespace Axe.Windows.Desktop.ColorContrastAnalyzer
 {
     internal class ColorContrastTransition

--- a/src/Desktop/ColorContrastAnalyzer/ContrastTransition.cs
+++ b/src/Desktop/ColorContrastAnalyzer/ContrastTransition.cs
@@ -9,8 +9,8 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
     {
         private readonly IColorContrastConfig _colorContrastConfig;
 
-        internal Boolean IsClosed { get; private set; }
-        internal Boolean IsConnecting { get; private set; }
+        internal bool IsClosed { get; private set; }
+        internal bool IsConnecting { get; private set; }
 
         internal readonly Color StartingColor;
 
@@ -22,8 +22,8 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
          * These two booleans help us track that, without having to store all the colors
          * in a list.
          */
-        private Boolean _isMountainShaped = true;
-        private Boolean _isIncreasingInContrast = true;
+        private bool _isMountainShaped = true;
+        private bool _isIncreasingInContrast = true;
 
         /**
          * It is useful to track the size of a transition. Especially for debugging purposes,
@@ -72,7 +72,7 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
         /**
          * True if the transition may be a transition involving text.
          */
-        public Boolean IsPotentialForegroundBackgroundPair()
+        public bool IsPotentialForegroundBackgroundPair()
         {
             return IsConsequential() && !ToColorPair().AreVisuallySimilarColors();
         }
@@ -85,7 +85,7 @@ namespace Axe.Windows.Desktop.ColorContrastAnalyzer
             return new ColorPair(StartingColor, MostContrastingColor);
         }
 
-        internal Boolean IsConsequential()
+        internal bool IsConsequential()
         {
             return IsConnecting && _size > 2 && _isMountainShaped;
         }

--- a/src/Rules/RuleProvider.cs
+++ b/src/Rules/RuleProvider.cs
@@ -21,7 +21,7 @@ namespace Axe.Windows.Rules
     {
         private readonly IRuleFactory _ruleFactory;
         private readonly ConcurrentDictionary<RuleId, IRule> _allRules = new ConcurrentDictionary<RuleId, IRule>();
-        private readonly Object _allRulesLock = new Object();
+        private readonly object _allRulesLock = new object();
         private bool _areAllRulesInitialized;
 
         public RuleProvider(IRuleFactory ruleFactory)

--- a/src/Win32/HighContrast.cs
+++ b/src/Win32/HighContrast.cs
@@ -9,7 +9,7 @@ namespace Axe.Windows.Win32
     internal class HighContrast
     {
         private const uint SPI_GetHighContrast = 0x0042;
-        private const UInt32 HighContrastOnFlag = 0x1;
+        private const uint HighContrastOnFlag = 0x1;
 
         private HighContrastData _data;
 
@@ -23,7 +23,7 @@ namespace Axe.Windows.Win32
         public static HighContrast Create()
         {
             var data = new HighContrastData();
-            data.Size = (UInt32)Marshal.SizeOf(data);
+            data.Size = (uint)Marshal.SizeOf(data);
 
             NativeMethods.SystemParametersInfoHighContrast(SPI_GetHighContrast, data.Size, ref data, 0);
 

--- a/src/Win32/HighContrast.cs
+++ b/src/Win32/HighContrast.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace Axe.Windows.Win32

--- a/src/Win32/HighContrastData.cs
+++ b/src/Win32/HighContrastData.cs
@@ -9,7 +9,7 @@ namespace Axe.Windows.Win32
     [StructLayout(LayoutKind.Sequential)]
     internal struct HighContrastData
     {
-        public UInt32 Size;
+        public uint Size;
         public int Flags;
 
         // changing the following type to string will cause .NET Core to crash during the unit tests

--- a/src/Win32/HighContrastData.cs
+++ b/src/Win32/HighContrastData.cs
@@ -10,7 +10,7 @@ namespace Axe.Windows.Win32
     internal struct HighContrastData
     {
         public UInt32 Size;
-        public Int32 Flags;
+        public int Flags;
 
         // changing the following type to string will cause .NET Core to crash during the unit tests
         public IntPtr DefaultScheme;


### PR DESCRIPTION
#### Details

IDE0049 nudges us toward language-specific type names instead of framework type names, so things like:
- `int` instead of `System.Int32`
- `uint` instead of `System.UInt32`
- `double` instead of `System.Double`
- `string` instead of `System.String`
- `object` instead of `System.Object`
- `bool` instead of `System.Boolean`

Most of the code is already following this rule, but there are some outliers. This PR updates `.editorconfig` to call out these issues, then also applies the changes across all projects

##### Motivation

Code consistency

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
