### PR TITLE
chore: Add localization testing tool to tools directory

### DIFF
--- a/tools/LocTestingSampleApp/LocTestingSampleApp.csproj
+++ b/tools/LocTestingSampleApp/LocTestingSampleApp.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <RootNamespace>axe_win_testing</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Axe.Windows" Version="2.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/tools/LocTestingSampleApp/LocTestingSampleApp.csproj
+++ b/tools/LocTestingSampleApp/LocTestingSampleApp.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Axe.Windows" Version="2.0.0" />
+    <PackageReference Include="Axe.Windows" Version="2.1.0" />
   </ItemGroup>
 
 </Project>

--- a/tools/LocTestingSampleApp/LocTestingSampleApp.csproj
+++ b/tools/LocTestingSampleApp/LocTestingSampleApp.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>AxeWinLocTesting</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Platform>AnyCPU</Platform>
+    <Platforms>AnyCPU;x86</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/LocTestingSampleApp/LocTestingSampleApp.csproj
+++ b/tools/LocTestingSampleApp/LocTestingSampleApp.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>AxeWinLocTesting</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Platform>AnyCPU</Platform>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/LocTestingSampleApp/LocTestingSampleApp.csproj
+++ b/tools/LocTestingSampleApp/LocTestingSampleApp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <RootNamespace>axe_win_testing</RootNamespace>
+    <RootNamespace>AxeWinLocTesting</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tools/LocTestingSampleApp/LocTestingSampleApp.sln
+++ b/tools/LocTestingSampleApp/LocTestingSampleApp.sln
@@ -8,13 +8,19 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{25DD1F10-F135-49CC-829D-A264AB98D5E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{25DD1F10-F135-49CC-829D-A264AB98D5E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25DD1F10-F135-49CC-829D-A264AB98D5E2}.Debug|x86.ActiveCfg = Debug|x86
+		{25DD1F10-F135-49CC-829D-A264AB98D5E2}.Debug|x86.Build.0 = Debug|x86
 		{25DD1F10-F135-49CC-829D-A264AB98D5E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{25DD1F10-F135-49CC-829D-A264AB98D5E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25DD1F10-F135-49CC-829D-A264AB98D5E2}.Release|x86.ActiveCfg = Release|x86
+		{25DD1F10-F135-49CC-829D-A264AB98D5E2}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tools/LocTestingSampleApp/LocTestingSampleApp.sln
+++ b/tools/LocTestingSampleApp/LocTestingSampleApp.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.31826.467
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LocTestingSampleApp", "LocTestingSampleApp.csproj", "{25DD1F10-F135-49CC-829D-A264AB98D5E2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{25DD1F10-F135-49CC-829D-A264AB98D5E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25DD1F10-F135-49CC-829D-A264AB98D5E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25DD1F10-F135-49CC-829D-A264AB98D5E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25DD1F10-F135-49CC-829D-A264AB98D5E2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F8865011-B112-40E5-AC9E-8C5F2A59BCEC}
+	EndGlobalSection
+EndGlobal

--- a/tools/LocTestingSampleApp/Program.cs
+++ b/tools/LocTestingSampleApp/Program.cs
@@ -22,9 +22,6 @@ namespace AxeWinLocTesting
         // descriptions/ text) and content that should not be localized (ex: property/field names).
         private static bool showFullResults = false;
 
-        // Wait time to allow process to start up before beginning scan.
-        private static int processStartupWaitTime = 1000;
-
         static void Main(string[] _)
         {
             var process = StartTestExe();

--- a/tools/LocTestingSampleApp/Program.cs
+++ b/tools/LocTestingSampleApp/Program.cs
@@ -47,15 +47,15 @@ namespace AxeWinLocTesting
         private static Process StartTestExe()
         {
             var process = Process.Start(exePath);
-            Thread.Sleep(processStartupWaitTime);
+            process.WaitForInputIdle();
             return process;
         }
 
         private static IScanner CreateScanner(int processId)
         {
             Console.WriteLine("Creating scanner...");
-            var configBuilder = Config.Builder.ForProcessId(processId);
-            configBuilder.WithOutputFileFormat(OutputFileFormat.None);
+            var configBuilder = Config.Builder.ForProcessId(processId)
+                .WithOutputFileFormat(OutputFileFormat.None);
             var config = configBuilder.Build();
             var scanner = ScannerFactory.CreateScanner(config);
             return scanner;

--- a/tools/LocTestingSampleApp/Program.cs
+++ b/tools/LocTestingSampleApp/Program.cs
@@ -1,0 +1,91 @@
+﻿using Axe.Windows.Automation;
+using Axe.Windows.Automation.Data;
+using Newtonsoft.Json;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace AxeWinLocTesting
+{
+    internal class Program
+    {
+        // Change this code to experiment with differnet languages, for example "es", "it", "ja", "ko".
+        private static string langCode = "fr";
+
+        // Change this path to experiment with different test apps.
+        private static string exePath = "../WildlifeManager/WildlifeManager.exe";
+
+        // True will show full JSON scan results, false will just show a short example. The long output can
+        // be very long and confusing, since it serializes both content that should be localized (ex: rule
+        // descriptions/ text) and content that should not be localized (ex: property/field names).
+        private static bool showFullResults = false;
+
+        // Wait time to allow process to start up before beginning scan.
+        private static int processStartupWaitTime = 1000;
+
+        static void Main(string[] _)
+        {
+            var process = StartTestExe();
+            Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture(langCode);
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.CreateSpecificCulture(langCode);
+            try
+            {
+                var scanner = CreateScanner(process.Id);
+
+                var scanResults = GetScanResults(scanner);
+
+                PrintScanResults(scanResults, showFullResults);
+            }
+            finally
+            {
+                process.Kill();
+            }
+        }
+
+        private static Process StartTestExe()
+        {
+            var process = Process.Start(exePath);
+            Thread.Sleep(processStartupWaitTime);
+            return process;
+        }
+
+        private static IScanner CreateScanner(int processId)
+        {
+            Console.WriteLine("Creating scanner...");
+            var configBuilder = Config.Builder.ForProcessId(processId);
+            configBuilder.WithOutputFileFormat(OutputFileFormat.None);
+            var config = configBuilder.Build();
+            var scanner = ScannerFactory.CreateScanner(config);
+            return scanner;
+        }
+
+        private static ScanOutput GetScanResults(IScanner scanner)
+        {
+            Console.WriteLine("Scanning...");
+            var scanResults = scanner.Scan(null);
+            return scanResults;
+        }
+
+        private static void PrintScanResults(ScanOutput scanResults, bool fullContent)
+        {
+            Console.WriteLine("Scan results:");
+            Console.WriteLine();
+            Console.WriteLine("===========================================");
+            if (fullContent)
+            {
+                Console.WriteLine(JsonConvert.SerializeObject(scanResults, Formatting.Indented));
+            }
+            else
+            {
+                foreach (var scanResult in scanResults.WindowScanOutputs)
+                {
+                    foreach (var error in scanResult.Errors)
+                    {
+                        Console.WriteLine(error.Rule.Description);
+                    }
+                }
+            }
+            Console.WriteLine("===========================================");
+            Console.WriteLine();
+        }
+    }
+}

--- a/tools/LocTestingSampleApp/Program.cs
+++ b/tools/LocTestingSampleApp/Program.cs
@@ -1,4 +1,7 @@
-﻿using Axe.Windows.Automation;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Automation;
 using Axe.Windows.Automation.Data;
 using Newtonsoft.Json;
 using System.Diagnostics;

--- a/tools/LocTestingSampleApp/README.md
+++ b/tools/LocTestingSampleApp/README.md
@@ -1,0 +1,40 @@
+# Localization Testing Sample App
+
+This is a test app used to test axe-windows localization. It starts up a sample app to test (by default, the WildLifeManager app in `../WildlifeManager/WildlifeManager.exe`), creates a scanner, scans the app, and prints localized results to the console. 
+
+## How to run
+
+You can run this app from the command line via `dotnet run`. If testing a released version of the `axe-windows` nuget package, this project can be run with no changes. If you want to run this app against an unreleased version of the axe-windows package, you can do so as follows:
+
+1. Create a `packages` directory within `LocTestingSampleApp` and place the package (`.nupkg`) inside it.
+
+2. Update the package reference in `LocTestingSampleApp.csproj` to the proper version of the package (i.e. replace `2.1.0` in `<PackageReference Include="Axe.Windows" Version="2.1.0" />`).
+
+3. Create a `nuget.config` to point nuget to the newly created `packages` directory and pick up the local copy of the package. See example `nuget.config` content below:
+```
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+    <clear />
+    <add key="LocalPackages" value=".\packages" />
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+    <disabledPackageSources />
+</configuration>
+```
+
+## Customizations
+
+By default, this project tests against the `WildlifeManager` sample app, sets the language to french, and shows only a subset of results. These defaults can all be changed by editing the following fields in Program.cs:
+
+### langCode
+
+This string determines the language that the scan results will be in. For versions 2.1.0 and higher, the axe-windows package supports the following language codes: `cs`, `de`, `es`, `fr`, `it`, `ja`, `ko`, `pl`, `pl-BR`, `ru`, `tr`, `zh-Hans`, and `zh-Hant`.
+
+### exePath
+
+This string is a path to any `.exe` file to run a scan against.
+
+### showFullResults
+
+This boolean determines what format the results will be printed to the console in. When this is `true`, the full results will be printed in the `JSON` format, however these results can be quite long and confusing, since they include both items that are localized and items that are intentionally not localized (such as field/property names). When this is `false` the app will only print a subset of the results, all of which should be localized according to the language provided via `langCode`. This setting is ideal for spot testing localization.


### PR DESCRIPTION
#### Details

Adds a test app that can be used to test axe-windows localization to the tools directory. See the README for details on usage.

##### Motivation

Keep all tools related to axe-windows in one place

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
