### PR TITLE
feat(chrome-scans): Add mechanism for excluding elements from scans

### DIFF
--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -26,8 +26,7 @@ namespace Axe.Windows.AutomationTests
         const int WindowsFormsControlSamplerKnownErrorCount = 6;
         const int WpfControlSamplerKnownErrorCount = 7;
         const int WindowsFormsMultiWindowSamplerAppAllErrorCount = 12;
-        // Note: This will be reduced to 1 when we add logic to ignore all but the top level chrome element
-        const int WebViewSampleKnownErrorCount = 35;
+        const int WebViewSampleKnownErrorCount = 1;
 
         readonly string _wildlifeManagerAppPath = Path.GetFullPath("../../../../../tools/WildlifeManager/WildlifeManager.exe");
         readonly string _win32ControlSamplerAppPath = Path.GetFullPath("../../../../../tools/Win32ControlSampler/Win32ControlSampler.exe");

--- a/src/Core/Bases/A11yElement.cs
+++ b/src/Core/Bases/A11yElement.cs
@@ -328,7 +328,7 @@ namespace Axe.Windows.Core.Bases
         /// the framework on which the application is based: WPF, UWP, etc
         /// </summary>
         [JsonIgnore]
-        public string Framework
+        public virtual string Framework
         {
             get
             {

--- a/src/DesktopTests/UIAutomation/TreeWalkers/TreeWalkerForTestTests.cs
+++ b/src/DesktopTests/UIAutomation/TreeWalkers/TreeWalkerForTestTests.cs
@@ -44,7 +44,7 @@ namespace Axe.Windows.DesktopTests.UIAutomation.TreeWalkers
         public void RefreshTreeData_RunsAllRules()
         {
             _elementMock.Setup(e => e.Framework).Returns(FrameworkId.WPF);
-            var dataContext = new DesktopDataContext(Registrar.GetDefaultInstance(), A11yAutomation.GetDefaultInstance(), CancellationToken.None);
+            var dataContext = DesktopDataContext.DefaultContext;
             _treeWalker.RefreshTreeData(TreeViewMode.Raw, dataContext);
             var scanResults = _elementMock.Object.ScanResults;
             Assert.AreEqual(2, scanResults.Items.Count);
@@ -57,7 +57,7 @@ namespace Axe.Windows.DesktopTests.UIAutomation.TreeWalkers
         public void RefreshTreeData_ExcludesElementsWhenTheyViolateExclusionRules()
         {
             _elementMock.Setup(e => e.Framework).Returns(FrameworkId.Chrome);
-            var dataContext = new DesktopDataContext(Registrar.GetDefaultInstance(), A11yAutomation.GetDefaultInstance(), CancellationToken.None);
+            var dataContext = DesktopDataContext.DefaultContext;
             _treeWalker.RefreshTreeData(TreeViewMode.Raw, dataContext);
             var scanResults = _elementMock.Object.ScanResults;
             Assert.AreEqual(1, scanResults.Items.Count);

--- a/src/DesktopTests/UIAutomation/TreeWalkers/TreeWalkerForTestTests.cs
+++ b/src/DesktopTests/UIAutomation/TreeWalkers/TreeWalkerForTestTests.cs
@@ -10,6 +10,7 @@ using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
+using System.Linq;
 using System.Threading;
 
 namespace Axe.Windows.DesktopTests.UIAutomation.TreeWalkers
@@ -31,13 +32,38 @@ namespace Axe.Windows.DesktopTests.UIAutomation.TreeWalkers
         }
 
         [TestMethod]
-        [Timeout(1000)]
         public void RefreshTreeData_ThrowsWhenCancelled()
         {
             var cancellationToken = new CancellationTokenSource();
             cancellationToken.Cancel();
             var dataContext = new DesktopDataContext(Registrar.GetDefaultInstance(), A11yAutomation.GetDefaultInstance(), cancellationToken.Token);
             Assert.ThrowsException<OperationCanceledException>(() => _treeWalker.RefreshTreeData(TreeViewMode.Raw, dataContext));
+        }
+
+        [TestMethod]
+        public void RefreshTreeData_RunsAllRules()
+        {
+            _elementMock.Setup(e => e.Framework).Returns(FrameworkId.WPF);
+            var dataContext = new DesktopDataContext(Registrar.GetDefaultInstance(), A11yAutomation.GetDefaultInstance(), CancellationToken.None);
+            _treeWalker.RefreshTreeData(TreeViewMode.Raw, dataContext);
+            var scanResults = _elementMock.Object.ScanResults;
+            Assert.AreEqual(2, scanResults.Items.Count);
+            var exclusionRule = scanResults.Items.Where(i => i.Items.FirstOrDefault().Rule.Equals(RuleId.ChromiumComponentsShouldUseWebScanner));
+            Assert.AreEqual(1, exclusionRule.Count());
+            Assert.AreEqual(Core.Results.ScanStatus.Pass, exclusionRule.FirstOrDefault().Status);
+        }
+
+        [TestMethod]
+        public void RefreshTreeData_ExcludesElementsWhenTheyViolateExclusionRules()
+        {
+            _elementMock.Setup(e => e.Framework).Returns(FrameworkId.Chrome);
+            var dataContext = new DesktopDataContext(Registrar.GetDefaultInstance(), A11yAutomation.GetDefaultInstance(), CancellationToken.None);
+            _treeWalker.RefreshTreeData(TreeViewMode.Raw, dataContext);
+            var scanResults = _elementMock.Object.ScanResults;
+            Assert.AreEqual(1, scanResults.Items.Count);
+            var exclusionRule = scanResults.Items.Where(i => i.Items.FirstOrDefault().Rule.Equals(RuleId.ChromiumComponentsShouldUseWebScanner));
+            Assert.AreEqual(1, exclusionRule.Count());
+            Assert.AreEqual(Core.Results.ScanStatus.Fail, exclusionRule.FirstOrDefault().Status);
         }
     }
 }

--- a/src/RuleSelectionTests/RuleRunnerTests.cs
+++ b/src/RuleSelectionTests/RuleRunnerTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.RuleSelection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Linq;
+using System.Threading;
+
+namespace Axe.Windows.RuleSelectionTests
+{
+    [TestClass]
+    public class RuleRunnerTests
+    {
+        [TestMethod]
+        public void ExcludeFromRun_WhenExcludeRulesPass_ReturnsFalse()
+        {
+            var mockElement = new Mock<A11yElement>(MockBehavior.Strict);
+            mockElement.Setup(e => e.Framework).Returns(FrameworkId.WPF);
+            var exclude = RuleRunner.ExcludeFromRun(mockElement.Object, CancellationToken.None);
+            Assert.IsFalse(exclude);
+            var scanResults = mockElement.Object.ScanResults;
+            Assert.AreEqual(1, scanResults.Items.Count);
+            var chromeRuleResult = scanResults.Items.Where(i => i.Items.FirstOrDefault().Rule.Equals(RuleId.ChromiumComponentsShouldUseWebScanner));
+            Assert.AreEqual(1, chromeRuleResult.Count());
+            Assert.AreEqual(Core.Results.ScanStatus.Pass, chromeRuleResult.FirstOrDefault().Status);
+        }
+
+        [TestMethod]
+        public void ExcludeFromRun_WhenExcludeRulesFail_ReturnsTrue()
+        {
+            var mockElement = new Mock<A11yElement>(MockBehavior.Strict);
+            mockElement.Setup(e => e.Framework).Returns(FrameworkId.Chrome);
+            var exclude = RuleRunner.ExcludeFromRun(mockElement.Object, CancellationToken.None);
+            Assert.IsTrue(exclude);
+            var scanResults = mockElement.Object.ScanResults;
+            Assert.AreEqual(1, scanResults.Items.Count);
+            var chromeRuleResult = scanResults.Items.Where(i => i.Items.FirstOrDefault().Rule.Equals(RuleId.ChromiumComponentsShouldUseWebScanner));
+            Assert.AreEqual(1, chromeRuleResult.Count());
+            Assert.AreEqual(Core.Results.ScanStatus.Fail, chromeRuleResult.FirstOrDefault().Status);
+        }
+    } // class
+} // namespace

--- a/src/RuleSelectionTests/RuleSelectionTests.csproj
+++ b/src/RuleSelectionTests/RuleSelectionTests.csproj
@@ -12,6 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="coverlet.collector" Version="3.2.0">

--- a/src/Rules/Library/ChromiumComponentsShouldUseWebScanner.cs
+++ b/src/Rules/Library/ChromiumComponentsShouldUseWebScanner.cs
@@ -11,7 +11,7 @@ namespace Axe.Windows.Rules.Library
     [RuleInfo(ID = RuleId.ChromiumComponentsShouldUseWebScanner)]
     class ChromiumComponentsShouldUseWebScanner : Rule
     {
-        public override bool Exclusionary => true;
+        public override bool IsExclusionRule => true;
 
         public ChromiumComponentsShouldUseWebScanner()
         {

--- a/src/Rules/Library/ChromiumComponentsShouldUseWebScanner.cs
+++ b/src/Rules/Library/ChromiumComponentsShouldUseWebScanner.cs
@@ -11,6 +11,8 @@ namespace Axe.Windows.Rules.Library
     [RuleInfo(ID = RuleId.ChromiumComponentsShouldUseWebScanner)]
     class ChromiumComponentsShouldUseWebScanner : Rule
     {
+        public override bool Exclusionary => true;
+
         public ChromiumComponentsShouldUseWebScanner()
         {
             Info.Description = Descriptions.ChromiumComponentsShouldUseWebScanner;
@@ -26,6 +28,12 @@ namespace Axe.Windows.Rules.Library
         protected override Condition CreateCondition()
         {
             return Chrome;
+        }
+
+        public override bool IncludeInResults(IA11yElement element)
+        {
+            // Only include a failure for the top level element
+            return element.Parent == null || !element.Parent.Framework.Equals(FrameworkId.Chrome);
         }
     } // class
 } // namespace

--- a/src/Rules/Rule.cs
+++ b/src/Rules/Rule.cs
@@ -15,14 +15,14 @@ namespace Axe.Windows.Rules
         bool PassesTest(IA11yElement element);
         bool IncludeInResults(IA11yElement element);
         // True if this rule failing should cause the element to be excluded from the rest of the scan.
-        bool Exclusionary { get; }
+        bool IsExclusionRule { get; }
     }
 
     abstract class Rule : IRule
     {
         public RuleInfo Info { get; private set; }
         public Condition Condition { get; }
-        public virtual bool Exclusionary => false;
+        public virtual bool IsExclusionRule => false;
 
         protected Rule()
         {

--- a/src/Rules/Rule.cs
+++ b/src/Rules/Rule.cs
@@ -13,12 +13,16 @@ namespace Axe.Windows.Rules
         RuleInfo Info { get; }
         Condition Condition { get; }
         bool PassesTest(IA11yElement element);
+        bool IncludeInResults(IA11yElement element);
+        // True if this rule failing should cause the element to be excluded from the rest of the scan.
+        bool Exclusionary { get; }
     }
 
     abstract class Rule : IRule
     {
         public RuleInfo Info { get; private set; }
         public Condition Condition { get; }
+        public virtual bool Exclusionary => false;
 
         protected Rule()
         {
@@ -56,5 +60,10 @@ namespace Axe.Windows.Rules
         public abstract bool PassesTest(IA11yElement element);
 
         protected abstract Condition CreateCondition();
+
+        public virtual bool IncludeInResults(IA11yElement element)
+        {
+            return true;
+        }
     }
 } // namespace

--- a/src/Rules/RuleProvider.cs
+++ b/src/Rules/RuleProvider.cs
@@ -13,7 +13,7 @@ namespace Axe.Windows.Rules
         IRule GetRule(RuleId id);
         IEnumerable<IRule> All { get; }
         IEnumerable<IRule> ExclusionRules { get; }
-        IEnumerable<IRule> IncludedRules { get; }
+        IEnumerable<IRule> InclusionRules { get; }
     }
 
     /// <summary>
@@ -26,7 +26,7 @@ namespace Axe.Windows.Rules
         // Rules that, if violated, cause an element to be excluded from the scan.
         private readonly ConcurrentDictionary<RuleId, IRule> _exclusionRules = new ConcurrentDictionary<RuleId, IRule>();
         // Rules that are not exclusionary.
-        private readonly ConcurrentDictionary<RuleId, IRule> _includedRules = new ConcurrentDictionary<RuleId, IRule>();
+        private readonly ConcurrentDictionary<RuleId, IRule> _inclusionRules = new ConcurrentDictionary<RuleId, IRule>();
         private readonly object _allRulesLock = new object();
         private bool _areAllRulesInitialized;
 
@@ -53,13 +53,13 @@ namespace Axe.Windows.Rules
                     if (!_allRules.ContainsKey(k))
                     {
                         var rule = _ruleFactory.CreateRule(k);
-                        if (rule.Exclusionary)
+                        if (rule.IsExclusionRule)
                         {
                             _exclusionRules.TryAdd(k, rule);
                         }
                         else
                         {
-                            _includedRules.TryAdd(k, rule);
+                            _inclusionRules.TryAdd(k, rule);
                         }
                         _allRules.TryAdd(k, rule);
                     }
@@ -94,13 +94,13 @@ namespace Axe.Windows.Rules
             }
         }
 
