### PR TITLE
fix: Simplify NameIsInformative and whitelist common top-level domains

### DIFF
--- a/src/Rules/Library/NameIsInformative.cs
+++ b/src/Rules/Library/NameIsInformative.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Core.Bases;
@@ -26,19 +26,11 @@ namespace Axe.Windows.Rules.Library
 
         public override bool PassesTest(IA11yElement e)
         {
-            string[] stringsToExclude =
-            {
-                @"^\s*Microsoft(\.(\w|\d)+)+\s*$",
-                @"^\s*Windows(\.(\w|\d)+)+\s*$"
-            };
+            string failExpr = @"^\s*(Microsoft|Windows)(\.(\w|\d)+)+\s*$";
 
-            foreach (var s in stringsToExclude)
-            {
-                if (Regex.IsMatch(e.Name, s, RegexOptions.IgnoreCase))
-                    return false;
-            }
+            string passExpr = @".+\.com|org|net|info$";
 
-            return true;
+            return !Regex.IsMatch(e.Name, failExpr, RegexOptions.IgnoreCase) || Regex.IsMatch(e.Name, passExpr);
         }
 
         protected override Condition CreateCondition()


### PR DESCRIPTION
#### Details
This PR combines the `Microsoft.*.*` and `Windows.*.*` regexes into one expression, as they're fairly similar, and adds an additional check to pass elements whose names end in common TLDs (i.e. `microsoft.com` no longer throws an error).

##### Context
The check remains imperfect, as many of these violations don't start with `Microsoft` or `Windows` at all: for instance, this rule would not be able to detect microsoft/accessibility-insights-windows#1438.

Maybe we should change the regex to look for names with, say, at least three or four dots (and not specifically look for `Microsoft` or `Windows` at all)?

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
