### PR TITLE
chore: Update compliance tools to the next generation

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -123,7 +123,8 @@ jobs:
         userProvideBuildInfo: msBuildInfo
         msbuildVersion: 17.0
         msBuildArchitecture: '$(BuildPlatform)'
-        msBuildCommandline: 'set & echo . & echo csc -version & csc -version & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
+        setupCommandLine: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat"'
+        msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
         rulesetName: Recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -123,7 +123,7 @@ jobs:
         userProvideBuildInfo: msBuildInfo
         msbuildVersion: 17.0
         msBuildArchitecture: '$(BuildPlatform)'
-        setupCommandLine: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat"'
+        setupCommandLine: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat'
         msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
         rulesetName: Recommended
         internalAnalyzersVersion: Latest

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -124,7 +124,7 @@ jobs:
         userProvideBuildInfo: msBuildInfo
         msbuildVersion: 17.0
         msBuildArchitecture: '$(BuildPlatform)'
-        setupCommandLine: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat" && set'
+        setupCommandLine: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat" && set && echo . && echo Running csc -version && csc -version'
         msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
         rulesetName: Recommended
         internalAnalyzersVersion: Latest

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -118,6 +118,12 @@ jobs:
       targetType: F
     continueOnError: true
 
+  - task: UseDotNet@2
+    displayName: Use .NET 6.0 (for Roslyn)
+    inputs:
+      packageType: 'sdk'
+      version: '6.0.x'
+
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
     displayName: 'Run Roslyn analyzers'
     continueOnError: true
@@ -125,7 +131,7 @@ jobs:
         userProvideBuildInfo: msBuildInfo
         msbuildVersion: 17.0
         msBuildArchitecture: '$(BuildPlatform)'
-        setupCommandLine: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat" && set PATH="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Roslyn";%PATH% && set && echo . && echo Running csc -version && csc -version'
+        setupCommandLine: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat" && set'
         msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
         rulesetName: Recommended
         internalAnalyzersVersion: Latest

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -121,9 +121,9 @@ jobs:
     displayName: 'Run Roslyn analyzers'
     inputs:
         userProvideBuildInfo: msBuildInfo
-        msbuildVersion: 16.0
+        msbuildVersion: 17.0
         msBuildArchitecture: '$(BuildPlatform)'
-        msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="16.0"'
+        msBuildCommandline: 'set & echo . & echo csc -version & csc -version & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
         rulesetName: Recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -125,8 +125,8 @@ jobs:
         userProvideBuildInfo: msBuildInfo
         msbuildVersion: 17.0
         msBuildArchitecture: '$(BuildPlatform)'
-        setupCommandLine: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat" && set && echo . && echo Running csc -version && csc -version'
-        msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
+        setupCommandLine: '"$(VSINSTALLDIR)\Common7\Tools\VsMSBuildCmd.bat" && set PATH="$(VSINSTALLDIR)\MSBuild\Current\Bin\Roslyn";%PATH% && set && echo . && where csc.exe && echo . && echo Running csc -version && csc -version'
+        msBuildCommandline: '"$(VSINSTALLDIR)\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
         rulesetName: Recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -142,6 +142,8 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
     displayName: 'Post Analysis (CredScan, RoslynAnalyzers, and PoliCheck)'
+    inputs:
+      GdnBreakAllTools: false
 
   - task: PowerShell@2
     displayName: 'Create tsa.config file (CredScan, Roslyn, and PoliCheck)'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -153,7 +153,7 @@ jobs:
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
       arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAV2ProjectName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (CredScan, RoslynAnalyzers, and PoliCheck)'
     inputs:
       GdnPublishTsaOnboard: true

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -277,7 +277,7 @@ jobs:
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
       arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAV2ProjectName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "BinSkim" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (BinSkim)'
     inputs:
       GdnPublishTsaOnboard: true

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -119,15 +119,17 @@ jobs:
     continueOnError: true
 
   - task: UseDotNet@2
