### PR TITLE
chore: Prevent dependabot updates of pinned package versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,6 @@ updates:
     interval: daily
     time: "13:00"
   ignore:
-  - dependency-name: Axe.Windows
-    versions:
-    - "> 0.3.1-prerelease"
   - dependency-name: Microsoft.CodeAnalysis.BinSkim
     versions:
     - "> 1.7.0, < 1.8"
@@ -42,3 +39,16 @@ updates:
   - dependency-name: MSTest.TestAdapter
     versions:
     - 2.2.2
+
+- package-ecosystem: nuget
+  directory: "/src/CurrentFileVersionCompatibilityTests"
+  schedule:
+    interval: daily
+    time: "13:00"
+  ignore:
+  - dependency-name: Axe.Windows
+    versions:
+    - "> 0.3.1-prerelease"
+  - dependency-name: Newtonsoft.Json
+    versions:
+    - "> 9.0.1"


### PR DESCRIPTION
#### Details

The `CurrentFileVersionCompatibilityTests` project is intentionally pinned to old versions of `Axe.Windows` and `Newtonsoft.Json`. This is for testing only and not something that we ship. Dependabot knows to leave `Axe.Windows` alone, but we want updates to `Newtonsoft.Json` everywhere but in this project.

This PR creates a separate set of rules for the `CurrentFileVersionCompatibilityTests` project. This should work, based on the dependabot.yml [docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file), but we'll ultimately find out empirically.

##### Motivation

Reduce overhead from unwanted dependabot changes

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