-        public IEnumerable<IRule> IncludedRules
+        public IEnumerable<IRule> InclusionRules
         {
             get
             {
                 InitAllRules();
 
-                return _includedRules.Values;
+                return _inclusionRules.Values;
             }
         }
     } // class

--- a/src/Rules/RuleRunner.cs
+++ b/src/Rules/RuleRunner.cs
@@ -54,11 +54,11 @@ namespace Axe.Windows.Rules
             return results;
         }
 
-        public IEnumerable<RunResult> RunAll(IA11yElement element, CancellationToken cancellationToken)
+        public IEnumerable<RunResult> RunInclusionRules(IA11yElement element, CancellationToken cancellationToken)
         {
             var results = new List<RunResult>();
 
-            foreach (var rule in _provider.IncludedRules)
+            foreach (var rule in _provider.InclusionRules)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var result = RunRule(rule, element);

--- a/src/Rules/RuleRunner.cs
+++ b/src/Rules/RuleRunner.cs
@@ -8,6 +8,7 @@ using Axe.Windows.Rules.Resources;
 using Axe.Windows.Telemetry;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 namespace Axe.Windows.Rules
@@ -39,11 +40,25 @@ namespace Axe.Windows.Rules
             return retVal;
         }
 
+        public IEnumerable<RunResult> RunExclusionRules(IA11yElement element, CancellationToken cancellationToken)
+        {
+            var results = new List<RunResult>();
+
+            foreach (var rule in _provider.ExclusionRules)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var result = RunRule(rule, element);
+                results.Add(result);
+            } // for all rules
+
+            return results;
+        }
+
         public IEnumerable<RunResult> RunAll(IA11yElement element, CancellationToken cancellationToken)
         {
             var results = new List<RunResult>();
 
-            foreach (var rule in _provider.All)
+            foreach (var rule in _provider.IncludedRules)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var result = RunRule(rule, element);
@@ -90,6 +105,7 @@ namespace Axe.Windows.Rules
                 return result;
 
             result.EvaluationCode = rule.PassesTest(element) ? EvaluationCode.Pass : rule.Info.ErrorCode;
+            result.IncludeInResults = rule.IncludeInResults(element);
 
             return result;
         }

