### PR TITLE
chore: Run unit tests before running the Roslyn analyzer

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -104,6 +104,14 @@ jobs:
       platform: '$(BuildPlatform)'
       configuration: debug
 
+  - task: DotNetCoreCLI@2
+    displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
+    inputs:
+      arguments: --no-build --blame --verbosity normal --configuration debug
+      command: test
+      projects: |
+        **\*test*.csproj
+
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-autoapplicability.AutoApplicability@1
     displayName: 'Run AutoApplicability'
 
@@ -167,14 +175,6 @@ jobs:
       uploadModernCop: false
       uploadPREfast: false
       uploadTSLint: false
-
-  - task: DotNetCoreCLI@2
-    displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
-    inputs:
-      arguments: --no-build --blame --verbosity normal --configuration debug
-      command: test
-      projects: |
-        **\*test*.csproj
 
   - task: CopyFiles@2
     displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
#### Details

This is the Axe.Windows analog of https://github.com/microsoft/accessibility-insights-windows/pull/1569. We currently run the unit tests _after_ running the Roslyn analyzers. The problem is that Running the Roslyn analyzers rebuilds the solution, which could potentially create subtle differences between the tests that run locally and the tests that run in the ComplianceDebug pipeline job. This PR simply runs the unit tests immediately after building the solution so that we increase the consistency of the tests that we run.

##### Motivation

Make pipeline tests more like local tests

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
