### PR TITLE
fix: Skip English-specific rules on non-English systems

### DIFF
--- a/src/Rules/Library/LocalizedControlTypeIsReasonable.cs
+++ b/src/Rules/Library/LocalizedControlTypeIsReasonable.cs
@@ -8,6 +8,7 @@ using Axe.Windows.Rules.Resources;
 using System;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.StringProperties;
+using static Axe.Windows.Rules.PropertyConditions.SystemProperties;
 
 namespace Axe.Windows.Rules.Library
 {
@@ -174,7 +175,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return ~Custom & LocalizedControlType.NotNullOrEmpty & LocalizedControlType.NotWhiteSpace;
+            return IsEnglish & ~Custom & LocalizedControlType.NotNullOrEmpty & LocalizedControlType.NotWhiteSpace;
         }
     } // class
 } // namespace

--- a/src/Rules/PropertyConditions/SystemProperties.cs
+++ b/src/Rules/PropertyConditions/SystemProperties.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Axe.Windows.Rules.PropertyConditions
+{
+    static class SystemProperties
+    {
+        private static string SystemCultureName = System.Globalization.CultureInfo.CurrentCulture.Name;
+
+        internal static string OverriddenCultureName { get; set; }
+
+        public static Condition IsEnglish = CreateEnglishConditionWithTestOverride();
+
+        private static Condition CreateEnglishConditionWithTestOverride()
+        {
+            StringProperty cultureName = new StringProperty(_ => (OverriddenCultureName ?? SystemCultureName).ToLowerInvariant());
+
+            return new OrCondition(cultureName.IsNoCase("en"), cultureName.MatchesRegEx("^en-.*"));
+        }
+    } // class
+} // namespace

--- a/src/Rules/PropertyConditions/SystemProperties.cs
+++ b/src/Rules/PropertyConditions/SystemProperties.cs
@@ -5,17 +5,17 @@ namespace Axe.Windows.Rules.PropertyConditions
 {
     static class SystemProperties
     {
-        private static string SystemCultureName = System.Globalization.CultureInfo.CurrentCulture.Name;
+        private static readonly string SystemISOLanguageName = System.Globalization.CultureInfo.CurrentCulture.ThreeLetterISOLanguageName;
 
-        internal static string OverriddenCultureName { get; set; }
+        internal static string OverriddenISOLanguageName { get; set; }
 
         public static Condition IsEnglish = CreateEnglishConditionWithTestOverride();
 
         private static Condition CreateEnglishConditionWithTestOverride()
         {
-            StringProperty cultureName = new StringProperty(_ => (OverriddenCultureName ?? SystemCultureName).ToLowerInvariant());
+            StringProperty cultureName = new StringProperty(_ => (OverriddenISOLanguageName ?? SystemISOLanguageName));
 
-            return new OrCondition(cultureName.IsNoCase("en"), cultureName.MatchesRegEx("^en-.*"));
+            return cultureName.IsNoCase("eng");
         }
     } // class
 } // namespace

--- a/src/RulesTest/Library/LocalizedControlTypeIsReasonableTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsReasonableTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Axe.Windows.RulesTests.ControlType;
 