--- a/src/Rules/Rules.cs
+++ b/src/Rules/Rules.cs
@@ -48,13 +48,13 @@ namespace Axe.Windows.Rules
         }
 
         /// <summary>
-        /// Run all the rules in the Rules assembly.
+        /// Run all the inclusion rules in the Rules assembly.
         /// </summary>
         /// <param name="element"></param>
         /// <returns></returns>
-        public static IEnumerable<RunResult> RunAll(IA11yElement element, CancellationToken cancellationToken)
+        public static IEnumerable<RunResult> RunInclusionRules(IA11yElement element, CancellationToken cancellationToken)
         {
-            return Runner.RunAll(element, cancellationToken);
+            return Runner.RunInclusionRules(element, cancellationToken);
         }
 
         /// <summary>

--- a/src/Rules/Rules.cs
+++ b/src/Rules/Rules.cs
@@ -56,5 +56,15 @@ namespace Axe.Windows.Rules
         {
             return Runner.RunAll(element, cancellationToken);
         }
+
+        /// <summary>
+        /// Run all the exclusionary rules in the Rules assembly.
+        /// </summary>
+        /// <param name="element"></param>
+        /// <returns></returns>
+        public static IEnumerable<RunResult> RunExclusionRules(IA11yElement element, CancellationToken cancellationToken)
+        {
+            return Runner.RunExclusionRules(element, cancellationToken);
+        }
     } // class
 } // namespace

