### PR TITLE
Chore(Lock-keyword): Replace narrative translator guidance with machine-readable annotations

### DIFF
--- a/src/Rules/Resources/ConditionDescriptions.resx
+++ b/src/Rules/Resources/ConditionDescriptions.resx
@@ -131,7 +131,7 @@
   </data>
   <data name="BoundingRectangleCompletelyObscuresContainer" xml:space="preserve">
     <value>BoundingRectangle completely obscures container</value>
-    <comment>The name of a condition used by the automated accessibility scanner. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The name of a condition used by the automated accessibility scanner. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="ChildrenExist" xml:space="preserve">
     <value>children exist</value>

--- a/src/Rules/Resources/ConditionDescriptions.resx
+++ b/src/Rules/Resources/ConditionDescriptions.resx
@@ -131,7 +131,7 @@
   </data>
   <data name="BoundingRectangleCompletelyObscuresContainer" xml:space="preserve">
     <value>BoundingRectangle completely obscures container</value>
-    <comment>The name of a condition used by the automated accessibility scanner. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
+    <comment>The name of a condition used by the automated accessibility scanner. {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="ChildrenExist" xml:space="preserve">
     <value>children exist</value>

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -119,115 +119,115 @@
   </resheader>
   <data name="BoundingRectangleNotValidButOffScreen" xml:space="preserve">
     <value>The BoundingRectangle property is not valid, but the element is off-screen.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="ButtonWithSplitButtonParentPattern" xml:space="preserve">
     <value>A button element should only support one of the Invoke, Toggle, or ExpandCollapse patterns when a splitbutton is the parent. </value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="SiblingUniqueAndNotFocusable" xml:space="preserve">
     <value>The given element has siblings with the same Name and LocalizedControlType.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="ComboBoxShouldNotSupportScrollPattern" xml:space="preserve">
     <value>A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes that support the Scroll pattern by default, which app developers can't easily fix.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Scroll" should not be translated (i.e. it should be treated as a loanword). {Locked="Scroll"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Scroll"}</comment>
   </data>
   <data name="ControlShouldNotSupportValuePattern" xml:space="preserve">
     <value>An element of the given type should not support the Value pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Value" should not be translated (i.e. it should be treated as a loanword). {Locked="Value"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Value"}</comment>
   </data>
   <data name="ControlShouldNotSupportWindowPattern" xml:space="preserve">
     <value>An element of the given type should not support the Window pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Window" should not be translated (i.e. it should be treated as a loanword). {Locked="Window"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Window"}</comment>
   </data>
   <data name="HelpTextNotEqualToName" xml:space="preserve">
     <value>The HelpText property of an element must not be the same as the element's Name property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "HelpText" and "Name" should not be translated (i.e. they should be treated as loanwords). {Locked="HelpText", "Name"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="HelpText", "Name"}</comment>
   </data>
   <data name="IsContentElementFalseOptional" xml:space="preserve">
     <value>The recommended value of the IsContentElement property for the given control type is false. Please consider if this is an element that should be reported to an assistive technology user as content.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsContentElement"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsContentElement"}</comment>
   </data>
   <data name="IsContentElementTrueOptional" xml:space="preserve">
     <value>The recommended value of the IsContentElement property for the given control type is true. Please consider if this is an element that should be reported to an assistive technology user as content.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsContentElement"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsContentElement"}</comment>
   </data>
   <data name="IsControlElementTrueOptional" xml:space="preserve">
     <value>The recommended value of the IsControlElement property for the given control type is true. Please consider if this is an element that should be reported to an assistive technology user as a control. Note that almost all controls are required to have the IsControl Property set to true.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsControlElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsControlElement"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsControlElement"}</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element should be true based on its control type.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButDisabled" xml:space="preserve">
     <value>The IsKeyboardFocusable property is false for an element where it would normally be true. However, the IsEnabled property on the element is also false, so the value of IsKeyboardFocusable may be acceptable.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsEnabled" should not be translated (i.e. they should be treated as loanwords). {Locked="IsKeyboardFocusable", "IsEnabled"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable", "IsEnabled"}</comment>
   </data>
   <data name="IsKeyboardFocusableForListItemShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given list item is false, but the element has children that are focusable. The element should probably be focusable instead of its children.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButOffscreen" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element is false for an element where it would normally be true. However, the IsOffscreen property on the element is true, so the value of IsKeyboardFocusable may be acceptable.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsOffscreen" should not be translated (i.e. they should be treated as loanwords). {Locked="IsKeyboardFocusable", "IsOffscreen"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable", "IsOffscreen"}</comment>
   </data>
   <data name="IsKeyboardFocusableForCustomShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for a custom element should be true when the element supports actionable patterns.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableDescendantTextPattern" xml:space="preserve">
     <value>The IsKeyboardFocusable property may be false when the given element supports the Text pattern and is the descendant of an element that also supports the Text pattern. Please consider if the given element should or should not be focusable.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated (i.e. they should be treated as loanwords). {Locked="IsKeyboardFocusable", "Text"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable", "Text"}</comment>
   </data>
   <data name="IsKeyboardFocusableOnEmptyContainer" xml:space="preserve">
     <value>The IsKeyboardFocusable property should be true when you want an empty container to be discoverable by assistive technology users. IsKeyboardFocusable may be false when you want an empty container not to be discoverable by assistive technology users.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeFalse" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element is expected to be false because of the element's control type.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableTopLevelTextPattern" xml:space="preserve">
     <value>The IsKeyboardFocusable property should be true for an element that supports the Text pattern, is not a descendant of an element that supports the Text pattern, and which supports text selection.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated (i.e. they should be treated as loanwords). {Locked="IsKeyboardFocusable", "Text"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable", "Text"}</comment>
   </data>
   <data name="ItemStatusExists" xml:space="preserve">
     <value>The ItemStatus property for the given element should exist.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "ItemStatus" should not be translated (i.e. it should be treated as a loanword). {Locked="ItemStatus"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ItemStatus"}</comment>
   </data>
   <data name="LocalizedControlTypeReasonable" xml:space="preserve">
     <value>The LocalizedControlType should be reasonable based on the element's ControlTypeId.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LocalizedControlType" and "ControlTypeId" should not be translated (i.e. they should be treated as loanwords). {Locked="LocalizedControlType", "ControlTypeId"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedControlType", "ControlTypeId"}</comment>
   </data>
   <data name="ItemTypeRecommended" xml:space="preserve">
     <value>The ItemType property for the given element has no content, and the element has a child image. Please consider including an ItemType so that assistive technology users can obtain the information provided by the image. If this information is already provided in another way, the ItemType may not be necessary.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "ItemType" should not be translated (i.e. it should be treated as a loanword). {Locked="ItemType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ItemType"}</comment>
   </data>
   <data name="NameEmptyButElementNotKeyboardFocusable" xml:space="preserve">
     <value>The Name property for the given element is empty, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
   </data>
   <data name="NameNoSiblingsOfSameType" xml:space="preserve">
     <value>The Name property of the given element may be null or empty if the element has no siblings of the same type.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
   </data>
   <data name="NameNullButElementNotKeyboardFocusable" xml:space="preserve">
     <value>The Name property for the given element is null, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
   </data>
   <data name="NameOnCustomWithParentWPFDataItem" xml:space="preserve">
-    <value>The Name property of a custom control may be empty if the parent is a WPF dataitem.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "dataitem" should not be translated (i.e. they should be treated as loanwords). {Locked="Name", "DataItem"}</comment>
+    <value>The Name property of a custom control may be empty if the parent is a WPF DataItem.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name", "DataItem"}</comment>
   </data>
   <data name="NameOnOptionalType" xml:space="preserve">
     <value>The Name property for the given element type is optional.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
   </data>
   <data name="NameWithValidBoundingRectangle" xml:space="preserve">
     <value>An interactive element with a valid Name property is usually expected to have a valid BoundingRectangle that is not null and has area.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "BoundingRectangle" should not be translated (i.e. they should be treated as loanwords). {Locked="Name", "BoundingRectangle"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name", "BoundingRectangle"}</comment>
   </data>
   <data name="Structure" xml:space="preserve">
     <value>The given element is expected to have the following structure: {0}.</value>
@@ -235,107 +235,107 @@
   </data>
   <data name="ButtonInvokeAndExpandCollapsePatterns" xml:space="preserve">
     <value>A button may have the Invoke and ExpandCollapse patterns together, but it is not recommended. If possible, please have only one of them. </value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "ExpandCollapse"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Invoke", "ExpandCollapse"}</comment>
   </data>
   <data name="ButtonShouldHavePatterns" xml:space="preserve">
     <value>A button must support one of these patterns: Invoke, Toggle, or ExpandCollapse.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="ButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>A button must not support both the Invoke and Toggle patterns.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "Toggle" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Invoke", "Toggle"}</comment>
   </data>
   <data name="ButtonToggleAndExpandCollapsePatterns" xml:space="preserve">
     <value>A button must not support both the Toggle and ExpandCollapse patterns.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Toggle" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Toggle", "ExpandCollapse"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="ProgressBarRangeValue" xml:space="preserve">
     <value>The RangeValue pattern of a progress bar must have specific Minimum, Maximum, and IsReadOnly values.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "RangeValue", "Minimum", "Maximum", and "IsReadOnly" should not be translated (i.e. they should be treated as loanwords). {Locked="RangeValue", "Minimum", "Maximum", "IsReadOnly"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="RangeValue", "Minimum", "Maximum", "IsReadOnly"}</comment>
   </data>
   <data name="EditSupportsIncorrectRangeValuePattern" xml:space="preserve">
     <value>The RangeValue pattern of an edit control must have a null LargeChange property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "RangeValue" and "LargeChange" should not be translated (i.e. they should be treated as loanwords). {Locked="RangeValue", "LargeChange"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="RangeValue", "LargeChange"}</comment>
   </data>
   <data name="SplitButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>A split button must support exactly one of the Invoke or Toggle patterns.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "Toggle" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Invoke", "Toggle"}</comment>
   </data>
   <data name="ControlShouldNotSupportInvokePattern" xml:space="preserve">
     <value>An element of the given ControlType must not support the Invoke pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Invoke" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Invoke"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "Invoke"}</comment>
   </data>
   <data name="ControlShouldNotSupportScrollPattern" xml:space="preserve">
     <value>An element of the given ControlType must not support the Scroll pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Scroll" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Scroll"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "Scroll"}</comment>
   </data>
   <data name="ControlShouldNotSupportTogglePattern" xml:space="preserve">
     <value>An element of the given ControlType must not support the Toggle pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Toggle" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Toggle"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "Toggle"}</comment>
   </data>
   <data name="ControlShouldSupportExpandCollapsePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the ExpandCollapse pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "ExpandCollapse"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "ExpandCollapse"}</comment>
   </data>
   <data name="ControlShouldSupportGridItemPattern" xml:space="preserve">
     <value>An element whose parent supports the Grid pattern must support the GridItem pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Grid" and "GridItem" should not be translated (i.e. they should be treated as loanwords). {Locked="Grid", "GridItem"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Grid", "GridItem"}</comment>
   </data>
   <data name="ControlShouldSupportGridPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Grid pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Grid" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Grid"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "Grid"}</comment>
   </data>
   <data name="ControlShouldSupportInvokePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Invoke pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Invoke" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Invoke"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "Invoke"}</comment>
   </data>
   <data name="ControlShouldSupportScrollItemPattern" xml:space="preserve">
     <value>An element whose parent supports the Scroll pattern must support the ScrollItem pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Scroll" and "ScrollItem" should not be translated (i.e. they should be treated as loanwords). {Locked="Scroll", "ScrollItem"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Scroll", "ScrollItem"}</comment>
   </data>
   <data name="ControlShouldSupportSelectionItemPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the SelectionItem pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "SelectionItem" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "SelectionItem"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "SelectionItem"}</comment>
   </data>
   <data name="ControlShouldSupportSelectionPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Selection pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Selection" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Selection"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "Selection"}</comment>
   </data>
   <data name="ControlShouldSupportSpreadsheetItemPattern" xml:space="preserve">
     <value>An element whose parent supports the Spreadsheet pattern must support the SpreadsheetItem pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Spreadsheet" and "SpreadsheetItem" should not be translated (i.e. they should be treated as loanwords). {Locked="Spreadsheet", "SpreadsheetItem"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Spreadsheet", "SpreadsheetItem"}</comment>
   </data>
   <data name="ControlShouldSupportTableItemPattern" xml:space="preserve">
     <value>An element whose parent supports the Table pattern must support the TableItem pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Table" and "TableItem" should not be translated (i.e. they should be treated as loanwords). {Locked="Table", "TableItem"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Table", "TableItem"}</comment>
   </data>
   <data name="ControlShouldSupportTablePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Table pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Table" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Table"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "Table"}</comment>
   </data>
   <data name="ControlShouldSupportTextPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Text pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Table" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Table"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "Table"}</comment>
   </data>
   <data name="ControlShouldSupportTogglePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Toggle pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Toggle" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Toggle"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "Toggle"}</comment>
   </data>
   <data name="ControlShouldSupportTransformPattern" xml:space="preserve">
     <value>An element that can be resized must support the Transform pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Transform" should not be translated (i.e. it should be treated as a loanword). {Locked="Transform"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Transform"}</comment>
   </data>
   <data name="ChildrenNotAllowedInContentView" xml:space="preserve">
     <value>A separator must not have any children with IsContentElement set to TRUE.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsContentElement"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsContentElement"}</comment>
   </data>
   <data name="SelectionPatternSelectionRequired" xml:space="preserve">
     <value>An element of the given ControlType must have the IsSelectionRequired property set to TRUE.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsSelectionRequired" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "IsSelectionRequired"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsSelectionRequired"}</comment>
   </data>
   <data name="SelectionPatternSingleSelection" xml:space="preserve">
     <value>An element of the given ControlType must not support multiple selection.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "ControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="ControlType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType"}</comment>
   </data>
   <data name="SelectionItemPatternSingleSelection" xml:space="preserve">
     <value>An element whose parent supports single selection must not have selected siblings.</value>