-    displayName: Use .NET 6.0 (for Roslyn)
+    displayName: (Roslyn pre-req) Use .NET 6.0
     inputs:
       packageType: 'sdk'
       version: '6.0.x'
 
-  - task: CmdLine@2
-    displayName: 'Partial dotnet restore (for Roslyn)'
+  - task: DotNetCoreCLI@2
+    displayName: '(Roslyn pre-req) Patial dotnet restore'
     inputs:
-      script: 'dotnet restore --runtime win7-x86 $(Build.SourcesDirectory)\src\CLI_Full\CLI_Full.csproj'
+      command: restore
+      projects: $(Build.SourcesDirectory)\src\CLI_Full\CLI_Full.csproj
+      arguments: '--runtime win7-x86'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
     displayName: 'Run Roslyn analyzers'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -137,7 +137,7 @@ jobs:
         userProvideBuildInfo: msBuildInfo
         msbuildVersion: 17.0
         msBuildArchitecture: '$(BuildPlatform)'
-        setupCommandLine: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat" && set'
+        setupCommandLine: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat"'
         msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
         rulesetName: Recommended
         internalAnalyzersVersion: Latest

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -123,7 +123,7 @@ jobs:
         userProvideBuildInfo: msBuildInfo
         msbuildVersion: 17.0
         msBuildArchitecture: '$(BuildPlatform)'
-        setupCommandLine: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat"'
+        setupCommandLine: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat" && set'
         msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
         rulesetName: Recommended
         internalAnalyzersVersion: Latest

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -121,9 +121,9 @@ jobs:
     displayName: 'Run Roslyn analyzers'
     inputs:
         userProvideBuildInfo: msBuildInfo
-        msbuildVersion: 17.0
+        msbuildVersion: 16.0
         msBuildArchitecture: '$(BuildPlatform)'
-        msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
+        msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="16.0"'
         rulesetName: Recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -137,7 +137,7 @@ jobs:
       RoslynAnalyzers: true
       PoliCheck: true
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
     displayName: 'Publish Security Analysis Logs (CredScan, RoslynAnalyzers, and PoliCheck)'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -125,8 +125,8 @@ jobs:
         userProvideBuildInfo: msBuildInfo
         msbuildVersion: 17.0
         msBuildArchitecture: '$(BuildPlatform)'
-        setupCommandLine: '"$(VSINSTALLDIR)\Common7\Tools\VsMSBuildCmd.bat" && set PATH="$(VSINSTALLDIR)\MSBuild\Current\Bin\Roslyn";%PATH% && set && echo . && where csc.exe && echo . && echo Running csc -version && csc -version'
-        msBuildCommandline: '"$(VSINSTALLDIR)\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
+        setupCommandLine: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat" && set PATH="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Roslyn";%PATH% && set && echo . && where csc.exe && echo . && echo Running csc -version && csc -version'
+        msBuildCommandline: 'msbuild.exe "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
         rulesetName: Recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -180,6 +180,12 @@ jobs:
     inputs:
       ArtifactName: 'Compliance'
 
+  - task: PowerShell@2
+    displayName: 'Intentionally fail the build job to save resources'
+    inputs:
+      targetType: "filePath"
+      filePath: tools\scripts\bad-path\bad-file.ps1
+      
 - job: SignedRelease
   dependsOn: 
   - ComplianceRelease

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -168,7 +168,7 @@ jobs:
     inputs:
       targetType: "filePath"
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAV2ProjectName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAV2ProjectName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;RoslynAnalyzers;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (CredScan, RoslynAnalyzers, and PoliCheck)'
@@ -195,12 +195,6 @@ jobs:
     displayName: 'Publish Artifact: Compliance'
     inputs:
       ArtifactName: 'Compliance'
