### PR TITLE
chore: Ignore launchSettings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+launchSettings.json
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs


### PR DESCRIPTION
#### Details

Current versions of VS store user-specific settings in `launchSettings.json`. This file shouldn't be in the repo, so adding it to the `.gitignore` file seems appropriate.

##### Motivation

Enable local debugging without risk of contaminating the repo with these files.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