@@ -343,7 +343,7 @@
   </data>
   <data name="ParentChildShouldNotHaveSameNameAndLocalizedControlType" xml:space="preserve">
     <value>An element must not have the same Name and LocalizedControlType as its parent.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords). {Locked="Name", "LocalizedControlType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name", "LocalizedControlType"}</comment>
   </data>
   <data name="SiblingUniqueAndFocusable" xml:space="preserve">
     <value>Focusable sibling elements must not have the same Name and LocalizedControlType.</value>
@@ -351,31 +351,31 @@
   </data>
   <data name="ControlShouldSupportSetInfo" xml:space="preserve">
     <value>The element's ControlType requires valid values for SizeOfSet and PositionInSet.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType", "SizeOfSet", and "PositionInSet" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "SizeOfSet", "PositionInSet"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "SizeOfSet", "PositionInSet"}</comment>
   </data>
   <data name="BoundingRectangleCompletelyObscuresContainer" xml:space="preserve">
     <value>An element's BoundingRectangle must not obscure its container element.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="BoundingRectangleContainedInParent" xml:space="preserve">
     <value>An element's BoundingRectangle must be contained within its parent element.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="BoundingRectangleDataFormatCorrect" xml:space="preserve">
     <value>The BoundingRectangle property must return a valid rectangle.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="BoundingRectangleNotAllZeros" xml:space="preserve">
     <value>The BoundingRectangle property must not be defined as [0,0,0,0]</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="BoundingRectangleNotNull" xml:space="preserve">
     <value>An on-screen element must not have a null BoundingRectangle property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="BoundingRectangleSizeReasonable" xml:space="preserve">
     <value>The BoundingRectangle property must represent an area of at least 25 pixels.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="HeadingLevelDescendsWhenNested" xml:space="preserve">
     <value>An element's HeadingLevel must be greater than or equal to that of its ancestors.</value>
