### PR TITLE
chore: Migrate EXE's from .NET Core 3.1 to .NET 6.0

### DIFF
--- a/build/NetStandardTest.targets
+++ b/build/NetStandardTest.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <NoWarn>1701;1702</NoWarn>
+    <NoWarn>1701;1702;CA1416</NoWarn>
   </PropertyGroup>
 
   <Import Project=".\NetStandardAll.targets" />

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -343,14 +343,14 @@ jobs:
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)\src'
       Contents: |
-       CLI_Full\bin\release\netcoreapp3.1\win7-x86\?(*.exe|*.dll)
+       CLI_Full\bin\release\net6.0\win7-x86\?(*.exe|*.dll)
       TargetFolder: '$(Build.ArtifactStagingDirectory)\SigningValidation'
 
   - task: CopyFiles@2
     displayName: 'Copy CLI Files for Signing Validation'
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)\src'
-      Contents: 'CLI\bin\release\netcoreapp3.1\**\?(*.exe|*.dll)'
+      Contents: 'CLI\bin\release\net6.0\**\?(*.exe|*.dll)'
       TargetFolder: '$(Build.ArtifactStagingDirectory)\SigningValidation'
 
   - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1

--- a/src/ActionsTests/ActionsTests.csproj
+++ b/src/ActionsTests/ActionsTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Axe.Windows.ActionsTests</RootNamespace>
   </PropertyGroup>
 

--- a/src/AutomationTests/AutomationTests.csproj
+++ b/src/AutomationTests/AutomationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Axe.Windows.AutomationTests</RootNamespace>
   </PropertyGroup>
 

--- a/src/CLI/CLI.csproj
+++ b/src/CLI/CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>AxeWindowsCLI</AssemblyName>
     <RootNamespace>AxeWindowsCLI</RootNamespace>
   </PropertyGroup>

--- a/src/CLITests/CLITests.csproj
+++ b/src/CLITests/CLITests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>AxeWindowsCLITests</RootNamespace>
   </PropertyGroup>
 

--- a/src/CLI_Full/CLI_Full.csproj
+++ b/src/CLI_Full/CLI_Full.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>AxeWindowsCLI</AssemblyName>
     <RootNamespace>AxeWindowsCLI</RootNamespace>
     <RuntimeIdentifier>win7-x86</RuntimeIdentifier>
@@ -56,7 +56,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="del $(TargetDir)InteropDummy*.*&#xD;&#xA;copy /y $(ProjectDir)\..\CLI\bin\$(Configuration)\netcoreapp3.1\CommandLine.dll $(TargetDir)&#xD;&#xA;copy /y $(ProjectDir)\..\CLI\bin\$(Configuration)\netcoreapp3.1\Newtonsoft.Json.dll $(TargetDir)&#xD;&#xA;copy /y $(ProjectDir)\..\CLI\bin\$(Configuration)\netcoreapp3.1\AxeWindowsCLI.dll $(TargetDir)" />
+    <Exec Command="del $(TargetDir)InteropDummy*.*&#xD;&#xA;copy /y $(ProjectDir)\..\CLI\bin\$(Configuration)\net6.0\CommandLine.dll $(TargetDir)&#xD;&#xA;copy /y $(ProjectDir)\..\CLI\bin\$(Configuration)\net6.0\Newtonsoft.Json.dll $(TargetDir)&#xD;&#xA;copy /y $(ProjectDir)\..\CLI\bin\$(Configuration)\net6.0\AxeWindowsCLI.dll $(TargetDir)" />
   </Target>
 
 </Project>

--- a/src/CLI_Installer/CLI_Installer.wixproj
+++ b/src/CLI_Installer/CLI_Installer.wixproj
@@ -68,7 +68,7 @@
 	</Target>
 	-->
   <Target Condition=" '$(CreateAxeWindowsZippedCLI)' == 'true' AND '$(ConfigurationName)' == 'Release' " Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\BuildZippedCLI.ps1 -SrcDir $(SolutionDir)CLI_Full\bin\$(ConfigurationName)\netcoreapp3.1\win7-x86 -TargetDir $(TargetDir) " />
+    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\BuildZippedCLI.ps1 -SrcDir $(SolutionDir)CLI_Full\bin\$(ConfigurationName)\net6.0\win7-x86 -TargetDir $(TargetDir) " />
   </Target>
   <Import Project="..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" Condition="Exists('..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" />
 </Project>

--- a/src/CLI_Installer/Product.wxs
+++ b/src/CLI_Installer/Product.wxs
@@ -34,10 +34,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <Feature Id="ProductFeature" Title="Axe.Windows CLI" Level="1">
       <ComponentGroupRef Id="ProductComponents" />
-      <ComponentGroupRef Id="NetCoreApp20Components" />
-      <ComponentGroupRef Id="NetCoreApp21Components" />
-      <ComponentGroupRef Id="NetCoreApp31Components" />
-      <ComponentGroupRef Id="NetStandard20Components" />
+      <ComponentGroupRef Id="Net60Components" />
     </Feature>
 
     <Condition Message="[ProductName] requires .NET Core Runtime 3.1 or newer. Please visit https://dotnet.microsoft.com/download/dotnet-core">
