### PR TITLE
chore: Apply/suppress new analyzer suggestions

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -137,8 +137,12 @@ csharp_style_deconstructed_variable_declaration = false
 csharp_prefer_simple_default_expression = false
 csharp_style_pattern_local_over_anonymous_function = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
-csharp_prefer_simple_using_statement = false:silent
 csharp_style_prefer_local_over_anonymous_function = false
+
+# Rules that require C# version above 7.3 (our limit of .NET Standard 2.0 & .NET Framework)
+csharp_prefer_simple_using_statement = false:error
+csharp_style_implicit_object_creation_when_type_is_apparent = false:error
+csharp_style_prefer_range_operator = false:error
 ###############################
 # C# Formatting Rules         #
 ###############################

--- a/src/Actions/Trackers/TreeTracker.cs
+++ b/src/Actions/Trackers/TreeTracker.cs
@@ -123,8 +123,7 @@ namespace Axe.Windows.Actions.Trackers
         /// <param name="getElementMethod"></param>
         private void MoveToWithoutLock(GetElementDelegate getElementMethod)
         {
-            var element = GetNearbyElement(getElementMethod);
-            if (element == null) throw new TreeNavigationFailedException();
+            var element = GetNearbyElement(getElementMethod) ?? throw new TreeNavigationFailedException();
 
 #pragma warning disable CA2000 // Call IDisposable.Dispose()
             var desktopElement = new DesktopElement(element, true, false);

--- a/src/ActionsTests/Actions/ScreenShotActionTests.cs
+++ b/src/ActionsTests/Actions/ScreenShotActionTests.cs
@@ -18,7 +18,7 @@ namespace Axe.Windows.ActionsTests.Actions
     {
         // This sets the Bounding Rectangle. It breaks encapsulation in
         // many reproachable ways
-        private void SetBoundingRectangle(A11yElement element, Rectangle b)
+        private static void SetBoundingRectangle(A11yElement element, Rectangle b)
         {
             int typeId = PropertyType.UIA_BoundingRectanglePropertyId;
             double[] data = { b.Left, b.Top, b.Right - b.Left, b.Bottom - b.Top };

--- a/src/ActionsTests/Contexts/ScopedActionContextTests.cs
+++ b/src/ActionsTests/Contexts/ScopedActionContextTests.cs
@@ -98,7 +98,7 @@ namespace Axe.Windows.ActionsTests.Contexts
             }
         }
 
-        private void AssertAreDifferentObjectsOfType<T>(object object1, object object2)
+        private static void AssertAreDifferentObjectsOfType<T>(object object1, object object2)
         {
             Assert.IsInstanceOfType(object1, typeof(T));
             Assert.IsInstanceOfType(object2, typeof(T));

--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -295,7 +295,7 @@ namespace Axe.Windows.AutomationTests
             return output.First();
         }
 
-        private void ValidateTaskCancelled(Task<ScanOutput> task)
+        private static void ValidateTaskCancelled(Task<ScanOutput> task)
         {
             var exception = Assert.ThrowsException<AggregateException>(() => task.Result);
             Assert.AreEqual(typeof(TaskCanceledException), exception.InnerException.GetType());

--- a/src/AutomationTests/SnapshotCommandTests.cs
+++ b/src/AutomationTests/SnapshotCommandTests.cs
@@ -63,7 +63,7 @@ namespace Axe.Windows.AutomationTests
                 .Returns(() => tempOutput);
         }
 
-        private IReadOnlyList<A11yElement> CreateMockElementArray()
+        private static IReadOnlyList<A11yElement> CreateMockElementArray()
         {
             var elements = new List<A11yElement>();
 

--- a/src/CLITests/OptionsEvaluatorTests.cs
+++ b/src/CLITests/OptionsEvaluatorTests.cs
@@ -29,7 +29,7 @@ namespace AxeWindowsCLITests
             _processHelperMock.VerifyAll();
         }
 
-        private void ValidateOptions(IOptions options, string processName = TestProcessName,
+        private static void ValidateOptions(IOptions options, string processName = TestProcessName,
             int processId = TestProcessId, string outputDirectory = null, string scanId = null,
             VerbosityLevel verbosityLevel = VerbosityLevel.Default, int delayInSeconds = 0)
         {

--- a/src/CLITests/OptionsTests.cs
+++ b/src/CLITests/OptionsTests.cs
@@ -32,7 +32,7 @@ namespace AxeWindowsCLITests
             return UnexpectedFailure;
         }
 
-        private int ValidateOptions(Options options, string processName = null,
+        private static int ValidateOptions(Options options, string processName = null,
             int processId = 0, string outputDirectory = null, string scanId = null,
             string verbosity = null, bool showThirdPartyNotices = false,
             int delayInSeconds = 0, string customUia = null)

--- a/src/CLITests/OutputGeneratorTests.cs
+++ b/src/CLITests/OutputGeneratorTests.cs
@@ -235,7 +235,7 @@ namespace AxeWindowsCLITests
             VerifyAllMocks();
         }
 
-        private IReadOnlyDictionary<string, string> BuildTestProperties(int? propertyCount)
+        private static IReadOnlyDictionary<string, string> BuildTestProperties(int? propertyCount)
         {
             if (!propertyCount.HasValue)
                 return null;
@@ -250,7 +250,7 @@ namespace AxeWindowsCLITests
             return properties;
         }
 
-        private IEnumerable<string> BuildTestPatterns(int? patternCount)
+        private static IEnumerable<string> BuildTestPatterns(int? patternCount)
         {
             if (!patternCount.HasValue)
                 return null;
@@ -265,7 +265,7 @@ namespace AxeWindowsCLITests
             return patterns;
         }
 
-        private WindowScanOutput BuildTestScanResults(int errorCount = 0, string a11yTestFile = null,
+        private static WindowScanOutput BuildTestScanResults(int errorCount = 0, string a11yTestFile = null,
             int? propertyCount = null, int? patternCount = null, string frameworkIssueLink = null)
         {
             List<ScanResult> errors = new List<ScanResult>(errorCount);

--- a/src/Core/Misc/ExtensionMethods.cs
+++ b/src/Core/Misc/ExtensionMethods.cs
@@ -480,9 +480,9 @@ namespace Axe.Windows.Core.Misc
         /// <returns></returns>
         public static A11yProperty ById(this Dictionary<int, A11yProperty> ps, int id)
         {
-            if (ps != null && ps.ContainsKey(id))
+            if (ps != null && ps.TryGetValue(id, out A11yProperty property))
             {
-                return ps[id];
+                return property;
             }
 
             return null;

--- a/src/Desktop/UIAutomation/EventHandlers/ActiveTextPositionChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/ActiveTextPositionChangedEventListener.cs
@@ -61,10 +61,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     if (IsHooked)
                     {
                         IUIAutomation6 uia6 = IUIAutomation6;
-                        if (uia6 != null)
-                        {
-                            uia6.RemoveActiveTextPositionChangedEventHandler(Element, this);
-                        }
+                        uia6?.RemoveActiveTextPositionChangedEventHandler(Element, this);
                     }
                 }
             }

--- a/src/Desktop/UIAutomation/EventHandlers/EventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventListener.cs
@@ -49,11 +49,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     if (IsHooked)
                     {
                         IUIAutomation uia = IUIAutomation;
-
-                        if (uia != null)
-                        {
-                            uia.RemoveAutomationEventHandler(EventId, Element, this);
-                        }
+                        uia?.RemoveAutomationEventHandler(EventId, Element, this);
                     }
                 }
             }

--- a/src/Desktop/UIAutomation/EventHandlers/EventListenerFactory.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/EventListenerFactory.cs
@@ -286,9 +286,8 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                         }
                         break;
                     default:
-                        if (EventListeners.ContainsKey(msgData.EventId))
+                        if (EventListeners.TryGetValue(msgData.EventId, out EventListener l))
                         {
-                            var l = EventListeners[msgData.EventId];
                             listener = l.ListenEventMessage;
                             EventListeners.Remove(msgData.EventId);
                             l.Dispose();

--- a/src/Desktop/UIAutomation/EventHandlers/NotificationEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/NotificationEventListener.cs
@@ -61,10 +61,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     if (IsHooked)
                     {
                         IUIAutomation5 uia5 = IUIAutomation5;
-                        if (uia5 != null)
-                        {
-                            uia5.RemoveNotificationEventHandler(Element, this);
-                        }
+                        uia5?.RemoveNotificationEventHandler(Element, this);
                     }
                 }
             }

--- a/src/Desktop/UIAutomation/EventHandlers/PropertyChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/PropertyChangedEventListener.cs
@@ -62,10 +62,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     if (IsHooked)
                     {
                         IUIAutomation uia = IUIAutomation;
-                        if (uia != null)
-                        {
-                            uia.RemovePropertyChangedEventHandler(Element, this);
-                        }
+                        uia?.RemovePropertyChangedEventHandler(Element, this);
                     }
                 }
             }

--- a/src/Desktop/UIAutomation/EventHandlers/StructureChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/StructureChangedEventListener.cs
@@ -54,10 +54,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     if (IsHooked)
                     {
                         IUIAutomation uia = IUIAutomation;
-                        if (uia != null)
-                        {
-                            uia.RemoveStructureChangedEventHandler(Element, this);
-                        }
+                        uia?.RemoveStructureChangedEventHandler(Element, this);
                     }
                 }
             }

