### PR TITLE
chore: Tiny code cleanups that got missed before

### DIFF
--- a/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
+++ b/src/Desktop/UIAutomation/CustomObjects/Registrar.cs
@@ -28,16 +28,16 @@ namespace Axe.Windows.Desktop.UIAutomation.CustomObjects
             _idToCustomPropertyMap = new Dictionary<int, CustomProperty>();
         }
 
-        static Registrar sDefaultInstance;
+        static Registrar DefaultInstance;
 
 #pragma warning disable CA1024 // Use properties where appropriate: backing field
         public static Registrar GetDefaultInstance()
 #pragma warning restore CA1024 // Use properties where appropriate: backing field
         {
             // This code is currently not thread safe.
-            if (sDefaultInstance == null)
-                sDefaultInstance = new Registrar();
-            return sDefaultInstance;
+            if (DefaultInstance == null)
+                DefaultInstance = new Registrar();
+            return DefaultInstance;
         }
 
         public void RegisterCustomProperty(CustomProperty prop)

--- a/src/Rules/Extensions/ExtensionMethods.cs
+++ b/src/Rules/Extensions/ExtensionMethods.cs
@@ -41,7 +41,7 @@ namespace Axe.Windows.Rules.Extensions
                 ? value : default(T);
         }
 
-        public static Condition WithTimer(this Condition c, string message)
+        public static Condition WithTimer(this Condition c)
         {
             if (c == null) return null;
 


### PR DESCRIPTION
#### Details

This PR cleans up 2 things:
1. Renaming `Registrar.sDefaultInstance` to `Registrar.DefaultInstance` to match naming guidelines
2. Removing an unused parameter from an extension method. The entire method itself seems to be unused but I left it for now.

##### Motivation

Code consistency

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
I'd love to remove all unused methods, but I'm not sure how to identify them in an efficient way

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