@@ -10,6 +11,26 @@ namespace Axe.Windows.RulesTests.Library
     public class LocalizedControlTypeIsReasonableTests
     {
         private static readonly Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.LocalizedControlTypeIsReasonable();
+
+        [TestMethod]
+        public void Condition_IsNotEnglish_Returns_False()
+        {
+            SystemProperties.OverriddenCultureName = "es-ES";
+
+            Assert.IsFalse(Rule.Condition.Matches(null));
+        }
+
+        [TestMethod]
+        public void Condition_IsEnglish_Returns_True()
+        {
+            SystemProperties.OverriddenCultureName = "en-US";
+
+            var e = new MockA11yElement();
+            e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_AppBarControlTypeId;
+            e.LocalizedControlType = "app bar";
+
+            Assert.IsTrue(Rule.Condition.Matches(e));
+        }
 
         [TestMethod]
         public void TestControlTypeIdIsAppBarAndLocalizedControlTypeIsAppBar()

--- a/src/RulesTest/Library/LocalizedControlTypeIsReasonableTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsReasonableTests.cs
@@ -13,6 +13,7 @@ namespace Axe.Windows.RulesTests.Library
         private static readonly Axe.Windows.Rules.IRule Rule = new Axe.Windows.Rules.Library.LocalizedControlTypeIsReasonable();
 
         [TestMethod]
+        [Timeout(1000)]
         public void Condition_IsNotEnglish_Returns_False()
         {
             SystemProperties.OverriddenISOLanguageName = "spa";
@@ -25,6 +26,7 @@ namespace Axe.Windows.RulesTests.Library
         }
 
         [TestMethod]
+        [Timeout(1000)]
         public void Condition_IsEnglish_Returns_True()
         {
             SystemProperties.OverriddenISOLanguageName = "eng";

--- a/src/RulesTest/Library/LocalizedControlTypeIsReasonableTests.cs
+++ b/src/RulesTest/Library/LocalizedControlTypeIsReasonableTests.cs
@@ -15,21 +15,29 @@ namespace Axe.Windows.RulesTests.Library
         [TestMethod]
         public void Condition_IsNotEnglish_Returns_False()
         {
-            SystemProperties.OverriddenCultureName = "es-ES";
+            SystemProperties.OverriddenISOLanguageName = "spa";
 
-            Assert.IsFalse(Rule.Condition.Matches(null));
+            bool matches = Rule.Condition.Matches(null);
+
+            SystemProperties.OverriddenISOLanguageName = null;
+
+            Assert.IsFalse(matches);
         }
 
         [TestMethod]
         public void Condition_IsEnglish_Returns_True()
         {
-            SystemProperties.OverriddenCultureName = "en-US";
+            SystemProperties.OverriddenISOLanguageName = "eng";
 
             var e = new MockA11yElement();
             e.ControlTypeId = Axe.Windows.Core.Types.ControlType.UIA_AppBarControlTypeId;
             e.LocalizedControlType = "app bar";
 
-            Assert.IsTrue(Rule.Condition.Matches(e));
+            bool matches = Rule.Condition.Matches(e);
+
+            SystemProperties.OverriddenISOLanguageName = null;
+
+            Assert.IsTrue(matches);
         }
 
         [TestMethod]

--- a/src/RulesTest/MonsterTest.cs
+++ b/src/RulesTest/MonsterTest.cs
@@ -6,6 +6,7 @@ using Axe.Windows.Core.Enums;
 using Axe.Windows.UnitTestSharedLibrary;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
@@ -217,6 +218,8 @@ namespace Axe.Windows.RulesTests
         {
             DoNotPassNotApplicableAsExpectedResults(expectedResults);
 
+            RemoveEnglishSpecificRulesIfNeeded(expectedResults);
+
             foreach (KeyValuePair<RuleId, EvaluationCode> actualPair in actualResults)
             {
                 if (actualPair.Value == EvaluationCode.NotApplicable)
@@ -234,6 +237,17 @@ namespace Axe.Windows.RulesTests
             }
 
             CheckForExtraRules(expectedResults);
+        }
+
+        private static void RemoveEnglishSpecificRulesIfNeeded(Dictionary<RuleId, EvaluationCode> expectedResults)
+        {
+            if (!string.Equals(CultureInfo.CurrentCulture.ThreeLetterISOLanguageName, "eng", System.StringComparison.OrdinalIgnoreCase))
+            {
+                if (expectedResults.ContainsKey(RuleId.LocalizedControlTypeReasonable))
+                {
+                    expectedResults.Remove(RuleId.LocalizedControlTypeReasonable);
+                }
+            }
         }
 
         private static void DoNotPassNotApplicableAsExpectedResults(Dictionary<RuleId, EvaluationCode> expectedResults)

--- a/src/RulesTest/MonsterTest.cs
+++ b/src/RulesTest/MonsterTest.cs
@@ -16,6 +16,11 @@ namespace Axe.Windows.RulesTests
     [TestClass]
     public class MonsterTest
     {
+        private static readonly IEnumerable<RuleId> EnglishSpecificRuleIds = new RuleId[]
+        {
+            RuleId.LocalizedControlTypeReasonable,
+        };
+
         [TestMethod()]
         public void MonsterButtonTest()
         {
@@ -243,9 +248,12 @@ namespace Axe.Windows.RulesTests
         {
             if (!string.Equals(CultureInfo.CurrentCulture.ThreeLetterISOLanguageName, "eng", System.StringComparison.OrdinalIgnoreCase))
             {
-                if (expectedResults.ContainsKey(RuleId.LocalizedControlTypeReasonable))
+                foreach (RuleId ruleId in EnglishSpecificRuleIds)
                 {
-                    expectedResults.Remove(RuleId.LocalizedControlTypeReasonable);
+                    if (expectedResults.ContainsKey(ruleId))
+                    {
+                        expectedResults.Remove(ruleId);
+                    }
                 }
             }
         }

--- a/src/RulesTest/PropertyConditions/SystemProperitesTests.cs
+++ b/src/RulesTest/PropertyConditions/SystemProperitesTests.cs
@@ -13,68 +13,62 @@ namespace Axe.Windows.RulesTests.PropertyConditions
         [TestCleanup]
         public void Cleanup()
         {
-            SystemProperties.OverriddenCultureName = null;
+            SystemProperties.OverriddenISOLanguageName = null;
         }
 
         [TestMethod]
         public void IsEnglish_DefaultInput_MatchesSystemLocale()
         {
-            string cultureName = CultureInfo.CurrentCulture.Name;
-            AssertConditionMatches(cultureName, IsSystemSetToEnglish(cultureName));
+            string languageName = CultureInfo.CurrentCulture.ThreeLetterISOLanguageName;
+            AssertConditionMatches(languageName, IsSystemSetToEnglish(languageName));
         }
 
         [TestMethod]
-        public void IsEnglish_IsSimpleEnglish_CaseInsensitive_ReturnsTrue()
+        public void IsEnglish_English_CaseInsensitive_ReturnsTrue()
         {
-            SetOverrideAndAssertConditionMatches("En", true);
-        }
-
-        [TestMethod]
-        public void IsEnglish_IsUKEnglish_CaseInsensitive_ReturnsTrue()
-        {
-            SetOverrideAndAssertConditionMatches("eN-Uk", true);
+            SetOverrideAndAssertConditionMatches("EnG", true);
         }
 
         [TestMethod]
         public void IsEnglish_IsGerman_ReturnsFalse()
         {
-            SetOverrideAndAssertConditionMatches("de-DE", false);
+            SetOverrideAndAssertConditionMatches("deu", false);
         }
 
         [TestMethod]
         public void OverriddenCultureName_ResetsToDefault()
         {
-            if (!IsSystemSetToEnglish(CultureInfo.CurrentCulture.Name))
+            if (!IsSystemSetToEnglish(CultureInfo.CurrentCulture.ThreeLetterISOLanguageName))
             {
                 Assert.Inconclusive("This test can only be run with English locale settings");
             }
 
             AssertConditionMatches("system default", true);
-            SetOverrideAndAssertConditionMatches("de-DE", false);
-            SystemProperties.OverriddenCultureName = null;
+            SetOverrideAndAssertConditionMatches("deu", false);
+            SystemProperties.OverriddenISOLanguageName = null;
             AssertConditionMatches("system default", true);
         }
 
-        private static bool IsSystemSetToEnglish(string cultureName)
+        private static bool IsSystemSetToEnglish(string languageName)
         {
-            return (cultureName.ToLowerInvariant() == "en" || cultureName.ToLowerInvariant().StartsWith("en-"));
+            return string.Equals(languageName, "eng", System.StringComparison.OrdinalIgnoreCase);
         }
 
-        private void SetOverrideAndAssertConditionMatches(string cultureName, bool expectsEnglish)
+        private void SetOverrideAndAssertConditionMatches(string languageName, bool expectsEnglish)
         {
-            SystemProperties.OverriddenCultureName = cultureName;
-            AssertConditionMatches(cultureName, expectsEnglish);
+            SystemProperties.OverriddenISOLanguageName = languageName;
+            AssertConditionMatches(languageName, expectsEnglish);
         }
 
-        private void AssertConditionMatches(string cultureName, bool expectsEnglish)
+        private void AssertConditionMatches(string languageName, bool expectsEnglish)
         {
             if (expectsEnglish)
             {
-                Assert.IsTrue(SystemProperties.IsEnglish.Matches(null), $"Expected {cultureName} to report true");
+                Assert.IsTrue(SystemProperties.IsEnglish.Matches(null), $"Expected {languageName} to report true");
             }
             else
             {
-                Assert.IsFalse(SystemProperties.IsEnglish.Matches(null), $"Expected {cultureName} to report false");
+                Assert.IsFalse(SystemProperties.IsEnglish.Matches(null), $"Expected {languageName} to report false");
             }
         }
     } // class

--- a/src/RulesTest/PropertyConditions/SystemProperitesTests.cs
+++ b/src/RulesTest/PropertyConditions/SystemProperitesTests.cs
@@ -58,13 +58,13 @@ namespace Axe.Windows.RulesTests.PropertyConditions
             return string.Equals(languageName, "eng", System.StringComparison.OrdinalIgnoreCase);
         }
 
-        private void SetOverrideAndAssertConditionMatches(string languageName, bool expectsEnglish)
+        private static void SetOverrideAndAssertConditionMatches(string languageName, bool expectsEnglish)
         {
             SystemProperties.OverriddenISOLanguageName = languageName;
             AssertConditionMatches(languageName, expectsEnglish);
         }
 
-        private void AssertConditionMatches(string languageName, bool expectsEnglish)
+        private static void AssertConditionMatches(string languageName, bool expectsEnglish)
         {
             if (expectsEnglish)
             {

--- a/src/RulesTest/PropertyConditions/SystemProperitesTests.cs
+++ b/src/RulesTest/PropertyConditions/SystemProperitesTests.cs
@@ -17,6 +17,7 @@ namespace Axe.Windows.RulesTests.PropertyConditions
         }
 
         [TestMethod]
+        [Timeout(1000)]
         public void IsEnglish_DefaultInput_MatchesSystemLocale()
         {
             string languageName = CultureInfo.CurrentCulture.ThreeLetterISOLanguageName;
@@ -24,18 +25,21 @@ namespace Axe.Windows.RulesTests.PropertyConditions
         }
 
         [TestMethod]
+        [Timeout(1000)]
         public void IsEnglish_English_CaseInsensitive_ReturnsTrue()
         {
             SetOverrideAndAssertConditionMatches("EnG", true);
         }
 
         [TestMethod]
+        [Timeout(1000)]
         public void IsEnglish_IsGerman_ReturnsFalse()
         {
             SetOverrideAndAssertConditionMatches("deu", false);
         }
 
         [TestMethod]
+        [Timeout(1000)]
         public void OverriddenCultureName_ResetsToDefault()
         {
             if (!IsSystemSetToEnglish(CultureInfo.CurrentCulture.ThreeLetterISOLanguageName))

--- a/src/RulesTest/PropertyConditions/SystemProperitesTests.cs
+++ b/src/RulesTest/PropertyConditions/SystemProperitesTests.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Globalization;
+
+namespace Axe.Windows.RulesTests.PropertyConditions
+{
+    [TestClass]
+    public class SystemProperitesTests
+    {
+        [TestCleanup]
+        public void Cleanup()
+        {
+            SystemProperties.OverriddenCultureName = null;
+        }
+
+        [TestMethod]
+        public void IsEnglish_DefaultInput_MatchesSystemLocale()
+        {
+            string cultureName = CultureInfo.CurrentCulture.Name;
+            AssertConditionMatches(cultureName, IsSystemSetToEnglish(cultureName));
+        }
+
+        [TestMethod]
+        public void IsEnglish_IsSimpleEnglish_CaseInsensitive_ReturnsTrue()
+        {
+            SetOverrideAndAssertConditionMatches("En", true);
+        }
+
+        [TestMethod]
+        public void IsEnglish_IsUKEnglish_CaseInsensitive_ReturnsTrue()
+        {
+            SetOverrideAndAssertConditionMatches("eN-Uk", true);
+        }
+
+        [TestMethod]
+        public void IsEnglish_IsGerman_ReturnsFalse()
+        {
+            SetOverrideAndAssertConditionMatches("de-DE", false);
+        }
+
+        [TestMethod]
+        public void OverriddenCultureName_ResetsToDefault()
+        {
+            if (!IsSystemSetToEnglish(CultureInfo.CurrentCulture.Name))
+            {
+                Assert.Inconclusive("This test can only be run with English locale settings");
+            }
+
+            AssertConditionMatches("system default", true);
+            SetOverrideAndAssertConditionMatches("de-DE", false);
+            SystemProperties.OverriddenCultureName = null;
+            AssertConditionMatches("system default", true);
+        }
+
+        private static bool IsSystemSetToEnglish(string cultureName)
+        {
+            return (cultureName.ToLowerInvariant() == "en" || cultureName.ToLowerInvariant().StartsWith("en-"));
+        }
+
+        private void SetOverrideAndAssertConditionMatches(string cultureName, bool expectsEnglish)
+        {
+            SystemProperties.OverriddenCultureName = cultureName;
+            AssertConditionMatches(cultureName, expectsEnglish);
+        }
+
+        private void AssertConditionMatches(string cultureName, bool expectsEnglish)
+        {
+            if (expectsEnglish)
+            {
+                Assert.IsTrue(SystemProperties.IsEnglish.Matches(null), $"Expected {cultureName} to report true");
+            }
+            else
+            {
+                Assert.IsFalse(SystemProperties.IsEnglish.Matches(null), $"Expected {cultureName} to report false");
+            }
+        }
+    } // class
+} // namespace

--- a/src/RulesTest/PropertyConditions/SystemPropertiesTests.cs
+++ b/src/RulesTest/PropertyConditions/SystemPropertiesTests.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 namespace Axe.Windows.RulesTests.PropertyConditions
 {
     [TestClass]
-    public class SystemProperitesTests
+    public class SystemPropertiesTests
     {
         [TestCleanup]
         public void Cleanup()


### PR DESCRIPTION
#### Details

https://github.com/microsoft/accessibility-insights-windows/issues/1572 called out the fact that the `LocalizedControlTypeReasonable` rule uses English language strings to validate localized names. The chosen solution was to change the `Condition` so that this rule only applies on English language systems. This PR adds a new `Condition` called `IsEnglish` that takes advantage of .NET's built-in support of 3 letter language codes as defined in the ISO 639-2 spec. For our purposes, we disable the rule for anything other than "eng". The check is case-insensitive, which probably isn't strictly necessary, but seemed like the safest bet.

Tested by setting my Windows language to French and verifying that `SystemPropertiesTests.OverriddenCultureName_ResetsToDefault` reports as inconclusive. It also revealed the need for adjustments to `MonsterTest` when run on non-English systems.

##### Motivation

Address https://github.com/microsoft/accessibility-insights-windows/issues/1572, avoid noise for Visual Customers running on non-English systems.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
My first iteration used the `CultureInfo.Name` property, which follows a format like **en-us**. This worked reasonably well, but using the three-letter language standard made the code a little it simpler.
 
#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: https://github.com/microsoft/accessibility-insights-windows/issues/1572