@@ -383,111 +383,111 @@
   </data>
   <data name="IsContentElementPropertyExists" xml:space="preserve">
     <value>The given ControlType must have a non-null IsContentElement property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsContentElement" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "IsContentElement"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsContentElement"}</comment>
   </data>
   <data name="IsControlElementPropertyExists" xml:space="preserve">
     <value>The given ControlType must have a non-null IsControlElement property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsControlElement" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "IsControlElement"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsControlElement"}</comment>
   </data>
   <data name="IsControlElementTrueRequired" xml:space="preserve">
     <value>The given ControlType must have the IsControlElement property set to TRUE.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsControlElement" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "IsControlElement"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsControlElement"}</comment>
   </data>
   <data name="LandmarkBannerIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "banner" must not descend from another landmark.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LandmarkComplementaryIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "complementary" must not descend from another landmark.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LandmarkContentInfoIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "contentinfo" must not descend from another landmark.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LandmarkMainIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "main" must not descend from another landmark.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LandmarkNoDuplicateBanner" xml:space="preserve">
     <value>A page must not have multiple elements with LocalizedLandmarkType "banner".</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LandmarkNoDuplicateContentInfo" xml:space="preserve">
     <value>A page must not have multiple elements with LocalizedLandmarkType "contentinfo".</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeIsReasonableLength" xml:space="preserve">
     <value>The LocalizedLandmarkType property must not be longer than 64 characters.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotCustom" xml:space="preserve">
     <value>The LandmarkType and LocalizedLandmarkType must not both be set to "custom".</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated (i.e. they should be treated as loanwords). {Locked="LandmarkType", "LocalizedLandmarkType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LandmarkType", "LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotEmpty" xml:space="preserve">
     <value>An element with LandmarkType set must not have an empty LocalizedLandmarkType.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated (i.e. they should be treated as loanwords). {Locked="LandmarkType", "LocalizedLandmarkType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LandmarkType", "LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotNull" xml:space="preserve">
     <value>An element with LandmarkType set must not have a null LocalizedLandmarkType.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated (i.e. they should be treated as loanwords). {Locked="LandmarkType", "LocalizedLandmarkType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LandmarkType", "LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotWhiteSpace" xml:space="preserve">
     <value>The LocalizedLandmarkType property must not contain only white space.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotCustom" xml:space="preserve">
     <value>The ControlType and LocalizedControlType must not both be set to "custom."</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "LocalizedControlType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "LocalizedControlType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotEmpty" xml:space="preserve">
     <value>The LocalizedControlType property must not be an empty string.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotNull" xml:space="preserve">
     <value>The LocalizedControlType property must not be null.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotWhiteSpace" xml:space="preserve">
     <value>The LocalizedControlType property must not contain only white space.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="OrientationPropertyExists" xml:space="preserve">
     <value>Controls that can be horizontal or vertical must support the Orientation property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Orientation" should not be translated (i.e. it should be treated as a loanword). {Locked="Orientation"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Orientation"}</comment>
   </data>
   <data name="NameExcludesControlType" xml:space="preserve">
     <value>The Name property must not include the element's control type.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
   </data>
   <data name="NameExcludesLocalizedControlType" xml:space="preserve">
     <value>The Name must not include the same text as the LocalizedControlType.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords). {Locked="Name", "LocalizedControlType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name", "LocalizedControlType"}</comment>
   </data>
   <data name="NameIsInformative" xml:space="preserve">
     <value>The Name property of an element should not contain class names like 'Microsoft.*.*' or 'Windows.*.*' as these are not usually informative.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">
     <value>The Name property of a focusable element must not be an empty string.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
   </data>
   <data name="NameNotNull" xml:space="preserve">
     <value>The Name property of a focusable element must not be null.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
   </data>
   <data name="NameNotWhiteSpace" xml:space="preserve">
     <value>The Name property must not contain only space characters.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
   </data>
   <data name="NameReasonableLength" xml:space="preserve">
     <value>The Name property must not be longer than 512 characters.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
   </data>
   <data name="ListItemSiblingsUnique" xml:space="preserve">
     <value>The Name property of sibling list items should be unique.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
   </data>
   <data name="HyperlinkNameShouldBeUnique" xml:space="preserve">
     <value>Links with different purposes and destinations should have different names.</value>
@@ -499,11 +499,11 @@
   </data>
   <data name="ClickablePointOnScreen" xml:space="preserve">
     <value>An element's IsOffScreen property must be false when its clickable point is on-screen.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsOffScreen" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsOffScreen"}</comment>
   </data>
   <data name="ClickablePointOffScreen" xml:space="preserve">
     <value>An element's IsOffScreen property must be true when its clickable point is off-screen.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsOffScreen" should not be translated (i.e. it should be treated as a loanword). {Locked="IsOffScreen"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsOffScreen"}</comment>
   </data>
   <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
     <value>The framework used to build this application does not support.</value>
@@ -518,7 +518,7 @@
 Description:    {1}
 HowToFix:    {2}
 Condition:  {3}</value>
-    <comment>Developers: {0} is id, {1} is description, {2} is how to fix, and {3} is condition</comment>
+    <comment>{0} is id, {1} is description, {2} is how to fix, and {3} is condition</comment>
   </data>
   <data name="ChromiumComponentsShouldUseWebScanner" xml:space="preserve">
     <value>Chromium components should be scanned with a web-based scanner.</value>

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -119,115 +119,115 @@
   </resheader>
   <data name="BoundingRectangleNotValidButOffScreen" xml:space="preserve">
     <value>The BoundingRectangle property is not valid, but the element is off-screen.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="ButtonWithSplitButtonParentPattern" xml:space="preserve">
     <value>A button element should only support one of the Invoke, Toggle, or ExpandCollapse patterns when a splitbutton is the parent. </value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="SiblingUniqueAndNotFocusable" xml:space="preserve">
     <value>The given element has siblings with the same Name and LocalizedControlType.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="ComboBoxShouldNotSupportScrollPattern" xml:space="preserve">
     <value>A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes that support the Scroll pattern by default, which app developers can't easily fix.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Scroll" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Scroll" should not be translated (i.e. it should be treated as a loanword). {Locked="Scroll"}</comment>
   </data>
   <data name="ControlShouldNotSupportValuePattern" xml:space="preserve">
     <value>An element of the given type should not support the Value pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Value" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Value" should not be translated (i.e. it should be treated as a loanword). {Locked="Value"}</comment>
   </data>
   <data name="ControlShouldNotSupportWindowPattern" xml:space="preserve">
     <value>An element of the given type should not support the Window pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Window" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Window" should not be translated (i.e. it should be treated as a loanword). {Locked="Window"}</comment>
   </data>
   <data name="HelpTextNotEqualToName" xml:space="preserve">
     <value>The HelpText property of an element must not be the same as the element's Name property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "HelpText" and "Name" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "HelpText" and "Name" should not be translated (i.e. they should be treated as loanwords). {Locked="HelpText", "Name"}</comment>
   </data>
   <data name="IsContentElementFalseOptional" xml:space="preserve">
     <value>The recommended value of the IsContentElement property for the given control type is false. Please consider if this is an element that should be reported to an assistive technology user as content.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsContentElement"}</comment>
   </data>
   <data name="IsContentElementTrueOptional" xml:space="preserve">
     <value>The recommended value of the IsContentElement property for the given control type is true. Please consider if this is an element that should be reported to an assistive technology user as content.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsContentElement"}</comment>
   </data>
   <data name="IsControlElementTrueOptional" xml:space="preserve">
     <value>The recommended value of the IsControlElement property for the given control type is true. Please consider if this is an element that should be reported to an assistive technology user as a control. Note that almost all controls are required to have the IsControl Property set to true.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsControlElement" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsControlElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsControlElement"}</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element should be true based on its control type.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButDisabled" xml:space="preserve">
     <value>The IsKeyboardFocusable property is false for an element where it would normally be true. However, the IsEnabled property on the element is also false, so the value of IsKeyboardFocusable may be acceptable.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsEnabled" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsEnabled" should not be translated (i.e. they should be treated as loanwords). {Locked="IsKeyboardFocusable", "IsEnabled"}</comment>
   </data>
   <data name="IsKeyboardFocusableForListItemShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given list item is false, but the element has children that are focusable. The element should probably be focusable instead of its children.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButOffscreen" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element is false for an element where it would normally be true. However, the IsOffscreen property on the element is true, so the value of IsKeyboardFocusable may be acceptable.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsOffscreen" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "IsOffscreen" should not be translated (i.e. they should be treated as loanwords). {Locked="IsKeyboardFocusable", "IsOffscreen"}</comment>
   </data>
   <data name="IsKeyboardFocusableForCustomShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for a custom element should be true when the element supports actionable patterns.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableDescendantTextPattern" xml:space="preserve">
     <value>The IsKeyboardFocusable property may be false when the given element supports the Text pattern and is the descendant of an element that also supports the Text pattern. Please consider if the given element should or should not be focusable.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated (i.e. they should be treated as loanwords). {Locked="IsKeyboardFocusable", "Text"}</comment>
   </data>
   <data name="IsKeyboardFocusableOnEmptyContainer" xml:space="preserve">
     <value>The IsKeyboardFocusable property should be true when you want an empty container to be discoverable by assistive technology users. IsKeyboardFocusable may be false when you want an empty container not to be discoverable by assistive technology users.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeFalse" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element is expected to be false because of the element's control type.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableTopLevelTextPattern" xml:space="preserve">
     <value>The IsKeyboardFocusable property should be true for an element that supports the Text pattern, is not a descendant of an element that supports the Text pattern, and which supports text selection.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "IsKeyboardFocusable" and "Text" should not be translated (i.e. they should be treated as loanwords). {Locked="IsKeyboardFocusable", "Text"}</comment>
   </data>
   <data name="ItemStatusExists" xml:space="preserve">
     <value>The ItemStatus property for the given element should exist.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "ItemStatus" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "ItemStatus" should not be translated (i.e. it should be treated as a loanword). {Locked="ItemStatus"}</comment>
   </data>
   <data name="LocalizedControlTypeReasonable" xml:space="preserve">
     <value>The LocalizedControlType should be reasonable based on the element's ControlTypeId.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LocalizedControlType" and "ControlTypeId" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LocalizedControlType" and "ControlTypeId" should not be translated (i.e. they should be treated as loanwords). {Locked="LocalizedControlType", "ControlTypeId"}</comment>
   </data>
   <data name="ItemTypeRecommended" xml:space="preserve">
     <value>The ItemType property for the given element has no content, and the element has a child image. Please consider including an ItemType so that assistive technology users can obtain the information provided by the image. If this information is already provided in another way, the ItemType may not be necessary.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "ItemType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "ItemType" should not be translated (i.e. it should be treated as a loanword). {Locked="ItemType"}</comment>
   </data>
   <data name="NameEmptyButElementNotKeyboardFocusable" xml:space="preserve">
     <value>The Name property for the given element is empty, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameNoSiblingsOfSameType" xml:space="preserve">
     <value>The Name property of the given element may be null or empty if the element has no siblings of the same type.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameNullButElementNotKeyboardFocusable" xml:space="preserve">
     <value>The Name property for the given element is null, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameOnCustomWithParentWPFDataItem" xml:space="preserve">
     <value>The Name property of a custom control may be empty if the parent is a WPF dataitem.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "dataitem" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "dataitem" should not be translated (i.e. they should be treated as loanwords). {Locked="Name", "DataItem"}</comment>
   </data>
   <data name="NameOnOptionalType" xml:space="preserve">
     <value>The Name property for the given element type is optional.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameWithValidBoundingRectangle" xml:space="preserve">
     <value>An interactive element with a valid Name property is usually expected to have a valid BoundingRectangle that is not null and has area.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "BoundingRectangle" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "BoundingRectangle" should not be translated (i.e. they should be treated as loanwords). {Locked="Name", "BoundingRectangle"}</comment>
   </data>
   <data name="Structure" xml:space="preserve">
     <value>The given element is expected to have the following structure: {0}.</value>