-
-  - task: PowerShell@2
-    displayName: 'Intentionally fail the build job to save resources'
-    inputs:
-      targetType: "filePath"
-      filePath: tools\scripts\bad-path\bad-file.ps1
       
 - job: SignedRelease
   dependsOn: 

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -119,6 +119,7 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
     displayName: 'Run Roslyn analyzers'
+    condition: false
     inputs:
         userProvideBuildInfo: msBuildInfo
         msbuildVersion: 17.0
@@ -147,7 +148,7 @@ jobs:
     inputs:
       targetType: "filePath"
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAV2ProjectName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;RoslynAnalyzers;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAV2ProjectName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
     displayName: 'TSA upload (CredScan, RoslynAnalyzers, and PoliCheck)'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -119,7 +119,7 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
     displayName: 'Run Roslyn analyzers'
-    condition: false
+    continueOnError: true
     inputs:
         userProvideBuildInfo: msBuildInfo
         msbuildVersion: 17.0
@@ -142,6 +142,7 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
     displayName: 'Post Analysis (CredScan, RoslynAnalyzers, and PoliCheck)'
+    continueOnError: true
     inputs:
       GdnBreakAllTools: false
 

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -123,7 +123,7 @@ jobs:
         userProvideBuildInfo: msBuildInfo
         msbuildVersion: 17.0
         msBuildArchitecture: '$(BuildPlatform)'
-        setupCommandLine: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat'
+        setupCommandLine: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat"'
         msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
         rulesetName: Recommended
         internalAnalyzersVersion: Latest

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -140,7 +140,7 @@ jobs:
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
     displayName: 'Publish Security Analysis Logs (CredScan, RoslynAnalyzers, and PoliCheck)'
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
     displayName: 'Post Analysis (CredScan, RoslynAnalyzers, and PoliCheck)'
 
   - task: PowerShell@2

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -58,7 +58,6 @@ jobs:
 
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
-    condition: false
     inputs:
       arguments: --no-build --blame --verbosity normal --configuration release
       command: test
@@ -178,7 +177,6 @@ jobs:
 
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
-    condition: false
     inputs:
       arguments: --no-build --blame --verbosity normal --configuration debug
       command: test
@@ -284,7 +282,6 @@ jobs:
 
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
-    condition: false
     inputs:
       arguments: --no-build --blame --verbosity normal --configuration release --filter TestCategory!=Integration
       command: test

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -125,7 +125,7 @@ jobs:
         userProvideBuildInfo: msBuildInfo
         msbuildVersion: 17.0
         msBuildArchitecture: '$(BuildPlatform)'
-        setupCommandLine: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat" && set PATH="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Roslyn";%PATH% && set && echo . && where csc.exe && echo . && echo Running csc -version && csc -version'
+        setupCommandLine: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat" && set PATH="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Roslyn";%PATH% && set && echo . && echo Running csc -version && csc -version'
         msBuildCommandline: 'msbuild.exe "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
         rulesetName: Recommended
         internalAnalyzersVersion: Latest

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -58,6 +58,7 @@ jobs:
 
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
+    condition: false
     inputs:
       arguments: --no-build --blame --verbosity normal --configuration release
       command: test
@@ -161,6 +162,7 @@ jobs:
 
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
+    condition: false
     inputs:
       arguments: --no-build --blame --verbosity normal --configuration debug
       command: test
@@ -264,6 +266,7 @@ jobs:
 
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
+    condition: false
     inputs:
       arguments: --no-build --blame --verbosity normal --configuration release --filter TestCategory!=Integration
       command: test

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -146,6 +146,9 @@ jobs:
     continueOnError: true
     inputs:
       GdnBreakAllTools: false
+      GdnBreakGdnToolPoliCheck: false
+      GdnBreakGdnToolRoslynAnalyzers: false
+      GdnBreakGdnToolCredScan: true
 
   - task: PowerShell@2
     displayName: 'Create tsa.config file (CredScan, Roslyn, and PoliCheck)'
@@ -269,6 +272,8 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
     displayName: 'Post Analysis (BinSkim)'
+    inputs:
+      GdnBreakAllTools: true
 
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -124,7 +124,7 @@ jobs:
       version: '6.0.x'
 
   - task: DotNetCoreCLI@2
-    displayName: '(Roslyn pre-req) Patial dotnet restore'
+    displayName: '(Roslyn pre-req) Partial dotnet restore'
     inputs:
       command: restore
       projects: $(Build.SourcesDirectory)\src\CLI_Full\CLI_Full.csproj

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -104,34 +104,31 @@ jobs:
       platform: '$(BuildPlatform)'
       configuration: debug
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-autoapplicability.AutoApplicability@1
-    displayName: 'Run AutoApplicability'
-
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
     displayName: 'Run CredScan'
     inputs:
-      toolMajorVersion: V2
+      outputFormat: 'pre'
       verboseOutput: true
       debugMode: false
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@2
     displayName: 'Run PoliCheck'
     inputs:
       targetType: F
     continueOnError: true
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
     displayName: 'Run Roslyn analyzers'
     inputs:
         userProvideBuildInfo: msBuildInfo
-        msbuildVersion: 16.0
+        msbuildVersion: 17.0
         msBuildArchitecture: '$(BuildPlatform)'
-        msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="16.0"'
-        rulesetName: recommended
+        msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
+        rulesetName: Recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@2
     displayName: 'Create Security Analysis Report (CredScan, RoslynAnalyzers, and PoliCheck)'
     inputs:
       CredScan: true
@@ -143,30 +140,19 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
     displayName: 'Post Analysis (CredScan, RoslynAnalyzers, and PoliCheck)'
+
+  - task: PowerShell@2
+    displayName: 'Create tsa.config file (CredScan, Roslyn, and PoliCheck)'
     inputs:
-      CredScan: true
-      RoslynAnalyzers: true
-      PoliCheck: true
+      targetType: "filePath"
+      filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAV2ProjectName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;RoslynAnalyzers;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
     displayName: 'TSA upload (CredScan, RoslynAnalyzers, and PoliCheck)'
     inputs:
-      tsaVersion: TsaV2
-      codebase: NewOrUpdate
-      codeBaseName: $(TSACodeBaseName)
-      notificationAlias: $(TSANotificationAlias)
-      codeBaseAdmins: $(TSACodeBaseAdmins)
-      instanceUrlForTsaV2: $(TSAInstance)
-      projectNameMSENG: $(TSAProjectName)
-      areaPath: $(TSAAreaPath)
-      iterationPath: $(TSAIterationPath)
-      uploadAPIScan: false
-      uploadBinSkim: false
-      uploadFortifySCA: false
-      uploadFxCop: false
-      uploadModernCop: false
-      uploadPREfast: false
-      uploadTSLint: false
+      GdnPublishTsaOnboard: true
+      GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\tsa.config'
 
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
@@ -246,34 +232,30 @@ jobs:
       platform: '$(BuildPlatform)'
       configuration: release
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
     displayName: 'Run BinSkim'
     inputs:
       InputType: Basic
       # Double-quote syntax with trailing backslash on each line concatenates lines without spaces
-      AnalyzeTarget: "$(System.DefaultWorkingDirectory)\\src\\CI\\bin\\Release\\**\\*.dll;\
-                      $(System.DefaultWorkingDirectory)\\src\\Actions\\bin\\Release\\*.dll;\
-                      $(System.DefaultWorkingDirectory)\\src\\Automation\\bin\\Release\\*.dll;\
-                      $(System.DefaultWorkingDirectory)\\src\\Core\\bin\\Release\\**\\*.dll;\
-                      $(System.DefaultWorkingDirectory)\\src\\Desktop\\bin\\Release\\*.dll;\
-                      $(System.DefaultWorkingDirectory)\\src\\Rules\\bin\\Release\\**\\*.dll;\
-                      $(System.DefaultWorkingDirectory)\\src\\RuleSelection\\bin\\Release\\**\\*.dll;\
-                      $(System.DefaultWorkingDirectory)\\src\\SystemAbstractions\\bin\\Release\\*.dll;\
-                      $(System.DefaultWorkingDirectory)\\src\\Telemetry\\bin\\Release\\*.dll;\
-                      $(System.DefaultWorkingDirectory)\\src\\Win32\\bin\\Release\\*.dll;"
+      AnalyzeTargetGlob: "$(System.DefaultWorkingDirectory)\\src\\CI\\bin\\Release\\**\\*.dll;\
+                          $(System.DefaultWorkingDirectory)\\src\\Actions\\bin\\Release\\*.dll;\
+                          $(System.DefaultWorkingDirectory)\\src\\Automation\\bin\\Release\\*.dll;\
+                          $(System.DefaultWorkingDirectory)\\src\\Core\\bin\\Release\\**\\*.dll;\
+                          $(System.DefaultWorkingDirectory)\\src\\Desktop\\bin\\Release\\*.dll;\
+                          $(System.DefaultWorkingDirectory)\\src\\Rules\\bin\\Release\\**\\*.dll;\
+                          $(System.DefaultWorkingDirectory)\\src\\RuleSelection\\bin\\Release\\**\\*.dll;\
+                          $(System.DefaultWorkingDirectory)\\src\\SystemAbstractions\\bin\\Release\\*.dll;\
+                          $(System.DefaultWorkingDirectory)\\src\\Telemetry\\bin\\Release\\*.dll;\
+                          $(System.DefaultWorkingDirectory)\\src\\Win32\\bin\\Release\\*.dll;"
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@2
     displayName: 'Create Security Analysis Report (BinSkim)'
-    inputs:
-      BinSkim: true
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
     displayName: 'Publish Security Analysis Logs (BinSkim)'
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
     displayName: 'Post Analysis (BinSkim)'
-    inputs:
-      BinSkim: true
 
   - task: DotNetCoreCLI@2
     displayName: 'Test Assemblies (.NET Core) **\*test*.csproj'
@@ -283,27 +265,18 @@ jobs:
       projects: |
         **\*test*.csproj
 
+  - task: PowerShell@2
+    displayName: 'Create tsa.config file (BinSkim)'
+    inputs:
+      targetType: "filePath"
+      filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAV2ProjectName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "BinSkim" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
     displayName: 'TSA upload (BinSkim)'
     inputs:
-      tsaVersion: TsaV2
-      codebase: NewOrUpdate
-      codeBaseName: $(TSACodeBaseName)
-      notificationAlias: $(TSANotificationAlias)
-      codeBaseAdmins: $(TSACodeBaseAdmins)
-      instanceUrlForTsaV2: $(TSAInstance)
-      projectNameMSENG: $(TSAProjectName)
-      areaPath: $(TSAAreaPath)
-      iterationPath: $(TSAIterationPath)
-      uploadAPIScan: false
-      uploadCredScan: false
-      uploadFortifySCA: false
-      uploadFxCop: false
-      uploadModernCop: false
-      uploadPoliCheck: false
-      uploadPREfast: false
-      uploadRoslyn: false
-      uploadTSLint: false
+      GdnPublishTsaOnboard: true
+      GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\tsa.config'
 
   - task: CopyFiles@2
     displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -124,6 +124,11 @@ jobs:
       packageType: 'sdk'
       version: '6.0.x'
 
+  - task: CmdLine@2
+    displayName: 'Partial dotnet restore (for Roslyn)'
+    inputs:
+      script: 'dotnet restore --runtime win7-x86 $(Build.SourcesDirectory)\src\CLI_Full\CLI_Full.csproj'
+
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
     displayName: 'Run Roslyn analyzers'
     continueOnError: true

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -126,7 +126,7 @@ jobs:
         msbuildVersion: 17.0
         msBuildArchitecture: '$(BuildPlatform)'
         setupCommandLine: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat" && set PATH="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Roslyn";%PATH% && set && echo . && echo Running csc -version && csc -version'
-        msBuildCommandline: 'msbuild.exe "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
+        msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AxeWindows.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
         rulesetName: Recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest

--- a/tools/scripts/pipeline/build/create-tsa-config.ps1
+++ b/tools/scripts/pipeline/build/create-tsa-config.ps1
@@ -1,0 +1,96 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+<#
+.SYNOPSIS
+Create the tsa.config file based on the parameters. Paramteters will be stored as pipeline variables for confidentiality reasons
+
+.PARAMETER InstanceUrl
+The Url to the TSA instance of the database
+
+.PARAMETER ProjectName
+The name of the TSA project
+
+.PARAMETER CodeBaseAdmins
+The admin[s] of the TSA database, as a semicolon delimited list
+
+.PARAMETER AreaPath
+The Area Path that will be attached to new TSA work items
+
+.PARAMETER IterationPath
+The iteration path that will be attached to new TSA work items
+
+.PARAMETER NotificationAliases
+The email alias[es] that will be used for TSA notifications, as a semicolon delimited list
+
+.PARAMETER Tools
+The tool[s] for which uploads are expected, as a semicolon delimited list
+
+.PARAMETER OutputFile
+The fully qualified path to the output file. Assumes that the folder already exists
+
+.EXAMPLE
+PS> .\create-tsa-config.ps1 `
+        -InstanceUrl "MyInstanceUrl" `
+        -ProjectName "MyProject" `
+        -CodeBaseAdmins "Domain/user1;Domain/user2" `
+        -AreaPath "MyAreaPath" `
+        -IterationPath "MyIterationPath" `
+        -NotificationAliases "MyTeam@MyCompany.com" `
+        -Tools "CredScan;Roslyn" `
+        -OutputFile ".\tsa.config"
+#>
+
+param(
+    [Parameter(Mandatory=$true)][string]$InstanceUrl,
+    [Parameter(Mandatory=$true)][string]$ProjectName,
+    [Parameter(Mandatory=$true)][string]$CodeBaseAdmins,
+    [Parameter(Mandatory=$true)][string]$AreaPath,
+    [Parameter(Mandatory=$true)][string]$IterationPath,
+    [Parameter(Mandatory=$true)][string]$NotificationAliases,
+    [Parameter(Mandatory=$true)][string]$Tools,
+    [Parameter(Mandatory=$true)][string]$OutputFile
+)
+
+Set-StrictMode -Version Latest
+$script:ErrorActionPreference = 'Stop'
+
+# Uncomment the next line for debugging
+$VerbosePreference='continue'
+
+function Get-ItemsFromSemicolonSeparatedList([string]$inputList)
+{
+    $test = @($inputList.Split(";"))
+    return $test
+}
+
+function Get-ConfigObject([string]$codeBaseAdmins,[string]$notificationAliases,[string]$instanceUrl,[string]$projectName,[string]$areaPath,[string]$iterationPath,[string]$tools)
+{
+    $notificationAliasesArray = @(Get-ItemsFromSemicolonSeparatedList $notificationAliases)
+    $codebaseAdminsArray = @(Get-ItemsFromSemicolonSeparatedList $codeBaseAdmins)
+    $toolsArray = @(Get-ItemsFromSemicolonSeparatedList $tools) 
+    
+    $config = @{}
+    $config | Add-Member -Name "codebaseName"        -Type NoteProperty "axe-windows"
+    $config | Add-Member -Name "repositoryName"      -Type NoteProperty "axe-windows"
+    $config | Add-Member -Name "tsaVersion"          -Type NoteProperty "TsaV2"
+    $config | Add-Member -Name "codebase"            -Type NoteProperty "NewOrUpdate"
+    $config | Add-Member -Name "tsaStamp"            -Type NoteProperty "DevDiv"
+    $config | Add-Member -Name "tsaEnvironment"      -Type NoteProperty "Prod"
+    $config | Add-Member -Name "template"            -Type NoteProperty "TFSPowerBI"
+    $config | Add-Member -Name "instanceUrl"         -Type NoteProperty $instanceUrl
+    $config | Add-Member -Name "projectName"         -Type NoteProperty $projectName
+    $config | Add-Member -Name "areaPath"            -Type NoteProperty $areaPath
+    $config | Add-Member -Name "iterationPath"       -Type NoteProperty $iterationPath
+    $config | Add-Member -Name "notificationAliases" -Type NoteProperty $notificationAliasesArray
+    $config | Add-Member -Name "codebaseAdmins"      -Type NoteProperty $codebaseAdminsArray
+    $config | Add-Member -Name "tools"               -Type NoteProperty $toolsArray
+
+    return $config
+}
+
+$config = Get-ConfigObject $CodeBaseAdmins $NotificationAliases $InstanceUrl $ProjectName $AreaPath $IterationPath $Tools
+
+$config | ConvertTo-Json | Out-File $OutputFile -Encoding "utf8"
+
+Write-Host "Output to ${OutputFile}:"
+Get-Content $OutputFile | Write-Host


