### PR TITLE
chore: Fix gaps in WxsValidationTests

### DIFF
--- a/src/CLI_Installer/Product.wxs
+++ b/src/CLI_Installer/Product.wxs
@@ -34,7 +34,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <Feature Id="ProductFeature" Title="Axe.Windows CLI" Level="1">
       <ComponentGroupRef Id="ProductComponents" />
-      <ComponentGroupRef Id="Net60Components" />
+      <ComponentGroupRef Id="Net60ComponentGroup" />
     </Feature>
 
     <Condition Message="[ProductName] requires .NET Core Runtime 3.1 or newer. Please visit https://dotnet.microsoft.com/download/dotnet-core">
@@ -82,8 +82,8 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="Net60Components" Directory="Net60Folder">
-      <Component Id="NetCoreApp20Component" Guid="5002A1F9-EB89-441C-B757-8E214EFE82CF">
+    <ComponentGroup Id="Net60ComponentGroup" Directory="Net60Folder">
+      <Component Id="Net60Components" Guid="5002A1F9-EB89-441C-B757-8E214EFE82CF">
         <File Source="..\CLI\bin\Release\net6.0\runtimes\win\lib\net6.0\Microsoft.Win32.SystemEvents.dll" Id="net60_systemevents" />
         <File Source="..\CLI\bin\Release\net6.0\runtimes\win\lib\net6.0\System.Drawing.Common.dll" Id="net60_systemdrawing" />
       </Component>


### PR DESCRIPTION
#### Details

This is the analog to [AIWin 1483](https://github.com/microsoft/accessibility-insights-windows/pull/1483). 

This fixes some issues with the MSI checker:
1. Due to a logic error, files were returned _only_ if a set of excluded files was provided. This empty set was not caught as a problem. These have both been fixed.
2. We weren't passing the correct component names in 1, so we were returning empty sets of files. This empty set was also not caught as a problem. This has been fixed.
3. As written, the checker assumed that everything in a component comes from the same build folder, which is OK in this project. For consistency with AIWIn, though, we ignore the source path of the file and validate the _set_ of files in the folder.

There was also 1 place in the WXS file where we were using a component name that was originally derived from a deprecated version of .NET Core. This component and its containing group have been renamed for clarity. This has absolutely no impact on the files included in the MSI package. Happy to move that to a different PR if desired.

##### Motivation

Make test detect errors (which is why it's there)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
It might also make sense to rename `ProductComponents` to `ProductComponentGroup` in the WXS file. It's easy to change this at any time if we so desire.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
