### PR TITLE
Fix: Clarify "how to fix" guidance for NameIsInformative rule violations

### DIFF
--- a/src/Rules/Resources/HowToFix.Designer.cs
+++ b/src/Rules/Resources/HowToFix.Designer.cs
@@ -865,9 +865,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Examine the UI Automation Name property of this element:
-        /// · If the Name property contains a class name (of the form Microsoft.*.* or Windows.*.*) that provides no meaningful information to end-users, update the Name to a concise, user-facing label.
-        /// · If the Name property contains &quot;Microsoft&quot; or &quot;Windows&quot; in user-facing content, such as a reference to microsoft.com in on-screen text, you may safely ignore this issue..
+        ///   Looks up a localized string similar to · If the Name property is not closely related to the on-screen text (and provides no meaningful information to end-users), update the Name to a concise, user-facing label that is closely related to the on-screen text..
         /// </summary>
         internal static string NameIsInformative {
             get {

--- a/src/Rules/Resources/HowToFix.Designer.cs
+++ b/src/Rules/Resources/HowToFix.Designer.cs
@@ -865,7 +865,9 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to · If the Name property is not closely related to the on-screen text (and provides no meaningful information to end-users), update the Name to a concise, user-facing label that is closely related to the on-screen text..
+        ///   Looks up a localized string similar to Examine the UI Automation Name property of this element:
+        /// · If the Name property contains &quot;Microsoft&quot; or &quot;Windows&quot; and is closely related to the on-screen text (for example, a reference to &quot;Microsoft.com&quot;), you may safely ignore this issue.
+        /// · If the Name property is not closely related to the on-screen text (and provides no meaningful information to end-users), update the Name to a concise, user-facing label that is closely related to the on-screen text..
         /// </summary>
         internal static string NameIsInformative {
             get {

--- a/src/Rules/Resources/HowToFix.Designer.cs
+++ b/src/Rules/Resources/HowToFix.Designer.cs
@@ -885,8 +885,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a UI Automation Name property that concisely identifies the element.
-        ///.
+        ///   Looks up a localized string similar to Provide a UI Automation Name property that concisely identifies the element..
         /// </summary>
         internal static string NameNotEmpty {
             get {

--- a/src/Rules/Resources/HowToFix.Designer.cs
+++ b/src/Rules/Resources/HowToFix.Designer.cs
@@ -865,9 +865,9 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a UI Automation Name property for the element that:
-        /// · Concisely identifies the element, AND
-        /// · Does not include the element&apos;s class name (such as Microsoft.*.* or Windows.*.*)..
+        ///   Looks up a localized string similar to Examine the UI Automation Name property of this element:
+        /// · If the Name property contains a class name (of the form Microsoft.*.* or Windows.*.*) that provides no meaningful information to end-users, update the Name to a concise, user-facing label.
+        /// · If the Name property contains &quot;Microsoft&quot; or &quot;Windows&quot; in user-facing content, such as a reference to microsoft.com in on-screen text, you may safely ignore this issue..
         /// </summary>
         internal static string NameIsInformative {
             get {
@@ -885,7 +885,8 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a UI Automation Name property that concisely identifies the element..
+        ///   Looks up a localized string similar to Provide a UI Automation Name property that concisely identifies the element.
+        ///.
         /// </summary>
         internal static string NameNotEmpty {
             get {

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -587,8 +587,7 @@ If your application targets a version of .NET Framework before 4.7.1, but is run
     <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">
-    <value>Provide a UI Automation Name property that concisely identifies the element.
-</value>
+    <value>Provide a UI Automation Name property that concisely identifies the element.</value>
     <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotNull" xml:space="preserve">

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -581,13 +581,14 @@ If your application targets a version of .NET Framework before 4.7.1, but is run
     <comment>Brief guidance on how to fix an accessibility problem. The terms "name" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="NameIsInformative" xml:space="preserve">
-    <value>Provide a UI Automation Name property for the element that:
- · Concisely identifies the element, AND
- · Does not include the element's class name (such as Microsoft.*.* or Windows.*.*).</value>
+    <value>Examine the UI Automation Name property of this element:
+ · If the Name property contains a class name (of the form Microsoft.*.* or Windows.*.*) that provides no meaningful information to end-users, update the Name to a concise, user-facing label.
+ · If the Name property contains "Microsoft" or "Windows" in user-facing content, such as a reference to microsoft.com in on-screen text, you may safely ignore this issue.</value>
     <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">
-    <value>Provide a UI Automation Name property that concisely identifies the element.</value>
+    <value>Provide a UI Automation Name property that concisely identifies the element.
+</value>
     <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotNull" xml:space="preserve">

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -582,8 +582,8 @@ If your application targets a version of .NET Framework before 4.7.1, but is run
   </data>
   <data name="NameIsInformative" xml:space="preserve">
     <value>Examine the UI Automation Name property of this element:
- · If the Name property contains a class name (of the form Microsoft.*.* or Windows.*.*) that provides no meaningful information to end-users, update the Name to a concise, user-facing label.
- · If the Name property contains "Microsoft" or "Windows" in user-facing content, such as a reference to microsoft.com in on-screen text, you may safely ignore this issue.</value>
+ · If the Name property contains "Microsoft" or "Windows" and is closely related to the on-screen text (for example, a reference to "Microsoft.com"), you may safely ignore this issue.</value>
+ · If the Name property is not closely related to the on-screen text (and provides no meaningful information to end-users), update the Name to a concise, user-facing label that is closely related to the on-screen text.
     <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -581,9 +581,7 @@ If your application targets a version of .NET Framework before 4.7.1, but is run
     <comment>Brief guidance on how to fix an accessibility problem. The terms "name" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="NameIsInformative" xml:space="preserve">
-    <value>Examine the UI Automation Name property of this element:
- · If the Name property contains "Microsoft" or "Windows" and is closely related to the on-screen text (for example, a reference to "Microsoft.com"), you may safely ignore this issue.</value>
- · If the Name property is not closely related to the on-screen text (and provides no meaningful information to end-users), update the Name to a concise, user-facing label that is closely related to the on-screen text.
+    <value>· If the Name property is not closely related to the on-screen text (and provides no meaningful information to end-users), update the Name to a concise, user-facing label that is closely related to the on-screen text.</value>
     <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -581,7 +581,9 @@ If your application targets a version of .NET Framework before 4.7.1, but is run
     <comment>Brief guidance on how to fix an accessibility problem. The terms "name" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords).</comment>
   </data>
   <data name="NameIsInformative" xml:space="preserve">
-    <value>· If the Name property is not closely related to the on-screen text (and provides no meaningful information to end-users), update the Name to a concise, user-facing label that is closely related to the on-screen text.</value>
+    <value>Examine the UI Automation Name property of this element:
+ · If the Name property contains "Microsoft" or "Windows" and is closely related to the on-screen text (for example, a reference to "Microsoft.com"), you may safely ignore this issue.
+ · If the Name property is not closely related to the on-screen text (and provides no meaningful information to end-users), update the Name to a concise, user-facing label that is closely related to the on-screen text.</value>
     <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">


### PR DESCRIPTION
#### Details
This PR adds additional guidance for when the `NameIsInformative` rule can be ignored safely.

##### Motivation
Related to #874.

##### Context


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: This PR should not close #874.