### PR TITLE
chore: We don't need to use WPF in this test

### DIFF
--- a/src/MsiFileTests/MsiFileTests.csproj
+++ b/src/MsiFileTests/MsiFileTests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
-    <UseWPF>true</UseWPF>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#### Details

After merging #834, I stopped to wonder why we needed WPF for this test...and couldn't find a reason. This PR just removes the `UseWPF` flag and updates the target accordingly

##### Motivation

Code consistency

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
