### PR TITLE
fix: Signed build is failing WXS validation

### DIFF
--- a/src/MsiFileTests/WxsValidationTests.cs
+++ b/src/MsiFileTests/WxsValidationTests.cs
@@ -27,6 +27,7 @@ namespace MsiFileTests
             HashSet<string> productComponentExclusions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "Axe.Windows.Automation.xml",
+                "AxeWindowsCLI.dll.lce",
                 "AxeWindowsCLI.runtimeconfig.dev.json",
             };
 


### PR DESCRIPTION
#### Details

The signed release build is including a localization file that is not included in the other builds. Since the CLI is not yet localized, we are not including the localized files and should add this file to the list of files that we intentionally exclude from the MSI package.

##### Motivation

Unblock signed builds

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