@@ -235,107 +235,107 @@
   </data>
   <data name="ButtonInvokeAndExpandCollapsePatterns" xml:space="preserve">
     <value>A button may have the Invoke and ExpandCollapse patterns together, but it is not recommended. If possible, please have only one of them. </value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "ExpandCollapse"}</comment>
   </data>
   <data name="ButtonShouldHavePatterns" xml:space="preserve">
     <value>A button must support one of these patterns: Invoke, Toggle, or ExpandCollapse.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="ButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>A button must not support both the Invoke and Toggle patterns.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "Toggle" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "Toggle" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle"}</comment>
   </data>
   <data name="ButtonToggleAndExpandCollapsePatterns" xml:space="preserve">
     <value>A button must not support both the Toggle and ExpandCollapse patterns.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Toggle" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Toggle" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="ProgressBarRangeValue" xml:space="preserve">
     <value>The RangeValue pattern of a progress bar must have specific Minimum, Maximum, and IsReadOnly values.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "RangeValue", "Minimum", "Maximum", and "IsReadOnly" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "RangeValue", "Minimum", "Maximum", and "IsReadOnly" should not be translated (i.e. they should be treated as loanwords). {Locked="RangeValue", "Minimum", "Maximum", "IsReadOnly"}</comment>
   </data>
   <data name="EditSupportsIncorrectRangeValuePattern" xml:space="preserve">
     <value>The RangeValue pattern of an edit control must have a null LargeChange property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "RangeValue" and "LargeChange" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "RangeValue" and "LargeChange" should not be translated (i.e. they should be treated as loanwords). {Locked="RangeValue", "LargeChange"}</comment>
   </data>
   <data name="SplitButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>A split button must support exactly one of the Invoke or Toggle patterns.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "Toggle" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Invoke" and "Toggle" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle"}</comment>
   </data>
   <data name="ControlShouldNotSupportInvokePattern" xml:space="preserve">
     <value>An element of the given ControlType must not support the Invoke pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Invoke" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Invoke" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Invoke"}</comment>
   </data>
   <data name="ControlShouldNotSupportScrollPattern" xml:space="preserve">
     <value>An element of the given ControlType must not support the Scroll pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Scroll" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Scroll" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Scroll"}</comment>
   </data>
   <data name="ControlShouldNotSupportTogglePattern" xml:space="preserve">
     <value>An element of the given ControlType must not support the Toggle pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Toggle" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Toggle" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Toggle"}</comment>
   </data>
   <data name="ControlShouldSupportExpandCollapsePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the ExpandCollapse pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "ExpandCollapse"}</comment>
   </data>
   <data name="ControlShouldSupportGridItemPattern" xml:space="preserve">
     <value>An element whose parent supports the Grid pattern must support the GridItem pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Grid" and "GridItem" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Grid" and "GridItem" should not be translated (i.e. they should be treated as loanwords). {Locked="Grid", "GridItem"}</comment>
   </data>
   <data name="ControlShouldSupportGridPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Grid pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Grid" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Grid" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Grid"}</comment>
   </data>
   <data name="ControlShouldSupportInvokePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Invoke pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Invoke" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Invoke" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Invoke"}</comment>
   </data>
   <data name="ControlShouldSupportScrollItemPattern" xml:space="preserve">
     <value>An element whose parent supports the Scroll pattern must support the ScrollItem pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Scroll" and "ScrollItem" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Scroll" and "ScrollItem" should not be translated (i.e. they should be treated as loanwords). {Locked="Scroll", "ScrollItem"}</comment>
   </data>
   <data name="ControlShouldSupportSelectionItemPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the SelectionItem pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "SelectionItem" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "SelectionItem" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "SelectionItem"}</comment>
   </data>
   <data name="ControlShouldSupportSelectionPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Selection pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Selection" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Selection" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Selection"}</comment>
   </data>
   <data name="ControlShouldSupportSpreadsheetItemPattern" xml:space="preserve">
     <value>An element whose parent supports the Spreadsheet pattern must support the SpreadsheetItem pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Spreadsheet" and "SpreadsheetItem" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Spreadsheet" and "SpreadsheetItem" should not be translated (i.e. they should be treated as loanwords). {Locked="Spreadsheet", "SpreadsheetItem"}</comment>
   </data>
   <data name="ControlShouldSupportTableItemPattern" xml:space="preserve">
     <value>An element whose parent supports the Table pattern must support the TableItem pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Table" and "TableItem" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Table" and "TableItem" should not be translated (i.e. they should be treated as loanwords). {Locked="Table", "TableItem"}</comment>
   </data>
   <data name="ControlShouldSupportTablePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Table pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Table" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Table" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Table"}</comment>
   </data>
   <data name="ControlShouldSupportTextPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Text pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Table" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Table" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Table"}</comment>
   </data>
   <data name="ControlShouldSupportTogglePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Toggle pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Toggle" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "Toggle" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Toggle"}</comment>
   </data>
   <data name="ControlShouldSupportTransformPattern" xml:space="preserve">
     <value>An element that can be resized must support the Transform pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Transform" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Transform" should not be translated (i.e. it should be treated as a loanword). {Locked="Transform"}</comment>
   </data>
   <data name="ChildrenNotAllowedInContentView" xml:space="preserve">
     <value>A separator must not have any children with IsContentElement set to TRUE.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsContentElement"}</comment>
   </data>
   <data name="SelectionPatternSelectionRequired" xml:space="preserve">
     <value>An element of the given ControlType must have the IsSelectionRequired property set to TRUE.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsSelectionRequired" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsSelectionRequired" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "IsSelectionRequired"}</comment>
   </data>
   <data name="SelectionPatternSingleSelection" xml:space="preserve">
     <value>An element of the given ControlType must not support multiple selection.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "ControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "ControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="ControlType"}</comment>
   </data>
   <data name="SelectionItemPatternSingleSelection" xml:space="preserve">
     <value>An element whose parent supports single selection must not have selected siblings.</value>
@@ -343,7 +343,7 @@
   </data>
   <data name="ParentChildShouldNotHaveSameNameAndLocalizedControlType" xml:space="preserve">
     <value>An element must not have the same Name and LocalizedControlType as its parent.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords). {Locked="Name", "LocalizedControlType"}</comment>
   </data>
   <data name="SiblingUniqueAndFocusable" xml:space="preserve">
     <value>Focusable sibling elements must not have the same Name and LocalizedControlType.</value>
@@ -351,31 +351,31 @@
   </data>
   <data name="ControlShouldSupportSetInfo" xml:space="preserve">
     <value>The element's ControlType requires valid values for SizeOfSet and PositionInSet.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType", "SizeOfSet", and "PositionInSet" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType", "SizeOfSet", and "PositionInSet" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "SizeOfSet", "PositionInSet"}</comment>
   </data>
   <data name="BoundingRectangleCompletelyObscuresContainer" xml:space="preserve">
     <value>An element's BoundingRectangle must not obscure its container element.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="BoundingRectangleContainedInParent" xml:space="preserve">
     <value>An element's BoundingRectangle must be contained within its parent element.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="BoundingRectangleDataFormatCorrect" xml:space="preserve">
     <value>The BoundingRectangle property must return a valid rectangle.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="BoundingRectangleNotAllZeros" xml:space="preserve">
     <value>The BoundingRectangle property must not be defined as [0,0,0,0]</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="BoundingRectangleNotNull" xml:space="preserve">
     <value>An on-screen element must not have a null BoundingRectangle property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="BoundingRectangleSizeReasonable" xml:space="preserve">
     <value>The BoundingRectangle property must represent an area of at least 25 pixels.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="HeadingLevelDescendsWhenNested" xml:space="preserve">
     <value>An element's HeadingLevel must be greater than or equal to that of its ancestors.</value>
@@ -383,111 +383,111 @@
   </data>
   <data name="IsContentElementPropertyExists" xml:space="preserve">
     <value>The given ControlType must have a non-null IsContentElement property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsContentElement" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsContentElement" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "IsContentElement"}</comment>
   </data>
   <data name="IsControlElementPropertyExists" xml:space="preserve">
     <value>The given ControlType must have a non-null IsControlElement property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsControlElement" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsControlElement" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "IsControlElement"}</comment>
   </data>
   <data name="IsControlElementTrueRequired" xml:space="preserve">
     <value>The given ControlType must have the IsControlElement property set to TRUE.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsControlElement" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "IsControlElement" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "IsControlElement"}</comment>
   </data>
   <data name="LandmarkBannerIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "banner" must not descend from another landmark.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LandmarkComplementaryIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "complementary" must not descend from another landmark.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LandmarkContentInfoIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "contentinfo" must not descend from another landmark.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LandmarkMainIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "main" must not descend from another landmark.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LandmarkNoDuplicateBanner" xml:space="preserve">
     <value>A page must not have multiple elements with LocalizedLandmarkType "banner".</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LandmarkNoDuplicateContentInfo" xml:space="preserve">
     <value>A page must not have multiple elements with LocalizedLandmarkType "contentinfo".</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeIsReasonableLength" xml:space="preserve">
     <value>The LocalizedLandmarkType property must not be longer than 64 characters.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotCustom" xml:space="preserve">
     <value>The LandmarkType and LocalizedLandmarkType must not both be set to "custom".</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated (i.e. they should be treated as loanwords). {Locked="LandmarkType", "LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotEmpty" xml:space="preserve">
     <value>An element with LandmarkType set must not have an empty LocalizedLandmarkType.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated (i.e. they should be treated as loanwords). {Locked="LandmarkType", "LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotNull" xml:space="preserve">
     <value>An element with LandmarkType set must not have a null LocalizedLandmarkType.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "LandmarkType" and "LocalizedLandmarkType" should not be translated (i.e. they should be treated as loanwords). {Locked="LandmarkType", "LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotWhiteSpace" xml:space="preserve">
     <value>The LocalizedLandmarkType property must not contain only white space.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedLandmarkType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotCustom" xml:space="preserve">
     <value>The ControlType and LocalizedControlType must not both be set to "custom."</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "ControlType" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "LocalizedControlType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotEmpty" xml:space="preserve">
     <value>The LocalizedControlType property must not be an empty string.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotNull" xml:space="preserve">
     <value>The LocalizedControlType property must not be null.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotWhiteSpace" xml:space="preserve">
     <value>The LocalizedControlType property must not contain only white space.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="OrientationPropertyExists" xml:space="preserve">
     <value>Controls that can be horizontal or vertical must support the Orientation property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Orientation" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Orientation" should not be translated (i.e. it should be treated as a loanword). {Locked="Orientation"}</comment>
   </data>
   <data name="NameExcludesControlType" xml:space="preserve">
     <value>The Name property must not include the element's control type.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameExcludesLocalizedControlType" xml:space="preserve">
     <value>The Name must not include the same text as the LocalizedControlType.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The terms "Name" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords). {Locked="Name", "LocalizedControlType"}</comment>
   </data>
   <data name="NameIsInformative" xml:space="preserve">
     <value>The Name property of an element should not contain class names like 'Microsoft.*.*' or 'Windows.*.*' as these are not usually informative.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">
     <value>The Name property of a focusable element must not be an empty string.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameNotNull" xml:space="preserve">
     <value>The Name property of a focusable element must not be null.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameNotWhiteSpace" xml:space="preserve">
     <value>The Name property must not contain only space characters.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameReasonableLength" xml:space="preserve">
     <value>The Name property must not be longer than 512 characters.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="ListItemSiblingsUnique" xml:space="preserve">
     <value>The Name property of sibling list items should be unique.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="HyperlinkNameShouldBeUnique" xml:space="preserve">
     <value>Links with different purposes and destinations should have different names.</value>
@@ -503,7 +503,7 @@
   </data>
   <data name="ClickablePointOffScreen" xml:space="preserve">
     <value>An element's IsOffScreen property must be true when its clickable point is off-screen.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsOffScreen" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. The term "IsOffScreen" should not be translated (i.e. it should be treated as a loanword). {Locked="IsOffScreen"}</comment>
   </data>
   <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
     <value>The framework used to build this application does not support.</value>
@@ -518,7 +518,7 @@
 Description:    {1}
 HowToFix:    {2}
 Condition:  {3}</value>
-    <comment>{0} is id, {1} is description, {2} is how to fix, and {3} is condition</comment>
+    <comment>Developers: {0} is id, {1} is description, {2} is how to fix, and {3} is condition</comment>
   </data>
   <data name="ChromiumComponentsShouldUseWebScanner" xml:space="preserve">
     <value>Chromium components should be scanned with a web-based scanner.</value>

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -119,54 +119,54 @@
   </resheader>
   <data name="BoundingRectangleNotValidButOffScreen" xml:space="preserve">
     <value>Remove the BoundingRectangle property when the element is off-screen.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="ButtonWithSplitButtonParentPattern" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="SiblingUniqueAndNotFocusable" xml:space="preserve">
     <value>Verify that each element has a meaningful UI Automation Name property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
   </data>
   <data name="ComboBoxShouldNotSupportScrollPattern" xml:space="preserve">
     <value>Modify the combo box to not support the Scroll pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Scroll" should not be translated (i.e. it should be treated as a loanword). {Locked="Scroll"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Scroll"}</comment>
   </data>
   <data name="ControlShouldNotSupportValuePattern" xml:space="preserve">
     <value>Modify the element to not support the Value pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Value" should not be translated (i.e. it should be treated as a loanword). {Locked="Value"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Value"}</comment>
   </data>
   <data name="ControlShouldNotSupportWindowPattern" xml:space="preserve">
     <value>Modify the element to not support the Window pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Window" should not be translated (i.e. it should be treated as a loanword). {Locked="Window"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Window"}</comment>
   </data>
   <data name="HelpTextNotEqualToName" xml:space="preserve">
     <value>Write meaningful text for the element's UI Automation HelpText property. This text is typically similar to, or taken from, a tooltip or placeholder, such as "type here to search".</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "HelpText" should not be translated (i.e. it should be treated as a loanword). {Locked="HelpText"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="HelpText"}</comment>
   </data>
   <data name="IsContentElementFalseOptional" xml:space="preserve">
     <value>Set the IsContentElement UI Automation property to false.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsContentElement"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsContentElement"}</comment>
   </data>
   <data name="IsContentElementTrueOptional" xml:space="preserve">
     <value>Set the IsContentElement UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsContentElement"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsContentElement"}</comment>
   </data>
   <data name="IsControlElementTrueOptional" xml:space="preserve">
     <value>Set the IsControlElement UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsControlElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsControlElement"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsControlElement"}</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeTrue" xml:space="preserve">
     <value>Set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButDisabled" xml:space="preserve">
     <value>If this element is still reachable via the keyboard even when it is disabled, set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableForListItemShouldBeTrue" xml:space="preserve">
     <value>Make this element focusable instead of its children.</value>