--- a/src/Rules/RunResult.cs
+++ b/src/Rules/RunResult.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Core.Bases;
@@ -31,5 +31,10 @@ namespace Axe.Windows.Rules
         /// Otherwise, it should be null.
         /// </summary>
         public string ErrorMessage { get; set; }
+
+        /// <summary>
+        /// True if this result should be included in user facing results.
+        /// </summary>
+        public bool IncludeInResults { get; set; } = true;
     } // class
 } // namespace

--- a/src/RulesTest/Library/ChromiumComponentsShouldUseWebScannerTests.cs
+++ b/src/RulesTest/Library/ChromiumComponentsShouldUseWebScannerTests.cs
@@ -27,7 +27,7 @@ namespace Axe.Windows.RulesTests.Library
         [TestMethod]
         public void Exclusionary_ReturnsTrue()
         {
-            Assert.IsTrue(Rule.Exclusionary);
+            Assert.IsTrue(Rule.IsExclusionRule);
         }
 
         [TestMethod]

--- a/src/RulesTest/MonsterTest.cs
+++ b/src/RulesTest/MonsterTest.cs
@@ -209,7 +209,7 @@ namespace Axe.Windows.RulesTests
 
         private static Dictionary<RuleId, EvaluationCode> GetTestResultsAsDictionary(A11yElement e)
         {
-            var results = Axe.Windows.Rules.Rules.RunAll(e, CancellationToken.None);
+            var results = Axe.Windows.Rules.Rules.RunInclusionRules(e, CancellationToken.None);
             return results.ToDictionary(r => r.RuleInfo.ID, r => r.EvaluationCode);
         }
 