@@ -51,10 +48,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
             <Directory Id="RuntimesFolder" Name="runtimes" >
               <Directory Id="WinFolder" Name="win" >
                 <Directory Id="LibFolder" Name="lib" >
-                  <Directory Id="NetCoreApp20Folder" Name="netcoreapp2.0" />
-                  <Directory Id="NetCoreApp21Folder" Name="netcoreapp2.1" />
-                  <Directory Id="NetCoreApp31Folder" Name="netcoreapp3.1" />
-                  <Directory Id="NetStandard20Folder" Name="netstandard2.0" />
+                  <Directory Id="Net60Folder" Name="net6.0" />
                 </Directory>
               </Directory>
             </Directory>
@@ -65,51 +59,33 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
       <Component Id="ProductComponent" Guid="548A9965-21AD-4CDF-99AD-A6F2A47D0AE8">
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\AxeWindowsCLI.exe" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\AxeWindowsCLI.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\AxeWindowsCLI.deps.json" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\AxeWindowsCLI.runtimeconfig.json" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.Actions.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.Automation.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.Core.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.Desktop.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.Rules.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.RuleSelection.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.SystemAbstractions.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.Telemetry.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\Axe.Windows.Win32.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\CommandLine.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\Microsoft.Win32.SystemEvents.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\Newtonsoft.Json.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\System.Drawing.Common.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\System.IO.Packaging.dll" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\thirdpartynotices.html" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\README.MD" />
+        <File Source="..\CLI\bin\Release\net6.0\AxeWindowsCLI.exe" />
+        <File Source="..\CLI\bin\Release\net6.0\AxeWindowsCLI.dll" />
+        <File Source="..\CLI\bin\Release\net6.0\AxeWindowsCLI.deps.json" />
+        <File Source="..\CLI\bin\Release\net6.0\AxeWindowsCLI.runtimeconfig.json" />
+        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.Actions.dll" />
+        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.Automation.dll" />
+        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.Core.dll" />
+        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.Desktop.dll" />
+        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.Rules.dll" />
+        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.RuleSelection.dll" />
+        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.SystemAbstractions.dll" />
+        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.Telemetry.dll" />
+        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.Win32.dll" />
+        <File Source="..\CLI\bin\Release\net6.0\CommandLine.dll" />
+        <File Source="..\CLI\bin\Release\net6.0\Microsoft.Win32.SystemEvents.dll" />
+        <File Source="..\CLI\bin\Release\net6.0\Newtonsoft.Json.dll" />
+        <File Source="..\CLI\bin\Release\net6.0\System.Drawing.Common.dll" />
+        <File Source="..\CLI\bin\Release\net6.0\System.IO.Packaging.dll" />
+        <File Source="..\CLI\bin\Release\net6.0\thirdpartynotices.html" />
+        <File Source="..\CLI\bin\Release\net6.0\README.MD" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="NetCoreApp20Components" Directory="NetCoreApp20Folder">
+    <ComponentGroup Id="Net60Components" Directory="Net60Folder">
       <Component Id="NetCoreApp20Component" Guid="5002A1F9-EB89-441C-B757-8E214EFE82CF">
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\runtimes\win\lib\netcoreapp2.0\System.Security.AccessControl.dll" Id="netcoreapp20_system_security_accesscontrol" />
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="NetCoreApp21Components" Directory="NetCoreApp21Folder">
-      <Component Id="NetCoreApp21Component" Guid="8DAE90E7-271A-40A6-8B57-B967EC305130">
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\runtimes\win\lib\netcoreapp2.1\System.Security.Principal.Windows.dll" Id="netcoreapp21_system_security_principal_windows" />
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="NetCoreApp31Components" Directory="NetCoreApp31Folder">
-      <Component Id="NetCoreApp31Component" Guid="2F921C55-E303-46DF-81B7-95923D83C32D">
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\runtimes\win\lib\netcoreapp3.1\Microsoft.Win32.SystemEvents.dll" Id="netcoreapp31_microsoft_win32_systemevents" />
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\runtimes\win\lib\netcoreapp3.1\System.Drawing.Common.dll" Id="netcoreapp31_system_drawing_common" />
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="NetStandard20Components" Directory="NetStandard20Folder">
-      <Component Id="NetStandard20Component" Guid="940EFA7D-6706-415A-9064-BAFE98B81855">
-        <File Source="..\CLI\bin\Release\netcoreapp3.1\runtimes\win\lib\netstandard2.0\Microsoft.Win32.Registry.dll" Id="netstandard20_microsoft_win32_registry" />
+        <File Source="..\CLI\bin\Release\net6.0\runtimes\win\lib\net6.0\Microsoft.Win32.SystemEvents.dll" Id="net60_systemevents" />
+        <File Source="..\CLI\bin\Release\net6.0\runtimes\win\lib\net6.0\System.Drawing.Common.dll" Id="net60_systemdrawing" />
       </Component>
     </ComponentGroup>
 