@@ -174,63 +174,63 @@
   </data>
   <data name="IsKeyboardFocusableFalseButOffscreen" xml:space="preserve">
     <value>If this element is still reachable via the keyboard even when it is off-screen, set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableForCustomShouldBeTrue" xml:space="preserve">
     <value>Ensure that this element can be manipulated via the keyboard, then set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableDescendantTextPattern" xml:space="preserve">
     <value>Set the IsKeyboardFocusable property to be false.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "IsKeyboardFocusable" and "Text" should not be translated (i.e. they should be treated as loanwords). {Locked="IsKeyboardFocusable", "Text"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "Text"}</comment>
   </data>
   <data name="IsKeyboardFocusableOnEmptyContainer" xml:space="preserve">
     <value>If this container should be discoverable by keyboard users, set the IsKeyboardFocusable UI Automation property to true. Otherwise, consider changing the ControlType.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "IsKeyboardFocusable" and "ControlType" should not be translated (i.e. they should be treated as loanwords). {Locked="IsKeyboardFocusable", "ControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "ControlType"}</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeFalse" xml:space="preserve">
     <value>Set the IsKeyboardFocusable UI Automation property to false. If this element really should be reachable via the keyboard, verify its ControlType.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "IsKeyboardFocusable" and "ControlType" should not be translated (i.e. they should be treated as loanwords). {Locked="IsKeyboardFocusable", "ControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "ControlType"}</comment>
   </data>
   <data name="IsKeyboardFocusableTopLevelTextPattern" xml:space="preserve">
     <value>Set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="ItemStatusExists" xml:space="preserve">
     <value>Add a meaningful ItemStatus UI Automation property to this element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ItemStatus" should not be translated (i.e. it should be treated as a loanword). {Locked="ItemStatus"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ItemStatus"}</comment>
   </data>
   <data name="LocalizedControlTypeReasonable" xml:space="preserve">
     <value>Set a meaningful LocalizedControlType UI Automation property for this element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="ItemTypeRecommended" xml:space="preserve">
     <value>If necessary, set the ItemType UI Automation property for this element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ItemType" should not be translated (i.e. it should be treated as a loanword). {Locked="ItemType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ItemType"}</comment>
   </data>
   <data name="NameEmptyButElementNotKeyboardFocusable" xml:space="preserve">
     <value>Set the UI Automation Name property for the given element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
   </data>
   <data name="NameNoSiblingsOfSameType" xml:space="preserve">
     <value>Set the UI Automation Name property of this element to be null or empty if the element has no siblings of the same type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
   </data>
   <data name="NameNullButElementNotKeyboardFocusable" xml:space="preserve">
     <value>Set the UI Automation Name property for the given element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
   </data>
   <data name="NameOnCustomWithParentWPFDataItem" xml:space="preserve">
     <value>Set the UI Automation Name property of this custom control to be empty.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Name" and "dataitem" should not be translated (i.e. they should be treated as loanwords). {Locked="Name", "DataItem"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
   </data>
   <data name="NameOnOptionalType" xml:space="preserve">
     <value>Remove the UI Automation Name property for this element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
   </data>
   <data name="NameWithValidBoundingRectangle" xml:space="preserve">
     <value>Modify the UI Automation Name property to have a valid BoundingRectangle (i.e. the BoundingRectangle is not null and has area).</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Name" and "BoundingRectangle" should not be translated (i.e. they should be treated as loanwords). {Locked="Name", "BoundingRectangle"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "BoundingRectangle"}</comment>
   </data>
   <data name="Structure" xml:space="preserve">
     <value>Set the element to conform to the following structure: {0}.</value>
@@ -238,155 +238,155 @@
   </data>
   <data name="SelectionPatternSelectionRequired" xml:space="preserve">
     <value>Set the element's IsSelectionRequired property of the SelectionPattern to TRUE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "IsSelectionRequired" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "IsSelectionRequired"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType", "IsSelectionRequired"}</comment>
   </data>
   <data name="ButtonInvokeAndExpandCollapsePatterns" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="ButtonShouldHavePatterns" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="ButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="ButtonToggleAndExpandCollapsePatterns" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="ProgressBarRangeValue" xml:space="preserve">
     <value>Implement the progress bar's RangeValue pattern using the following properties and values:
  · Minimum: 0.0
  · Maximum: 100.0
  · IsReadOnly: TRUE</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "RangeValue", "Minimum", "Maximum", and "IsReadOnly" should not be translated (i.e. they should be treated as loanwords). {Locked="RangeValue", "Minimum", "Maximum", "IsReadOnly"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="RangeValue", "Minimum", "Maximum", "IsReadOnly"}</comment>
   </data>
   <data name="EditSupportsIncorrectRangeValuePattern" xml:space="preserve">
     <value>Implement the edit control's RangeValue pattern with a null LargeChange property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "RangeValue" and "LargeChange" should not be translated (i.e. they should be treated as loanwords). {Locked="RangeValue", "LargeChange"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="RangeValue", "LargeChange"}</comment>
   </data>
   <data name="SplitButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>Modify the split button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke" and "Toggle" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Invoke", "Toggle"}</comment>
   </data>
   <data name="ControlShouldNotSupportInvokePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Modify the element to support only its allowed patterns.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="ControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType"}</comment>
   </data>
   <data name="ControlShouldNotSupportScrollPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Modify the element to support only its allowed patterns.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="ControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType"}</comment>
   </data>
   <data name="ControlShouldNotSupportTogglePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Modify the element to support only its allowed patterns.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="ControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType"}</comment>
   </data>
   <data name="ControlShouldSupportExpandCollapsePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the ExpandCollapse pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "ExpandCollapse"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType", "ExpandCollapse"}</comment>
   </data>
   <data name="ControlShouldSupportGridItemPattern" xml:space="preserve">
     <value>Modify the element (or one of its children) to support the GridItem pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "GridItem" should not be translated (i.e. it should be treated as a loanword). {Locked="GridItem"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="GridItem"}</comment>
   </data>
   <data name="ControlShouldSupportGridPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Grid pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Grid" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Grid"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType", "Grid"}</comment>
   </data>
   <data name="ControlShouldSupportInvokePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Invoke pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Invoke" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Invoke"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType", "Invoke"}</comment>
   </data>
   <data name="ControlShouldSupportScrollItemPattern" xml:space="preserve">
     <value>Modify the element (or one of its children) to support the ScrollItem pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ScrollItem" should not be translated (i.e. it should be treated as a loanword). {Locked="ScrollItem"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ScrollItem"}</comment>
   </data>
   <data name="ControlShouldSupportSelectionItemPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the SelectionItem pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "SelectionItem" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "SelectionItem"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType", "SelectionItem"}</comment>
   </data>
   <data name="ControlShouldSupportSelectionPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Selection pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Selection" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Selection"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType", "Selection"}</comment>
   </data>
   <data name="ControlShouldSupportSpreadsheetItemPattern" xml:space="preserve">
     <value>Modify the element (or one of its children) to support the SpreadsheetItem pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "SpreadsheetItem" should not be translated (i.e. it should be treated as a loanword). {Locked="SpreadsheetItem"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="SpreadsheetItem"}</comment>
   </data>
   <data name="ControlShouldSupportTableItemPattern" xml:space="preserve">
     <value>Modify the element (or one of its children) to support the TableItem pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "TableItem" should not be translated (i.e. it should be treated as a loanword). {Locked="TableItem"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="TableItem"}</comment>
   </data>
   <data name="ControlShouldSupportTablePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Table pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Table" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Table"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType", "Table"}</comment>
   </data>
   <data name="ControlShouldSupportTextPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Text pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Text" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Text"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType", "Text"}</comment>
   </data>
   <data name="ControlShouldSupportTogglePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Toggle pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Toggle" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Toggle"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType", "Toggle"}</comment>
   </data>
   <data name="ControlShouldSupportTransformPattern" xml:space="preserve">
     <value>If the element can be resized, implement the Transform pattern.
 If the element can't be resized, ensure the TransformPattern_CanResize property is FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Transform" and "TransformPattern_CanResize" should not be translated (i.e. they should be treated as loanwords). {Locked="Transform", "TransformPattern_CanResize"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Transform", "TransformPattern_CanResize"}</comment>
   </data>
   <data name="ChildrenNotAllowedInContentView" xml:space="preserve">
     <value>Make sure all of the element's children have the IsContentElement property set to FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsContentElement"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsContentElement"}</comment>
   </data>
   <data name="SelectionPatternSingleSelection" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Make sure Selection is the correct pattern.
 3. Set the element's CanSelectMultiple property to FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType", "Selection", and "CanSelectMultiple" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Selection", "CanSelectMultiple"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType", "Selection", "CanSelectMultiple"}</comment>
   </data>
   <data name="SelectionItemPatternSingleSelection" xml:space="preserve">
     <value>Do one of the following:
  1. Modify the element and/or its siblings so that only one of them is selected at any given time, OR
  2. Modify the parent element so its CanSelectMultiple property is TRUE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "CanSelectMultiple" should not be translated (i.e. it should be treated as a loanword). {Locked="CanSelectMultiple"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="CanSelectMultiple"}</comment>
   </data>
   <data name="ParentChildShouldNotHaveSameNameAndLocalizedControlType" xml:space="preserve">
     <value>Provide unique names for controls that have a parent/child relationship and the same ControlType property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="ControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType"}</comment>
   </data>
   <data name="SiblingUniqueAndFocusable" xml:space="preserve">
     <value>Provide unique names for sibling controls that have the same ControlType property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="ControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType"}</comment>
   </data>
   <data name="ControlShouldSupportSetInfo" xml:space="preserve">
     <value>Provide valid values for the SizeOfSet and PositionInSet properties.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "SizeOfSet" and "PositionInSet" should not be translated (i.e. they should be treated as loanwords). {Locked="SizeOfSet", "PositionInSet"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="SizeOfSet", "PositionInSet"}</comment>
   </data>
   <data name="BoundingRectangleCompletelyObscuresContainer" xml:space="preserve">
     <value>Modify one or both bounding rectangles to ensure that the bounding rectangle of the container element is not completely obscured.</value>
