### PR TITLE
chore: Revert failed dependabot.yml experiment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     interval: daily
     time: "13:00"
   ignore:
+  - dependency-name: Axe.Windows
+    versions:
+    - "> 0.3.1-prerelease"
   - dependency-name: Microsoft.CodeAnalysis.BinSkim
     versions:
     - "> 1.7.0, < 1.8"
@@ -39,16 +42,3 @@ updates:
   - dependency-name: MSTest.TestAdapter
     versions:
     - 2.2.2
-
-- package-ecosystem: nuget
-  directory: "/src/CurrentFileVersionCompatibilityTests"
-  schedule:
-    interval: daily
-    time: "13:00"
-  ignore:
-  - dependency-name: Axe.Windows
-    versions:
-    - "> 0.3.1-prerelease"
-  - dependency-name: Newtonsoft.Json
-    versions:
-    - "> 9.0.1"


### PR DESCRIPTION
#### Details

#889 was an dependabot.yml experiment that failed. Its intent was to reduce dependabot noise in the `src/CurrentFileVersionCompatibilityTests` folder. It actually made things worse, as shown by dependabot change #891, which was a direct result of the change. I did a little more research and found https://github.com/dependabot/dependabot-core/issues/4364, which is an ongoing request to allow the same ecosystem to support different dependabot rules in different folders. It has lots of upvotes but it doesn't seem to be getting any traction.

This PR simply reverts the change from #889

##### Motivation

Minimize build noise

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