--- a/src/RulesTest/Rule.test.cs
+++ b/src/RulesTest/Rule.test.cs
@@ -29,7 +29,7 @@ namespace Axe.Windows.RulesTests
         [TestMethod]
         public void RulesAreNotExclusionaryByDefault()
         {
-            Assert.IsFalse(ConcreteRule.Exclusionary);
+            Assert.IsFalse(ConcreteRule.IsExclusionRule);
         }
 
         [TestMethod]

--- a/src/RulesTest/Rule.test.cs
+++ b/src/RulesTest/Rule.test.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Rules;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Axe.Windows.RulesTests
+{
+    [RuleInfo]
+    internal class ConcreteRule : Rules.Rule
+    {
+        public override bool PassesTest(IA11yElement element)
+        {
+            return true;
+        }
+
+        protected override Condition CreateCondition()
+        {
+            return Condition.True;
+        }
+    }
+
+    [TestClass]
+    public class Rule
+    {
+        private static readonly Rules.IRule ConcreteRule = new ConcreteRule();
+
+        [TestMethod]
+        public void RulesAreNotExclusionaryByDefault()
+        {
+            Assert.IsFalse(ConcreteRule.Exclusionary);
+        }
+
+        [TestMethod]
+        public void RulesAreIncludedInResultsByDefault()
+        {
+            Assert.IsTrue(ConcreteRule.IncludeInResults(null));
+        }
+    } // class
+} // namespace

--- a/src/RulesTest/RuleRunnerTests.cs
+++ b/src/RulesTest/RuleRunnerTests.cs
@@ -324,10 +324,10 @@ namespace Axe.Windows.RulesTests
             var rules = from m in ruleMocks select (m.Object);
 
             var providerMock = new Mock<IRuleProvider>(MockBehavior.Strict);
-            providerMock.Setup(m => m.IncludedRules).Returns(() => rules).Verifiable();
+            providerMock.Setup(m => m.InclusionRules).Returns(() => rules).Verifiable();
 
             var runner = new RuleRunner(providerMock.Object);
-            var results = runner.RunAll(e, CancellationToken.None);
+            var results = runner.RunInclusionRules(e, CancellationToken.None);
 
             Assert.AreEqual(codes.Count(), results.Count());
 