@@ -404,7 +404,7 @@ If the element can't be resized, ensure the TransformPattern_CanResize property 
     b. Left edge
     c. Width
     d. Height</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="BoundingRectangleNotAllZeros" xml:space="preserve">
     <value>Specify the rectangle's position and size (in pixels) by providing array values in the following order:
@@ -417,11 +417,11 @@ If the element can't be resized, ensure the TransformPattern_CanResize property 
   <data name="BoundingRectangleNotNull" xml:space="preserve">
     <value>If the element is off-screen, set its IsOffscreen property to TRUE.
 If the element is on-screen, provide a BoundingRectangle property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "IsOffscreen" and "BoundingRectangle" should not be translated (i.e. they should be treated as loanwords). {Locked="IsOffscreen", "BoundingRectangle"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsOffscreen", "BoundingRectangle"}</comment>
   </data>
   <data name="BoundingRectangleSizeReasonable" xml:space="preserve">
     <value>Modify the BoundingRectangle property so that its width and height define an area of at least 25 pixels.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="HeadingLevelDescendsWhenNested" xml:space="preserve">
     <value>Modify the heading levels and/or nesting structure of the element and/or its ancestors.
@@ -432,17 +432,17 @@ For example, if an element has a level-5 heading, its descendants can have only 
     <value>Provide a value for the element's IsContentElement property:
  · If the element should be included in the content view, set the property to TRUE.
  · If the element should not be included in the content view, set the property to FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsContentElement"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsContentElement"}</comment>
   </data>
   <data name="IsControlElementPropertyExists" xml:space="preserve">
     <value>Provide a value for the element's IsControlElement property:
  · If the element should be included in the control view, set the property to TRUE.
  · If the element should not be included in the control view, set the property to FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsControlElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsControlElement"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsControlElement"}</comment>
   </data>
   <data name="IsControlElementTrueRequired" xml:space="preserve">
     <value>Set the element's IsControlElement property to TRUE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsControlElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsControlElement"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsControlElement"}</comment>
   </data>
   <data name="LandmarkBannerIsTopLevel" xml:space="preserve">
     <value>Modify the banner element so it does not descend from any other landmark.
@@ -484,7 +484,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotCustom" xml:space="preserve">
     <value>Provide string for the LocalizedLandmarkType property that does not include "custom."
@@ -497,7 +497,7 @@ Where appropriate, use a standard localized landmark type:
     ·         Use "navigation" for an area containing links for page or site navigation.
     ·         Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotEmpty" xml:space="preserve">
     <value>Provide a string for the LocalizedLandmarkType property.
@@ -510,7 +510,7 @@ Where appropriate, use a standard localized landmark type:
     ·         Use "navigation" for an area containing links for page or site navigation.
     ·         Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotNull" xml:space="preserve">
     <value>Provide a LocalizedLandmarkType property for the element.
@@ -523,7 +523,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotWhiteSpace" xml:space="preserve">
     <value>Provide a string for the LocalizedLandmarkType property.
@@ -536,7 +536,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotCustom" xml:space="preserve">
     <value>Sufficient:
@@ -544,7 +544,7 @@ Provide a string for the LocalizedControlType property that concisely describes 
 
 Better:
 If possible, use a predefined (non-custom) control type and the default localized control type. The UIA framework will provide the correct localized control type automatically.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotCustomWPFGridCell" xml:space="preserve">
     <value>{0}
@@ -554,55 +554,55 @@ If your application targets a version of .NET Framework before 4.7.1, but is run
   </data>
   <data name="LocalizedControlTypeNotEmpty" xml:space="preserve">
     <value>Provide a string for the LocalizedControlType property that concisely describes the control's type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotNull" xml:space="preserve">
     <value>Provide a string for the LocalizedControlType property that concisely describes the control's type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotWhiteSpace" xml:space="preserve">
     <value>Provide a string for the LocalizedControlType property that concisely describes the control's type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="OrientationPropertyExists" xml:space="preserve">
     <value>Provide an Orientation property for the element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Orientation" should not be translated (i.e. it should be treated as a loanword). {Locked="Orientation"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Orientation"}</comment>
   </data>
   <data name="NameExcludesControlType" xml:space="preserve">
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the control type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
   </data>
   <data name="NameExcludesLocalizedControlType" xml:space="preserve">
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the same text as the element's LocalizedControlType property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "name" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords). {Locked="Name", "LocalizedControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "LocalizedControlType"}</comment>
   </data>
   <data name="NameIsInformative" xml:space="preserve">
     <value>Examine the UI Automation Name property of this element:
  · If the Name property contains "Microsoft" or "Windows" and is closely related to the on-screen text (for example, a reference to "Microsoft.com"), you may safely ignore this issue.
  · If the Name property is not closely related to the on-screen text (and provides no meaningful information to end-users), update the Name to a concise, user-facing label that is closely related to the on-screen text.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">
     <value>Provide a UI Automation Name property that concisely identifies the element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
   </data>
   <data name="NameNotNull" xml:space="preserve">
     <value>Provide a UI Automation Name property that concisely identifies the element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
   </data>
   <data name="NameNotWhiteSpace" xml:space="preserve">
     <value>Provide a UI Automation Name property that concisely identifies the element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
   </data>
   <data name="NameReasonableLength" xml:space="preserve">
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Contains at most 512 characters.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
   </data>
   <data name="ListItemSiblingsUnique" xml:space="preserve">
     <value>Provide unique names for sibling list items.</value>
@@ -619,12 +619,12 @@ If your application targets a version of .NET Framework before 4.7.1, but is run
   <data name="ClickablePointOnScreen" xml:space="preserve">
     <value>If the element's ClickablePoint property is correct, set the element's IsOffScreen property to false.
 If the element's ClickablePoint property is incorrect, please ensure it returns the correct value.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ClickablePoint" and "IsOffscreen" should not be translated (i.e. they should be treated as loanwords). {Locked="ClickablePoint", "IsOffscreen"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ClickablePoint", "IsOffscreen"}</comment>
   </data>
   <data name="ClickablePointOffScreen" xml:space="preserve">
     <value>If the element's ClickablePoint property is correct, set the element's IsOffScreen property to true.
 If the element's ClickablePoint property is incorrect, please ensure it returns the correct value.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ClickablePoint" and "IsOffscreen" should not be translated (i.e. they should be treated as loanwords). {Locked="ClickablePoint", "IsOffscreen"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ClickablePoint", "IsOffscreen"}</comment>
   </data>
   <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
     <value>Switch your application to a framework that supports UI Automation.</value>

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -636,6 +636,6 @@ If the element's ClickablePoint property is incorrect, please ensure it returns 
   </data>
   <data name="ChromiumComponentsShouldUseWebScanner" xml:space="preserve">
     <value>Use a web-based scanner (for example, Accessibility Insights for Web) to scan this component.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Accessibility Insights for Web" is a product name that should not be translated. {Locked="Accessibility Insights for Web"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Accessibility Insights for Web"}</comment>
   </data>
 </root>

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -119,54 +119,54 @@
   </resheader>
   <data name="BoundingRectangleNotValidButOffScreen" xml:space="preserve">
     <value>Remove the BoundingRectangle property when the element is off-screen.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="ButtonWithSplitButtonParentPattern" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="SiblingUniqueAndNotFocusable" xml:space="preserve">
     <value>Verify that each element has a meaningful UI Automation Name property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="ComboBoxShouldNotSupportScrollPattern" xml:space="preserve">
     <value>Modify the combo box to not support the Scroll pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Scroll" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Scroll" should not be translated (i.e. it should be treated as a loanword). {Locked="Scroll"}</comment>
   </data>
   <data name="ControlShouldNotSupportValuePattern" xml:space="preserve">
     <value>Modify the element to not support the Value pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Value" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Value" should not be translated (i.e. it should be treated as a loanword). {Locked="Value"}</comment>
   </data>
   <data name="ControlShouldNotSupportWindowPattern" xml:space="preserve">
     <value>Modify the element to not support the Window pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Window" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Window" should not be translated (i.e. it should be treated as a loanword). {Locked="Window"}</comment>
   </data>
   <data name="HelpTextNotEqualToName" xml:space="preserve">
     <value>Write meaningful text for the element's UI Automation HelpText property. This text is typically similar to, or taken from, a tooltip or placeholder, such as "type here to search".</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "HelpText" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "HelpText" should not be translated (i.e. it should be treated as a loanword). {Locked="HelpText"}</comment>
   </data>
   <data name="IsContentElementFalseOptional" xml:space="preserve">
     <value>Set the IsContentElement UI Automation property to false.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsContentElement"}</comment>
   </data>
   <data name="IsContentElementTrueOptional" xml:space="preserve">
     <value>Set the IsContentElement UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsContentElement"}</comment>
   </data>
   <data name="IsControlElementTrueOptional" xml:space="preserve">
     <value>Set the IsControlElement UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsControlElement" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsControlElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsControlElement"}</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeTrue" xml:space="preserve">
     <value>Set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButDisabled" xml:space="preserve">
     <value>If this element is still reachable via the keyboard even when it is disabled, set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableForListItemShouldBeTrue" xml:space="preserve">
     <value>Make this element focusable instead of its children.</value>