--- a/src/CLI_Installer/Product.wxs
+++ b/src/CLI_Installer/Product.wxs
@@ -20,13 +20,13 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <Property Id="NETCORERUNTIMEFOUNDX86">
       <DirectorySearch Id="NetCoreDirectoryFoundx86" Path="[ProgramFilesFolder]dotnet" >
-        <FileSearch Name="dotnet.exe" MinVersion="3.1"/>
+        <FileSearch Name="dotnet.exe" MinVersion="6.0"/>
       </DirectorySearch>
     </Property>
 
     <Property Id="NETCORERUNTIMEFOUNDX64">
       <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="[ProgramFiles64Folder]dotnet" >
-        <FileSearch Name="dotnet.exe" MinVersion="3.1"/>
+        <FileSearch Name="dotnet.exe" MinVersion="6.0"/>
       </DirectorySearch>
     </Property>
 

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Axe.Windows.CoreTests</RootNamespace>
   </PropertyGroup>
 

--- a/src/Desktop/Desktop.csproj
+++ b/src/Desktop/Desktop.csproj
@@ -43,7 +43,7 @@
 
   <ItemGroup>
     <Reference Include="Interop.UIAutomationCore">
-      <HintPath>..\InteropDummy\bin\$(Configuration)\netcoreapp3.1\Interop.UIAutomationCore.dll</HintPath>
+      <HintPath>..\InteropDummy\bin\$(Configuration)\net6.0\Interop.UIAutomationCore.dll</HintPath>
       <EmbedInteropTypes>true</EmbedInteropTypes>
     </Reference>
   </ItemGroup>

--- a/src/DesktopTests/DesktopTests.csproj
+++ b/src/DesktopTests/DesktopTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Axe.Windows.DesktopTests</RootNamespace>
   </PropertyGroup>
 
@@ -46,7 +46,7 @@
 
   <ItemGroup>
     <Reference Include="Interop.UIAutomationCore">
-      <HintPath>..\InteropDummy\bin\$(Configuration)\netcoreapp3.1\Interop.UIAutomationCore.dll</HintPath>
+      <HintPath>..\InteropDummy\bin\$(Configuration)\net6.0\Interop.UIAutomationCore.dll</HintPath>
       <EmbedInteropTypes>true</EmbedInteropTypes>
     </Reference>
   </ItemGroup>

--- a/src/InteropDummy/InteropDummy.csproj
+++ b/src/InteropDummy/InteropDummy.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>InteropDummy</AssemblyName>
     <RootNamespace>InteropDummy</RootNamespace>
   </PropertyGroup>

--- a/src/OldFileVersionCompatibilityTests/OldFileVersionCompatibilityTests.csproj
+++ b/src/OldFileVersionCompatibilityTests/OldFileVersionCompatibilityTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Axe.Windows.OldFileVersionCompatibilityTests</RootNamespace>
   </PropertyGroup>
 

--- a/src/RuleSelectionTests/RuleSelectionTests.csproj
+++ b/src/RuleSelectionTests/RuleSelectionTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Axe.Windows.RuleSelectionTests</RootNamespace>
   </PropertyGroup>
 

--- a/src/RulesTest/RulesTests.csproj
+++ b/src/RulesTest/RulesTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Axe.Windows.RulesTests</RootNamespace>
   </PropertyGroup>
 

--- a/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
+++ b/src/SystemAbstractionsTests/SystemAbstractionsTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Axe.Windows.SystemAbstractionsTests</RootNamespace>
   </PropertyGroup>
 

--- a/src/TelemetryTests/TelemetryTests.csproj
+++ b/src/TelemetryTests/TelemetryTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Axe.Windows.TelemetryTests</RootNamespace>
   </PropertyGroup>
 

--- a/src/Win32Tests/Win32Tests.csproj
+++ b/src/Win32Tests/Win32Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Axe.Windows.Win32Tests</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
#### Details

As called out in this [blog post](https://devblogs.microsoft.com/dotnet/net-core-3-1-will-reach-end-of-support-on-december-13-2022/), .NET Core 3.1 ends LTS on 13 December 2022, which is coming up quickly. Some of our .NET dependencies are dropping support for .NET Core 3.1, so in order to stay on current binaries, we are shifting our EXE's to .NET 6.0. This includes the CLI and all test projects. The libraries in the NuGet package will continue to build using .NET Standard 2.0, so they'll continue to work in either .NET or .NET Framework applications. They will also continue to be Windows-specific, which makes sense since UIA is a Windows-specific technology.

Validation included:
1. Run changes through the signed build pipeline. Artifacts are [here](https://dev.azure.com/mseng/1ES/_build/results?buildId=18716735&view=artifacts&pathAsName=false&type=publishedArtifacts)
2. Install and run the signed CLI (using the MSI installer)
3. Using a local package store, update AIWin to use the signed NuGet package and make sure that it still works as expected

##### Motivation

Avoid the situation where we depend on libraries that are out of support or untested in our install environment.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
This and #834 both involve the WXS file. Some merge resolution will be needed, no matter what order we merge.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