### PR DESCRIPTION
#### Details

Our compliance tools are are being deprecated. Our signed build warnings include the following output:

Job | Task | Warning
--- | --- | ---
ComplianceDebug | Run AutoApplicability |  This tool is no longer supported. Please remove this build task from your build definition.
ComplianceDebug | Run CredScan | Please upgrade the version of this build task in your build to major version: 3.
ComplianceDebug | Run PoliCheck | Please upgrade the version of this build task in your build to major version: 2.
ComplianceDebug | Run Roslyn analyzers | Please upgrade the version of this build task in your build to major version: 3.
ComplianceDebug | Create Security Analysis Report (CredScan, RoslynAnalyzers, and PoliCheck) | Please upgrade the version of this build task in your build to major version: 2.
ComplianceDebug | Publish Security Analysis Logs (CredScan, RoslynAnalyzers, and PoliCheck) | Please upgrade the version of this build task in your build to major version: 3.
ComplianceDebug | Post Analysis (CredScan, RoslynAnalyzers, and PoliCheck) | Please upgrade the version of this build task in your build to major version: 2.
ComplianceDebug | TSA upload (CredScan, RoslynAnalyzers, and PoliCheck) | Please upgrade the version of this build task in your build to major version: 2.
SignedRelease | Run BinSkim | Please upgrade the version of this build task in your build to major version: 4.
SignedRelease | Create Security Analysis Report (BinSkim) | Please upgrade the version of this build task in your build to major version: 2.
SignedRelease | Publish Security Analysis Logs (BinSkim) | Please upgrade the version of this build task in your build to major version: 3.
SignedRelease | Post Analysis (BinSkim) | Please upgrade the version of this build task in your build to major version: 2.
SignedRelease | TSA upload (BinSkim) | Please upgrade the version of this build task in your build to major version: 2.

This is analogous to https://github.com/microsoft/accessibility-insights-windows/pull/1575. It:
- Updates to the task versions as listed above
- Updates the needed task parameters
- Uses a PowerShell script to generate the tsa.config file based on pipeline variables
- Adds tasks needed for RoslynAnalyzers to build our .NET 6.0 projects. This took a fair amount of trial and error to get right, and was not needed in AIWin. The extra tasks are prefixed with "Roslyn pre-req" and will (hopefully) only be needed temporarily

The validation build can be located at https://dev.azure.com/mseng/1ES/_build/results?buildId=19600051&view=results

##### Motivation

Use supported validation tools.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
3 Follow-up PR's will be needed:
1. Limit the uploads to just the main branch (see https://github.com/microsoft/accessibility-insights-windows/pull/1578).
2. Some cleanup work to simplify the pipeline variables that currently need to support 2 versions of TSA.
3. In theory, #882 should no longer be needed. We should confirm and revert if possible.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
