### PR TITLE
chore: Fix CLI validation script

### DIFF
--- a/tools/scripts/verification.scripts/ValidateCLI.ps1
+++ b/tools/scripts/verification.scripts/ValidateCLI.ps1
@@ -35,33 +35,35 @@ $ThirdPartyNoticesDisplayed = 3
 $BadInputParameters = 255
 
 Clear
-PromptAndWait 'This script assumes that you are running from the scripts folder and that you have built a release version of the CLI.'
+PromptAndWait 'This script assumes that you have built a release version of the
+CLI. It also assumes that you are running from the
+.\tools\scripts\verification.scripts folder.'
 
 # Note: I tried unsuccessfully to find a way to parameterize the command line and still get the exit code.
 # If you can find a way to make this work, then please refactor this code!
 
 Clear
-../../../src/cli/bin/Release/netcoreapp3.1/AxeWindowsCLI.exe
+../../../src/cli/bin/Release/net6.0/AxeWindowsCLI.exe
 ValidateExitCode $lastExitCode $BadInputParameters
 PromptAndWait 'The scenario should have displayed help text and thrown no exceptions'
 
 Clear
-../../../src/cli/bin/Release/netcoreapp3.1/AxeWindowsCLI.exe --UndefinedParameter
+../../../src/cli/bin/Release/net6.0/AxeWindowsCLI.exe --UndefinedParameter
 ValidateExitCode $lastExitCode $BadInputParameters
 PromptAndWait "The scenario should have identified 'UndefinedParameter' as an unknown `nparameter, shown the help text, and thrown no exceptions"
 
 Clear
-../../../src/cli/bin/Release/netcoreapp3.1/AxeWindowsCLI.exe --ProcessName
+../../../src/cli/bin/Release/net6.0/AxeWindowsCLI.exe --ProcessName
 ValidateExitCode $lastExitCode $BadInputParameters
 PromptAndWait "The scenario should have indicated that the user needs to specify either `nprocessId or processName, and thrown no exceptions"
 
 Clear
-../../../src/cli/bin/Release/netcoreapp3.1/AxeWindowsCLI.exe --ProcessName ThisProcessDoesNotExist
+../../../src/cli/bin/Release/net6.0/AxeWindowsCLI.exe --ProcessName ThisProcessDoesNotExist
 ValidateExitCode $lastExitCode $BadInputParameters
 PromptAndWait "The scenario should have indicated that it could not find a process named `nThisProcessDoesNotExist, and thrown no exceptions"
 
 Clear
-../../../src/cli/bin/Release/netcoreapp3.1/AxeWindowsCLI.exe --showthirdpartynotices
+../../../src/cli/bin/Release/net6.0/AxeWindowsCLI.exe --showthirdpartynotices
 ValidateExitCode $lastExitCode $ThirdPartyNoticesDisplayed
 PromptAndWait "The scenario should have opened the placeholder ThirdPartyNotices.html file `nin the default browser, and thrown no exceptions."
 


### PR DESCRIPTION
#### Details

When #833 changed the CLI to target .NET 6.0, it changed the path of the locally-built CLI, which (in turn) broke the validation script. This just fixes the validation script and makes the displayed instructions a little bit clearer.

##### Motivation

Validation scripts should work

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