@@ -354,12 +354,12 @@ namespace Axe.Windows.RulesTests
             var e = new MockA11yElement();
             var ruleMock = new Mock<IRule>(MockBehavior.Strict);
             var providerMock = new Mock<IRuleProvider>(MockBehavior.Strict);
-            providerMock.Setup(m => m.IncludedRules).Returns(() => new IRule[] { ruleMock.Object }).Verifiable();
+            providerMock.Setup(m => m.InclusionRules).Returns(() => new IRule[] { ruleMock.Object }).Verifiable();
 
             var runner = new RuleRunner(providerMock.Object);
             var cancellationToken = new CancellationTokenSource();
             cancellationToken.Cancel();
-            Assert.ThrowsException<OperationCanceledException>(() => runner.RunAll(e, cancellationToken.Token));
+            Assert.ThrowsException<OperationCanceledException>(() => runner.RunInclusionRules(e, cancellationToken.Token));
         }
 
         [TestMethod]

--- a/src/RulesTest/RulesProviderTests.cs
+++ b/src/RulesTest/RulesProviderTests.cs
@@ -21,9 +21,9 @@ namespace Axe.Windows.RulesTests
         public void BeforeEach()
         {
             _exclusionRuleMock = new Mock<IRule>(MockBehavior.Strict);
-            _exclusionRuleMock.Setup(r => r.Exclusionary).Returns(true);
+            _exclusionRuleMock.Setup(r => r.IsExclusionRule).Returns(true);
             _includedRuleMock = new Mock<IRule>(MockBehavior.Strict);
-            _includedRuleMock.Setup(r => r.Exclusionary).Returns(false);
+            _includedRuleMock.Setup(r => r.IsExclusionRule).Returns(false);
             _factoryMock = new Mock<IRuleFactory>(MockBehavior.Strict);
             _factoryMock.Setup(o => o.CreateRule(It.IsAny<RuleId>())).Returns(_includedRuleMock.Object);
             _factoryMock.Setup(o => o.CreateRule(RuleId.NameNotNull)).Returns(_exclusionRuleMock.Object);
@@ -64,7 +64,7 @@ namespace Axe.Windows.RulesTests
         public void InclusionRulesContainsOnlyInclusionRules()
         {
             var provider = new RuleProvider(_factoryMock.Object);
-            var actualIncludedRules = provider.IncludedRules;
+            var actualIncludedRules = provider.InclusionRules;
             Assert.AreEqual(provider.All.Count() - 1, actualIncludedRules.Count());
             Assert.AreEqual(_includedRuleMock.Object, actualIncludedRules.FirstOrDefault());
         }
@@ -74,10 +74,10 @@ namespace Axe.Windows.RulesTests
         {
             var provider = new RuleProvider(_factoryMock.Object);
             var actualAllRules = provider.All;
-            var excludedResult = actualAllRules.Where(r => r.Exclusionary);
+            var excludedResult = actualAllRules.Where(r => r.IsExclusionRule);
             Assert.AreEqual(1, excludedResult.Count());
             Assert.AreEqual(_exclusionRuleMock.Object, excludedResult.FirstOrDefault());
-            var includedResult = actualAllRules.Where(r => !r.Exclusionary);
+            var includedResult = actualAllRules.Where(r => !r.IsExclusionRule);
             Assert.AreEqual(actualAllRules.Count() - 1, includedResult.Count());
             Assert.AreEqual(_includedRuleMock.Object, includedResult.FirstOrDefault());
         }

--- a/src/RulesTest/RulesProviderTests.cs
+++ b/src/RulesTest/RulesProviderTests.cs
@@ -1,45 +1,85 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using System.Data;
+using System.Linq;
 
 namespace Axe.Windows.RulesTests
 {
     [TestClass]
     public class RulesProviderTests
     {
+        private Mock<IRule> _exclusionRuleMock;
+        private Mock<IRule> _includedRuleMock;
+        private Mock<IRuleFactory> _factoryMock;
+
+        [TestInitialize]
+        public void BeforeEach()
+        {
+            _exclusionRuleMock = new Mock<IRule>(MockBehavior.Strict);
+            _exclusionRuleMock.Setup(r => r.Exclusionary).Returns(true);
+            _includedRuleMock = new Mock<IRule>(MockBehavior.Strict);
+            _includedRuleMock.Setup(r => r.Exclusionary).Returns(false);
+            _factoryMock = new Mock<IRuleFactory>(MockBehavior.Strict);
+            _factoryMock.Setup(o => o.CreateRule(It.IsAny<RuleId>())).Returns(_includedRuleMock.Object);
+            _factoryMock.Setup(o => o.CreateRule(RuleId.NameNotNull)).Returns(_exclusionRuleMock.Object);
+        }
+
         [TestMethod]
         public void RulesAreCreatedOnlyOnce()
         {
-            var rule = new Mock<IRule>(MockBehavior.Strict);
-            var factory = new Mock<IRuleFactory>(MockBehavior.Strict);
-            factory.Setup(o => o.CreateRule(RuleId.NameNotNull)).Returns(rule.Object);
-            var provider = new RuleProvider(factory.Object);
-
+            var provider = new RuleProvider(_factoryMock.Object);
             for (int i = 0; i < 5; ++i)
             {
                 provider.GetRule(RuleId.NameNotNull);
-                factory.Verify(o => o.CreateRule(RuleId.NameNotNull), Times.Once());
+                _factoryMock.Verify(o => o.CreateRule(RuleId.NameNotNull), Times.Once());
             }
         }
 
         [TestMethod]
         public void RulesAreCreatedOnlyOnceForAll()
         {
-            var rule = new Mock<IRule>(MockBehavior.Strict);
-            var factory = new Mock<IRuleFactory>(MockBehavior.Strict);
-            factory.Setup(o => o.CreateRule(It.IsAny<RuleId>())).Returns(rule.Object);
-            factory.Setup(o => o.CreateRule(RuleId.NameNotNull)).Returns(rule.Object);
-            var provider = new RuleProvider(factory.Object);
-
+            var provider = new RuleProvider(_factoryMock.Object);
             for (int i = 0; i < 5; ++i)
             {
                 provider.All.GetEnumerator();
-                factory.Verify(o => o.CreateRule(RuleId.NameNotNull), Times.Once());
+                _factoryMock.Verify(o => o.CreateRule(RuleId.NameNotNull), Times.Once());
             }
+        }
+
+        [TestMethod]
+        public void ExclusionRulesContainsOnlyExclusionRules()
+        {
+            var provider = new RuleProvider(_factoryMock.Object);
+            var actualExclusionRules = provider.ExclusionRules;
+            Assert.AreEqual(1, actualExclusionRules.Count());
+            Assert.AreEqual(_exclusionRuleMock.Object, actualExclusionRules.FirstOrDefault());
+        }
+
+        [TestMethod]
+        public void InclusionRulesContainsOnlyInclusionRules()
+        {
+            var provider = new RuleProvider(_factoryMock.Object);
+            var actualIncludedRules = provider.IncludedRules;
+            Assert.AreEqual(provider.All.Count() - 1, actualIncludedRules.Count());
+            Assert.AreEqual(_includedRuleMock.Object, actualIncludedRules.FirstOrDefault());
+        }
+
+        [TestMethod]
+        public void AllRulesContainsExclusionAndInclusionRules()
+        {
+            var provider = new RuleProvider(_factoryMock.Object);
+            var actualAllRules = provider.All;
+            var excludedResult = actualAllRules.Where(r => r.Exclusionary);
+            Assert.AreEqual(1, excludedResult.Count());
+            Assert.AreEqual(_exclusionRuleMock.Object, excludedResult.FirstOrDefault());
+            var includedResult = actualAllRules.Where(r => !r.Exclusionary);
+            Assert.AreEqual(actualAllRules.Count() - 1, includedResult.Count());
+            Assert.AreEqual(_includedRuleMock.Object, includedResult.FirstOrDefault());
         }
     } // class
 } // namespace


### PR DESCRIPTION
#### Details

This PR is 2/2 of addressing https://github.com/microsoft/axe-windows/issues/836. https://github.com/microsoft/axe-windows/pull/871 added the `ChromiumComponentsShouldUseWebScanner` rule and this PR adds logic to exclude elements that fail this rule from further scanning. It also includes logic to ensure that only the top level chrome element reports a `ChromiumComponentsShouldUseWebScanner` rule violation. 

##### Motivation

Addresses issue #836

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #836