### PR TITLE
chore: Limit TSA uploads to main branch

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -16,7 +16,8 @@ variables:
   TeamName: 'Axe Windows'
   system.debug: 'true' #set to true in case our signed build flakes out again
   runCodesignValidationInjection: 'false'
-
+  isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+  
 jobs:
 - job: ComplianceRelease
   pool:
@@ -171,6 +172,7 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (CredScan, RoslynAnalyzers, and PoliCheck)'
+    condition: and(succeeded(), eq(variables.isMain, true))
     inputs:
       GdnPublishTsaOnboard: true
       GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\tsa.config'
@@ -297,6 +299,7 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (BinSkim)'
+    condition: and(succeeded(), eq(variables.isMain, true))
     inputs:
       GdnPublishTsaOnboard: true
       GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\tsa.config'


### PR DESCRIPTION
#### Details

Note: This is the analog of https://github.com/microsoft/accessibility-insights-windows/pull/1578

The old version of TSA automatically added the branch name to the database, which was kind of wasteful since new databases were created from each non-main branch used for a signed test build. The new version of TSA uses the same database name for all branches, which means that builds from any branch could create noise in the production version. To solve both problems, this PR restricts the TSA upload to just the main branch. All TSA artifacts are created as usual, but the upload task gets skipped. This is based on the method shown [here](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml%2Cstages).

The Validation build skips both TSA uploads:
- [ComplianceDebug](https://dev.azure.com/mseng/1ES/_build/results?buildId=19606013&view=logs&j=3c521f5b-2fd1-5273-f710-894af621d3fd&t=15028cb4-588f-5227-e094-117290118403&l=1)
- [SignedRelease](https://dev.azure.com/mseng/1ES/_build/results?buildId=19606013&view=logs&j=7c3ebc89-e7dd-5791-8c02-2ea1f3a27b50&t=e3d820ac-b555-5998-c763-65ae73427349&l=1)
##### Motivation

Maintain a single clean copy of the TSA database for the repo.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