@@ -174,63 +174,63 @@
   </data>
   <data name="IsKeyboardFocusableFalseButOffscreen" xml:space="preserve">
     <value>If this element is still reachable via the keyboard even when it is off-screen, set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableForCustomShouldBeTrue" xml:space="preserve">
     <value>Ensure that this element can be manipulated via the keyboard, then set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableDescendantTextPattern" xml:space="preserve">
     <value>Set the IsKeyboardFocusable property to be false.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "IsKeyboardFocusable" and "Text" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "IsKeyboardFocusable" and "Text" should not be translated (i.e. they should be treated as loanwords). {Locked="IsKeyboardFocusable", "Text"}</comment>
   </data>
   <data name="IsKeyboardFocusableOnEmptyContainer" xml:space="preserve">
     <value>If this container should be discoverable by keyboard users, set the IsKeyboardFocusable UI Automation property to true. Otherwise, consider changing the ControlType.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "IsKeyboardFocusable" and "ControlType" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "IsKeyboardFocusable" and "ControlType" should not be translated (i.e. they should be treated as loanwords). {Locked="IsKeyboardFocusable", "ControlType"}</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeFalse" xml:space="preserve">
     <value>Set the IsKeyboardFocusable UI Automation property to false. If this element really should be reachable via the keyboard, verify its ControlType.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "IsKeyboardFocusable" and "ControlType" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "IsKeyboardFocusable" and "ControlType" should not be translated (i.e. they should be treated as loanwords). {Locked="IsKeyboardFocusable", "ControlType"}</comment>
   </data>
   <data name="IsKeyboardFocusableTopLevelTextPattern" xml:space="preserve">
     <value>Set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsKeyboardFocusable" should not be translated (i.e. it should be treated as a loanword). {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="ItemStatusExists" xml:space="preserve">
     <value>Add a meaningful ItemStatus UI Automation property to this element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ItemStatus" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ItemStatus" should not be translated (i.e. it should be treated as a loanword). {Locked="ItemStatus"}</comment>
   </data>
   <data name="LocalizedControlTypeReasonable" xml:space="preserve">
     <value>Set a meaningful LocalizedControlType UI Automation property for this element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="ItemTypeRecommended" xml:space="preserve">
     <value>If necessary, set the ItemType UI Automation property for this element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ItemType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ItemType" should not be translated (i.e. it should be treated as a loanword). {Locked="ItemType"}</comment>
   </data>
   <data name="NameEmptyButElementNotKeyboardFocusable" xml:space="preserve">
     <value>Set the UI Automation Name property for the given element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameNoSiblingsOfSameType" xml:space="preserve">
     <value>Set the UI Automation Name property of this element to be null or empty if the element has no siblings of the same type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameNullButElementNotKeyboardFocusable" xml:space="preserve">
     <value>Set the UI Automation Name property for the given element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" (with uppercase N) should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameOnCustomWithParentWPFDataItem" xml:space="preserve">
     <value>Set the UI Automation Name property of this custom control to be empty.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Name" and "dataitem" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Name" and "dataitem" should not be translated (i.e. they should be treated as loanwords). {Locked="Name", "DataItem"}</comment>
   </data>
   <data name="NameOnOptionalType" xml:space="preserve">
     <value>Remove the UI Automation Name property for this element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameWithValidBoundingRectangle" xml:space="preserve">
     <value>Modify the UI Automation Name property to have a valid BoundingRectangle (i.e. the BoundingRectangle is not null and has area).</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Name" and "BoundingRectangle" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Name" and "BoundingRectangle" should not be translated (i.e. they should be treated as loanwords). {Locked="Name", "BoundingRectangle"}</comment>
   </data>
   <data name="Structure" xml:space="preserve">
     <value>Set the element to conform to the following structure: {0}.</value>
@@ -238,155 +238,155 @@
   </data>
   <data name="SelectionPatternSelectionRequired" xml:space="preserve">
     <value>Set the element's IsSelectionRequired property of the SelectionPattern to TRUE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "IsSelectionRequired" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "IsSelectionRequired" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "IsSelectionRequired"}</comment>
   </data>
   <data name="ButtonInvokeAndExpandCollapsePatterns" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="ButtonShouldHavePatterns" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="ButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="ButtonToggleAndExpandCollapsePatterns" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke", "Toggle", and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="ProgressBarRangeValue" xml:space="preserve">
     <value>Implement the progress bar's RangeValue pattern using the following properties and values:
  · Minimum: 0.0
  · Maximum: 100.0
  · IsReadOnly: TRUE</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "RangeValue", "Minimum", "Maximum", and "IsReadOnly" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "RangeValue", "Minimum", "Maximum", and "IsReadOnly" should not be translated (i.e. they should be treated as loanwords). {Locked="RangeValue", "Minimum", "Maximum", "IsReadOnly"}</comment>
   </data>
   <data name="EditSupportsIncorrectRangeValuePattern" xml:space="preserve">
     <value>Implement the edit control's RangeValue pattern with a null LargeChange property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "RangeValue" and "LargeChange" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "RangeValue" and "LargeChange" should not be translated (i.e. they should be treated as loanwords). {Locked="RangeValue", "LargeChange"}</comment>
   </data>
   <data name="SplitButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>Modify the split button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the Toggle pattern if the button can cycle through a series of up to three states.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke" and "Toggle" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Invoke" and "Toggle" should not be translated (i.e. they should be treated as loanwords). {Locked="Invoke", "Toggle"}</comment>
   </data>
   <data name="ControlShouldNotSupportInvokePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Modify the element to support only its allowed patterns.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="ControlType"}</comment>
   </data>
   <data name="ControlShouldNotSupportScrollPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Modify the element to support only its allowed patterns.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="ControlType"}</comment>
   </data>
   <data name="ControlShouldNotSupportTogglePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Modify the element to support only its allowed patterns.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="ControlType"}</comment>
   </data>
   <data name="ControlShouldSupportExpandCollapsePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the ExpandCollapse pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "ExpandCollapse" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "ExpandCollapse"}</comment>
   </data>
   <data name="ControlShouldSupportGridItemPattern" xml:space="preserve">
     <value>Modify the element (or one of its children) to support the GridItem pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "GridItem" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "GridItem" should not be translated (i.e. it should be treated as a loanword). {Locked="GridItem"}</comment>
   </data>
   <data name="ControlShouldSupportGridPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Grid pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Grid" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Grid" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Grid"}</comment>
   </data>
   <data name="ControlShouldSupportInvokePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Invoke pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Invoke" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Invoke" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Invoke"}</comment>
   </data>
   <data name="ControlShouldSupportScrollItemPattern" xml:space="preserve">
     <value>Modify the element (or one of its children) to support the ScrollItem pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ScrollItem" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ScrollItem" should not be translated (i.e. it should be treated as a loanword). {Locked="ScrollItem"}</comment>
   </data>
   <data name="ControlShouldSupportSelectionItemPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the SelectionItem pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "SelectionItem" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "SelectionItem" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "SelectionItem"}</comment>
   </data>
   <data name="ControlShouldSupportSelectionPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Selection pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Selection" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Selection" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Selection"}</comment>
   </data>
   <data name="ControlShouldSupportSpreadsheetItemPattern" xml:space="preserve">
     <value>Modify the element (or one of its children) to support the SpreadsheetItem pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "SpreadsheetItem" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "SpreadsheetItem" should not be translated (i.e. it should be treated as a loanword). {Locked="SpreadsheetItem"}</comment>
   </data>
   <data name="ControlShouldSupportTableItemPattern" xml:space="preserve">
     <value>Modify the element (or one of its children) to support the TableItem pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "TableItem" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "TableItem" should not be translated (i.e. it should be treated as a loanword). {Locked="TableItem"}</comment>
   </data>
   <data name="ControlShouldSupportTablePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Table pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Table" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Table" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Table"}</comment>
   </data>
   <data name="ControlShouldSupportTextPattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Text pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Text" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Text" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Text"}</comment>
   </data>
   <data name="ControlShouldSupportTogglePattern" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. If the current ControlType is correct, modify the element to support the Toggle pattern.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Toggle" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType" and "Toggle" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Toggle"}</comment>
   </data>
   <data name="ControlShouldSupportTransformPattern" xml:space="preserve">
     <value>If the element can be resized, implement the Transform pattern.
 If the element can't be resized, ensure the TransformPattern_CanResize property is FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "Transform" and "TransformPattern_CanResize" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "Transform" and "TransformPattern_CanResize" should not be translated (i.e. they should be treated as loanwords). {Locked="Transform", "TransformPattern_CanResize"}</comment>
   </data>
   <data name="ChildrenNotAllowedInContentView" xml:space="preserve">
     <value>Make sure all of the element's children have the IsContentElement property set to FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsContentElement"}</comment>
   </data>
   <data name="SelectionPatternSingleSelection" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Make sure Selection is the correct pattern.
 3. Set the element's CanSelectMultiple property to FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType", "Selection", and "CanSelectMultiple" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ControlType", "Selection", and "CanSelectMultiple" should not be translated (i.e. they should be treated as loanwords). {Locked="ControlType", "Selection", "CanSelectMultiple"}</comment>
   </data>
   <data name="SelectionItemPatternSingleSelection" xml:space="preserve">
     <value>Do one of the following:
  1. Modify the element and/or its siblings so that only one of them is selected at any given time, OR
  2. Modify the parent element so its CanSelectMultiple property is TRUE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "CanSelectMultiple" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "CanSelectMultiple" should not be translated (i.e. it should be treated as a loanword). {Locked="CanSelectMultiple"}</comment>
   </data>
   <data name="ParentChildShouldNotHaveSameNameAndLocalizedControlType" xml:space="preserve">
     <value>Provide unique names for controls that have a parent/child relationship and the same ControlType property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="ControlType"}</comment>
   </data>
   <data name="SiblingUniqueAndFocusable" xml:space="preserve">
     <value>Provide unique names for sibling controls that have the same ControlType property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "ControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="ControlType"}</comment>
   </data>
   <data name="ControlShouldSupportSetInfo" xml:space="preserve">
     <value>Provide valid values for the SizeOfSet and PositionInSet properties.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "SizeOfSet" and "PositionInSet" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "SizeOfSet" and "PositionInSet" should not be translated (i.e. they should be treated as loanwords). {Locked="SizeOfSet", "PositionInSet"}</comment>
   </data>
   <data name="BoundingRectangleCompletelyObscuresContainer" xml:space="preserve">
     <value>Modify one or both bounding rectangles to ensure that the bounding rectangle of the container element is not completely obscured.</value>
