### PR TITLE
chore: Make integration test timeouts more tolerant

### DIFF
--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -137,7 +137,6 @@ namespace Axe.Windows.AutomationTests
             });
         }
 
-
         [DataTestMethod]
         [DataRow(true)]
         [DataRow(false)]
@@ -242,6 +241,10 @@ namespace Axe.Windows.AutomationTests
 
             if (wrapper.CaughtException != null)
             {
+                if (wrapper.CaughtException.GetType() == typeof(AssertInconclusiveException))
+                {
+                    Assert.Inconclusive($"AssertInconclusiveException caught - See details below.\n{wrapper.CaughtException.Message}\n{wrapper.CaughtException.StackTrace}");
+                }
                 Assert.Fail($"Exception caught - See details below.\n{wrapper.CaughtException.Message}\n{wrapper.CaughtException.StackTrace}");
             }
 

--- a/src/AutomationTests/TimedExecutionWrapper.cs
+++ b/src/AutomationTests/TimedExecutionWrapper.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Axe.Windows.AutomationTests
+{
+    internal class TimedExecutionWrapper
+    {
+        private static readonly TimeSpan SleepTime = TimeSpan.FromMilliseconds(250);
+
+        private readonly TimeSpan _allowedTime;
+        private Stopwatch _stopwatch;
+        private Thread _thread;
+
+        internal bool Completed { get; private set; }
+        internal Exception CaughtException { get; private set; }
+
+        internal TimedExecutionWrapper(TimeSpan allowedTime)
+        {
+            _allowedTime = allowedTime;
+        }
+
+        internal void RunAction(Action testAction)
+        {
+            CaughtException = null;
+            _stopwatch = Stopwatch.StartNew();
+            CreateThreadForTest(testAction);
+            WaitForThreadToStart();
+            WaitForThreadToComplete();
+            Completed = !_thread.IsAlive;
+        }
+
+        private void CreateThreadForTest(Action testAction)
+        {
+            _thread = new Thread(new ThreadStart(() =>
+            {
+                try
+                {
+                    testAction();
+                }
+                catch (Exception e)
+                {
+                    CaughtException = e;
+                }
+            }));
+            _thread.Start();
+        }
+
+        private void WaitForThreadToStart()
+        {
+            while (_stopwatch.Elapsed < _allowedTime && !_thread.IsAlive)
+            {
+                Thread.Sleep(SleepTime);
+            }
+        }
+
+        private void WaitForThreadToComplete()
+        {
+            while (_stopwatch.Elapsed < _allowedTime && _thread.IsAlive)
+            {
+                Thread.Sleep(SleepTime);
+            }
+        }
+    }
+}

--- a/src/AutomationTests/TimedExecutionWrapper.cs
+++ b/src/AutomationTests/TimedExecutionWrapper.cs
@@ -7,6 +7,12 @@ using System.Threading;
 
 namespace Axe.Windows.AutomationTests
 {
+    /// <summary>
+    /// A simple wrapper to bring our timeout behavior under our own control. Given a max allowed time
+    /// and an Action, it spins up a thread, runs the Action on that thread, and reports the outcome
+    /// via the Completed and CaughtException properties. The same object can be used to run multiple
+    /// Actions (or the same Action multiple times), as long as they all share the same timeout.
+    /// </summary>
     internal class TimedExecutionWrapper
     {
         private static readonly TimeSpan SleepTime = TimeSpan.FromMilliseconds(250);
@@ -31,6 +37,7 @@ namespace Axe.Windows.AutomationTests
             WaitForThreadToStart();
             WaitForThreadToComplete();
             Completed = !_thread.IsAlive;
+            _stopwatch.Stop();
         }
 
         private void CreateThreadForTest(Action testAction)


### PR DESCRIPTION
#### Details

Automation integration tests frequently have timeouts in our pipelines, which is bad. This PR replaces the VSTest-controlled timeout with a timeout that we control, so that we can return Inconclusive if a test times out in the pipeline. It also slightly increases the timeouts on a couple of tests and makes the timeout directly proportional to the number of processes being spun up.

This will probably be easier to review if you enable the "Hide whitespace" setting

##### Motivation

Flaky tests make life hard.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
