### PR TITLE
fix: Temporary workaround to unblock build

### DIFF
--- a/src/RulesMD/RulesMD.csproj
+++ b/src/RulesMD/RulesMD.csproj
@@ -6,6 +6,8 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <!-- Keep the next element all on one line: -->
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <!-- Remove this line and the next line after moving to Roslyn V3 and build version set to 17.0 -->
+    <VSToolsPath>$(VSToolsPath)\..\v17.0</VSToolsPath>
     <TransformOnBuild>true</TransformOnBuild>
     <BeforeTransform>CustomPreTransform</BeforeTransform>
   </PropertyGroup>


### PR DESCRIPTION
#### Details

Our build pipeline recently broke in the Roslyn analyzers phase. Upon investigation, the problem was that the `RulesMD` project uses `$(VisualStudioVersion)`, which gets redefined from 16.0 to 17.0 when the Roslyn analyzer task is run. Future versions of the Roslyn analyzer task will support 17.0, but the objective here is to unblock the pipeline. Once we move to the updated Roslyn analyzer, this PR should be backed out.

Validation run of this change can be found [here](https://mseng.visualstudio.com/1ES/_build/results?buildId=19493022&view=logs&j=efe68385-d402-5492-a2cf-bc47ec32e784&t=e38751e8-0dc8-5e3c-8d46-e18c39d37211&l=3911). I canceled the build after the Roslyn step completed, since Roslyn was the only thing we were fixing.

##### Motivation

We need to be able to ship

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
This change applies locally, meaning that the RulesMD project can only be built with VS2022. That shouldn't be a problem, since that's already our documented supported compiler version.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