--- a/src/Desktop/UIAutomation/EventHandlers/TextEditTextChangedEventListener.cs
+++ b/src/Desktop/UIAutomation/EventHandlers/TextEditTextChangedEventListener.cs
@@ -72,10 +72,7 @@ namespace Axe.Windows.Desktop.UIAutomation.EventHandlers
                     if (IsHooked)
                     {
                         IUIAutomation4 uia4 = IUIAutomation4;
-                        if (uia4 != null)
-                        {
-                            uia4.RemoveTextEditTextChangedEventHandler(Element, this);
-                        }
+                        uia4?.RemoveTextEditTextChangedEventHandler(Element, this);
                     }
                 }
             }

--- a/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
+++ b/src/DesktopTests/UIAutomation/CustomObjects/RegistrarTests.cs
@@ -42,7 +42,7 @@ namespace Axe.Windows.DesktopTests.UIAutomation.CustomObjects
             uiaRegistrarMock.VerifyAll();
         }
 
-        private CustomProperty CreateEmptyPropertyOfType(string type)
+        private static CustomProperty CreateEmptyPropertyOfType(string type)
         {
             CustomProperty prop = new CustomProperty
             {

--- a/src/Rules/RuleFactory.cs
+++ b/src/Rules/RuleFactory.cs
@@ -29,9 +29,7 @@ namespace Axe.Windows.Rules
             return ruleTypes.ToDictionary(t =>
             {
                 var info = (RuleInfo)t.GetCustomAttribute(typeof(RuleInfo));
-                if (info == null) throw new InvalidOperationException(ErrorMessages.RuleInfoAttributeExpected);
-
-                return info.ID;
+                return info == null ? throw new InvalidOperationException(ErrorMessages.RuleInfoAttributeExpected) : info.ID;
             });
         }
 

--- a/src/RulesTest/Library/NameIsInformativeTests.cs
+++ b/src/RulesTest/Library/NameIsInformativeTests.cs
@@ -124,7 +124,7 @@ namespace Axe.Windows.RulesTests.Library
             TestExcludedControlType(ControlType.Text);
         }
 
-        private void TestExcludedControlType(int controlType)
+        private static void TestExcludedControlType(int controlType)
         {
             using (var e = new MockA11yElement())
             {


### PR DESCRIPTION
#### Details

The latest version of Visual Studio analyzers are flagging some things that they didn't flag before. This PR represents a single pass through the project to update the appropriate fields. The commits are non-overlapping and it's possibly simplest to review on a per-commit basis.

##### Motivation

Make analyzer suggestions more obvious in the IDE and less dangerous (i.e., don't use suggestions that require C# versions that we aren't guaranteed to have).

##### Context

According to the C# language versioning [docs](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version), both .NET Standard 2.0 and .NET Framework default to C# 7.3, which is why we max out the suggestions there. The fields added to `.editorconfig` are based on the actual analyzer messages that occurred. I made no attempt to create an exhaustive list (potentially based on https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview?tabs=net-7), since it would quickly get out of date and it's easy to check new analyzer suggests as they occur.

The `.editorconfig` changes should probably also occur in AIWin, but that's far from urgent...

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
