### PR TITLE
chore: add automation ids to failing controls in wildlife test app

### DIFF
--- a/tools/WildlifeManager/src/WildlifeManager/MainWindow.xaml
+++ b/tools/WildlifeManager/src/WildlifeManager/MainWindow.xaml
@@ -27,20 +27,20 @@
             <RowDefinition Height="*"/>
             <RowDefinition/>
         </Grid.RowDefinitions>
-        <ListView Margin="10,10,66,56" Grid.Row="4" Grid.Column="2" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-            <ListViewItem Content="Beetle" Width="200" HorizontalAlignment="Left"/>
-            <ListViewItem Content="Owl" Width="200" HorizontalAlignment="Left"/>
-            <ListViewItem Content="Mouse" Width="200" HorizontalAlignment="Left"/>
+        <ListView Margin="10,10,66,56" Grid.Row="4" Grid.Column="2" ScrollViewer.HorizontalScrollBarVisibility="Disabled" AutomationProperties.AutomationId="SpeciesListView">
+            <ListViewItem Content="Beetle" Width="200" HorizontalAlignment="Left" AutomationProperties.AutomationId="BettleListItem"/>
+            <ListViewItem Content="Owl" Width="200" HorizontalAlignment="Left" AutomationProperties.AutomationId="OwlListItem"/>
+            <ListViewItem Content="Mouse" Width="200" HorizontalAlignment="Left" AutomationProperties.AutomationId="MouseListItem"/>
         </ListView>
-        <DataGrid AutomationProperties.Name="Current Animals datagrid" Width="215" HorizontalAlignment="Left" Margin="66,10,0,26" Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2">
+        <DataGrid AutomationProperties.Name="Current Animals datagrid" Width="215" HorizontalAlignment="Left" Margin="66,10,0,26" Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" AutomationProperties.AutomationId="CurrentAnimalsDataGrid">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Species" />
                 <DataGridTextColumn Header="Weight" />
             </DataGrid.Columns>
         </DataGrid>
-        <TextBox Margin="10,11,66,18" Grid.Row="5" Grid.Column="2" />
+        <TextBox Margin="10,11,66,18" Grid.Row="5" Grid.Column="2"  AutomationProperties.AutomationId="WeightTextBox"/>
         <UserControl HorizontalAlignment="Left" HorizontalContentAlignment="Center" FontWeight="SemiBold" VerticalContentAlignment="Center" Width="349" Background="gray" Foreground="navy" Content="Add New Animal" MouseLeftButtonDown="UserControl_MouseLeftButtonDown" Margin="0,33,0,10" Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2" />
-        <Menu Margin="81,10,83,99" Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="2">
+        <Menu Margin="81,10,83,99" Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="2" AutomationProperties.AutomationId="FlagsMenu">
             <MenuItem Header="Flags">
                 <MenuItem Header="_Endangered" IsChecked="True" />
                 <MenuItem Header="_Fun"/>
@@ -50,7 +50,7 @@
         <TextBlock TextWrapping="Wrap" Margin="10,26,123,10" Text="Current Animals:" Grid.Row="1" Grid.Column="2"/>
         <TextBlock VerticalAlignment="Center" Margin="52,11,0,68" Height="24" Text="Weight:" Grid.Row="5" Grid.Column="1"/>
         <TextBlock TextWrapping="Wrap" Margin="50,10,0,110" Text="Species:" RenderTransformOrigin="0.379,0.838" Grid.Row="4" Grid.Column="1"/>
-        <local:InvokeToggleButton Width="71" Foreground="#0070FF" AutomationProperties.Name="Ok" Background="LightBlue" HorizontalAlignment="Left" Margin="78,27,0,28.667" Grid.Row="7" Content="Ok">
+        <local:InvokeToggleButton Width="71" Foreground="#0070FF" AutomationProperties.Name="Ok" Background="LightBlue" HorizontalAlignment="Left" Margin="78,27,0,28.667"  AutomationProperties.AutomationId="OkToggleButton" Grid.Row="7" Content="Ok">
             <Button.Template>
                 <ControlTemplate TargetType="{x:Type Button}">
                     <Border x:Name="bdr_main" BorderBrush="Black" Background="LightBlue" BorderThickness="1">
@@ -67,7 +67,7 @@
                 </ControlTemplate>
             </Button.Template>
         </local:InvokeToggleButton>
-        <local:InvokeToggleButton Width="71" AutomationProperties.Name="Ok" Foreground="#0070FF" Background="LightBlue" HorizontalAlignment="Left" Margin="26,29,0,26.667" Grid.Row="7" Grid.Column="1" Content="Close" Click="InvokeToggleButton_Click">
+        <local:InvokeToggleButton Width="71" AutomationProperties.Name="Ok" Foreground="#0070FF" Background="LightBlue" HorizontalAlignment="Left" Margin="26,29,0,26.667" AutomationProperties.AutomationId="CloseToggleButton" Grid.Row="7" Grid.Column="1" Content="Close" Click="InvokeToggleButton_Click">
             <Button.Template>
                 <ControlTemplate TargetType="{x:Type Button}">
                     <Border x:Name="bdr_main" BorderBrush="Black" Background="LightBlue" BorderThickness="1">
@@ -84,13 +84,13 @@
                 </ControlTemplate>
             </Button.Template>
         </local:InvokeToggleButton>
-        <Button HorizontalAlignment="Left" Width="77" Margin="108.667,28,0,26.667" Grid.Row="7" Grid.Column="2">
+        <Button HorizontalAlignment="Left" Width="77" Margin="108.667,28,0,26.667" Grid.Row="7" Grid.Column="2" AutomationProperties.AutomationId="GlyphButton">
             <Glyphs VerticalAlignment="Center"
                         UnicodeString="&#x263A;"
                         Fill="#004000"
                         FontRenderingEmSize="32"
                         FontUri="C:\Windows\Fonts\Arial.ttf" RenderTransformOrigin="2.442,0.578" />
         </Button>
-        <local:CustomControl Width="71" HorizontalAlignment="Left" Margin="38.667,27,0,28.667" Grid.Row="7" Grid.Column="3" Focusable="True" />
+        <local:CustomControl Width="71" HorizontalAlignment="Left" Margin="38.667,27,0,28.667" Grid.Row="7" Grid.Column="3" Focusable="True" AutomationProperties.AutomationId="HelpControl" />
     </Grid>
 </Window>


### PR DESCRIPTION
#### Details

Prior to this change none of the controls in the wildlife test app had automation IDs. This doesn't really matter since it's just a test app, but it means the automation ID column in the VS accessibility checker is not populated when testing this app. This is a simple improvement to make the wildlife test app better to demo with. 

##### Motivation

Improve demo app

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
