### PR TITLE
fix: Exclude Group and Text controls from NameIsInformative due to high false-positive rate

### DIFF
--- a/src/Rules/Library/NameIsInformative.cs
+++ b/src/Rules/Library/NameIsInformative.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Core.Bases;
@@ -7,6 +7,7 @@ using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using System.Text.RegularExpressions;
+using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Framework;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
@@ -45,6 +46,8 @@ namespace Axe.Windows.Rules.Library
         {
             return Name.NotNullOrEmpty & Name.NotWhiteSpace & BoundingRectangle.Valid
                 & ~Win32Framework
+                & ~PropertyConditions.ControlType.Group
+                & ~Text
                 & (ElementGroups.NameRequired | ElementGroups.NameOptional);
         }
     } // class

--- a/src/RulesTest/Library/NameIsInformativeTests.cs
+++ b/src/RulesTest/Library/NameIsInformativeTests.cs
@@ -1,7 +1,8 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UIAutomationClient;
 
 namespace Axe.Windows.RulesTests.Library
 {
@@ -104,11 +105,33 @@ namespace Axe.Windows.RulesTests.Library
         }
 
         [TestMethod]
-        public void FrameworkWind32_DoesNotMatch()
+        public void FrameworkWin32_DoesNotMatch()
         {
             var e = CreateMatchingElement();
             e.Framework = Core.Enums.FrameworkId.Win32;
             Assert.IsFalse(Rule.Condition.Matches(e));
+        }
+
+        [TestMethod]
+        public void GroupControlType_DoesNotMatch()
+        {
+            TestExcludedControlType(ControlType.Group);
+        }
+
+        [TestMethod]
+        public void TextControlType_DoesNotMatch()
+        {
+            TestExcludedControlType(ControlType.Text);
+        }
+
+        private void TestExcludedControlType(int controlType)
+        {
+            using (var e = new MockA11yElement())
+            {
+                e.ControlTypeId = controlType;
+                e.Name = "Microsoft.Windows.Some.Class.Name.Abc";
+                Assert.IsFalse(Rule.Condition.Matches(e));
+            }
         }
     } // class
 } // namespace

--- a/src/RulesTest/MonsterTest.cs
+++ b/src/RulesTest/MonsterTest.cs
@@ -201,7 +201,6 @@ namespace Axe.Windows.RulesTests
                 { RuleId.LocalizedControlTypeReasonable, EvaluationCode.Pass },
                 { RuleId.NameEmptyButElementNotKeyboardFocusable, EvaluationCode.Pass },
                 { RuleId.NameExcludesPrivateUnicodeCharacters, EvaluationCode.Pass },
-                { RuleId.NameIsInformative, EvaluationCode.Pass },
                 { RuleId.NameNotWhiteSpace, EvaluationCode.Pass },
                 { RuleId.NameNullButElementNotKeyboardFocusable, EvaluationCode.Pass },
             });


### PR DESCRIPTION
#### Details
This PR excludes the `Group` and `Text` UIA control types from the `NameIsInformative` rule in an attempt to reduce false positives.

##### Context
Re #874.

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