@@ -404,7 +404,7 @@ If the element can't be resized, ensure the TransformPattern_CanResize property 
     b. Left edge
     c. Width
     d. Height</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="BoundingRectangleNotAllZeros" xml:space="preserve">
     <value>Specify the rectangle's position and size (in pixels) by providing array values in the following order:
@@ -417,11 +417,11 @@ If the element can't be resized, ensure the TransformPattern_CanResize property 
   <data name="BoundingRectangleNotNull" xml:space="preserve">
     <value>If the element is off-screen, set its IsOffscreen property to TRUE.
 If the element is on-screen, provide a BoundingRectangle property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "IsOffscreen" and "BoundingRectangle" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "IsOffscreen" and "BoundingRectangle" should not be translated (i.e. they should be treated as loanwords). {Locked="IsOffscreen", "BoundingRectangle"}</comment>
   </data>
   <data name="BoundingRectangleSizeReasonable" xml:space="preserve">
     <value>Modify the BoundingRectangle property so that its width and height define an area of at least 25 pixels.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "BoundingRectangle" should not be translated (i.e. it should be treated as a loanword). {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="HeadingLevelDescendsWhenNested" xml:space="preserve">
     <value>Modify the heading levels and/or nesting structure of the element and/or its ancestors.
@@ -432,17 +432,17 @@ For example, if an element has a level-5 heading, its descendants can have only 
     <value>Provide a value for the element's IsContentElement property:
  · If the element should be included in the content view, set the property to TRUE.
  · If the element should not be included in the content view, set the property to FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsContentElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsContentElement"}</comment>
   </data>
   <data name="IsControlElementPropertyExists" xml:space="preserve">
     <value>Provide a value for the element's IsControlElement property:
  · If the element should be included in the control view, set the property to TRUE.
  · If the element should not be included in the control view, set the property to FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsControlElement" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsControlElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsControlElement"}</comment>
   </data>
   <data name="IsControlElementTrueRequired" xml:space="preserve">
     <value>Set the element's IsControlElement property to TRUE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "IsControlElement" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "IsControlElement" should not be translated (i.e. it should be treated as a loanword). {Locked="IsControlElement"}</comment>
   </data>
   <data name="LandmarkBannerIsTopLevel" xml:space="preserve">
     <value>Modify the banner element so it does not descend from any other landmark.
@@ -484,7 +484,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotCustom" xml:space="preserve">
     <value>Provide string for the LocalizedLandmarkType property that does not include "custom."
@@ -497,7 +497,7 @@ Where appropriate, use a standard localized landmark type:
     ·         Use "navigation" for an area containing links for page or site navigation.
     ·         Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotEmpty" xml:space="preserve">
     <value>Provide a string for the LocalizedLandmarkType property.
@@ -510,7 +510,7 @@ Where appropriate, use a standard localized landmark type:
     ·         Use "navigation" for an area containing links for page or site navigation.
     ·         Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotNull" xml:space="preserve">
     <value>Provide a LocalizedLandmarkType property for the element.
@@ -523,7 +523,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotWhiteSpace" xml:space="preserve">
     <value>Provide a string for the LocalizedLandmarkType property.
@@ -536,7 +536,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedLandmarkType" (written without spaces) should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotCustom" xml:space="preserve">
     <value>Sufficient:
@@ -544,7 +544,7 @@ Provide a string for the LocalizedControlType property that concisely describes 
 
 Better:
 If possible, use a predefined (non-custom) control type and the default localized control type. The UIA framework will provide the correct localized control type automatically.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotCustomWPFGridCell" xml:space="preserve">
     <value>{0}
@@ -554,55 +554,55 @@ If your application targets a version of .NET Framework before 4.7.1, but is run
   </data>
   <data name="LocalizedControlTypeNotEmpty" xml:space="preserve">
     <value>Provide a string for the LocalizedControlType property that concisely describes the control's type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotNull" xml:space="preserve">
     <value>Provide a string for the LocalizedControlType property that concisely describes the control's type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotWhiteSpace" xml:space="preserve">
     <value>Provide a string for the LocalizedControlType property that concisely describes the control's type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "LocalizedControlType" should not be translated (i.e. it should be treated as a loanword). {Locked="LocalizedControlType"}</comment>
   </data>
   <data name="OrientationPropertyExists" xml:space="preserve">
     <value>Provide an Orientation property for the element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Orientation" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Orientation" should not be translated (i.e. it should be treated as a loanword). {Locked="Orientation"}</comment>
   </data>
   <data name="NameExcludesControlType" xml:space="preserve">
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the control type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameExcludesLocalizedControlType" xml:space="preserve">
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the same text as the element's LocalizedControlType property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "name" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "name" and "LocalizedControlType" should not be translated (i.e. they should be treated as loanwords). {Locked="Name", "LocalizedControlType"}</comment>
   </data>
   <data name="NameIsInformative" xml:space="preserve">
     <value>Examine the UI Automation Name property of this element:
  · If the Name property contains "Microsoft" or "Windows" and is closely related to the on-screen text (for example, a reference to "Microsoft.com"), you may safely ignore this issue.
  · If the Name property is not closely related to the on-screen text (and provides no meaningful information to end-users), update the Name to a concise, user-facing label that is closely related to the on-screen text.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">
     <value>Provide a UI Automation Name property that concisely identifies the element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameNotNull" xml:space="preserve">
     <value>Provide a UI Automation Name property that concisely identifies the element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameNotWhiteSpace" xml:space="preserve">
     <value>Provide a UI Automation Name property that concisely identifies the element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="NameReasonableLength" xml:space="preserve">
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Contains at most 512 characters.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Name" should not be translated (i.e. it should be treated as a loanword). {Locked="Name"}</comment>
   </data>
   <data name="ListItemSiblingsUnique" xml:space="preserve">
     <value>Provide unique names for sibling list items.</value>
@@ -619,12 +619,12 @@ If your application targets a version of .NET Framework before 4.7.1, but is run
   <data name="ClickablePointOnScreen" xml:space="preserve">
     <value>If the element's ClickablePoint property is correct, set the element's IsOffScreen property to false.
 If the element's ClickablePoint property is incorrect, please ensure it returns the correct value.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ClickablePoint" and "IsOffscreen" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ClickablePoint" and "IsOffscreen" should not be translated (i.e. they should be treated as loanwords). {Locked="ClickablePoint", "IsOffscreen"}</comment>
   </data>
   <data name="ClickablePointOffScreen" xml:space="preserve">
     <value>If the element's ClickablePoint property is correct, set the element's IsOffScreen property to true.
 If the element's ClickablePoint property is incorrect, please ensure it returns the correct value.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The terms "ClickablePoint" and "IsOffscreen" should not be translated (i.e. they should be treated as loanwords).</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The terms "ClickablePoint" and "IsOffscreen" should not be translated (i.e. they should be treated as loanwords). {Locked="ClickablePoint", "IsOffscreen"}</comment>
   </data>
   <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
     <value>Switch your application to a framework that supports UI Automation.</value>
@@ -636,6 +636,6 @@ If the element's ClickablePoint property is incorrect, please ensure it returns 
   </data>
   <data name="ChromiumComponentsShouldUseWebScanner" xml:space="preserve">
     <value>Use a web-based scanner (for example, Accessibility Insights for Web) to scan this component.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. The term "Accessibility Insights for Web" is a product name that should not be translated.</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The term "Accessibility Insights for Web" is a product name that should not be translated. {Locked="Accessibility Insights for Web"}</comment>
   </data>
 </root>


### PR DESCRIPTION
#### Details
This PR adds (machine-readable) annotations to relevant translator comments to prevent the localization of technical terms and product names.

##### Motivation
[Bug 802071](https://dev.azure.com/ceapex/CEINTL/_workitems/edit/802071) (internal access required to view).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
