### PR TITLE
Chore: improve usage of {Locked} keyword and minor string cleanup

### DIFF
--- a/src/Rules/Resources/Descriptions.Designer.cs
+++ b/src/Rules/Resources/Descriptions.Designer.cs
@@ -160,7 +160,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A button element should only support one of the Invoke, Toggle, or ExpandCollapse patterns when a splitbutton is the parent. .
+        ///   Looks up a localized string similar to A button element should only support one of the Invoke, Toggle, or ExpandCollapse patterns when a split button is the parent. .
         /// </summary>
         internal static string ButtonWithSplitButtonParentPattern {
             get {
@@ -403,7 +403,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The framework used to build this application does not support..
+        ///   Looks up a localized string similar to The framework used to build this application does not support UI Automation..
         /// </summary>
         internal static string FrameworkDoesNotSupportUIAutomation {
             get {
@@ -520,7 +520,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The IsKeyboardFocusable property for a custom element should be true when the element supports actionable patterns..
+        ///   Looks up a localized string similar to The IsKeyboardFocusable property for a Custom element should be true when the element supports actionable patterns..
         /// </summary>
         internal static string IsKeyboardFocusableForCustomShouldBeTrue {
             get {
@@ -547,7 +547,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The IsKeyboardFocusable property for the given element is expected to be false because of the element&apos;s control type..
+        ///   Looks up a localized string similar to The IsKeyboardFocusable property for the given element is expected to be false because of the element&apos;s ControlType..
         /// </summary>
         internal static string IsKeyboardFocusableShouldBeFalse {
             get {
@@ -556,7 +556,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The IsKeyboardFocusable property for the given element should be true based on its control type..
+        ///   Looks up a localized string similar to The IsKeyboardFocusable property for the given element should be true based on its ControlType..
         /// </summary>
         internal static string IsKeyboardFocusableShouldBeTrue {
             get {
@@ -808,7 +808,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Name property must not contain only space characters..
+        ///   Looks up a localized string similar to The Name property must not contain only whitespace..
         /// </summary>
         internal static string NameNotWhiteSpace {
             get {
@@ -826,7 +826,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Name property of a custom control may be empty if the parent is a WPF dataitem..
+        ///   Looks up a localized string similar to The Name property of a custom control may be empty if the parent is a WPF DataItem..
         /// </summary>
         internal static string NameOnCustomWithParentWPFDataItem {
             get {

--- a/src/Rules/Resources/Descriptions.Designer.cs
+++ b/src/Rules/Resources/Descriptions.Designer.cs
@@ -160,7 +160,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A button element should only support one of the Invoke, Toggle, or ExpandCollapse patterns when a split button is the parent. .
+        ///   Looks up a localized string similar to A button element should only support one of the Invoke, Toggle, or ExpandCollapse patterns when a SplitButton is the parent. .
         /// </summary>
         internal static string ButtonWithSplitButtonParentPattern {
             get {

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -122,8 +122,8 @@
     <comment>The description of an accessibility problem with an element currently under inspection. {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="ButtonWithSplitButtonParentPattern" xml:space="preserve">
-    <value>A button element should only support one of the Invoke, Toggle, or ExpandCollapse patterns when a split button is the parent. </value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
+    <value>A button element should only support one of the Invoke, Toggle, or ExpandCollapse patterns when a SplitButton is the parent. </value>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Invoke", "Toggle", "ExpandCollapse", "SplitButton"}</comment>
   </data>
   <data name="SiblingUniqueAndNotFocusable" xml:space="preserve">
     <value>The given element has siblings with the same Name and LocalizedControlType.</value>

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -122,12 +122,12 @@
     <comment>The description of an accessibility problem with an element currently under inspection. {Locked="BoundingRectangle"}</comment>
   </data>
   <data name="ButtonWithSplitButtonParentPattern" xml:space="preserve">
-    <value>A button element should only support one of the Invoke, Toggle, or ExpandCollapse patterns when a splitbutton is the parent. </value>
+    <value>A button element should only support one of the Invoke, Toggle, or ExpandCollapse patterns when a split button is the parent. </value>
     <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
   </data>
   <data name="SiblingUniqueAndNotFocusable" xml:space="preserve">
     <value>The given element has siblings with the same Name and LocalizedControlType.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedControlType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedControlType", "Name"}</comment>
   </data>
   <data name="ComboBoxShouldNotSupportScrollPattern" xml:space="preserve">
     <value>A combo box should not support the Scroll pattern. This rule may be reported as a warning because some platforms have combo boxes that support the Scroll pattern by default, which app developers can't easily fix.</value>
@@ -158,8 +158,8 @@
     <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsControlElement"}</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeTrue" xml:space="preserve">
-    <value>The IsKeyboardFocusable property for the given element should be true based on its control type.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable"}</comment>
+    <value>The IsKeyboardFocusable property for the given element should be true based on its ControlType.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButDisabled" xml:space="preserve">
     <value>The IsKeyboardFocusable property is false for an element where it would normally be true. However, the IsEnabled property on the element is also false, so the value of IsKeyboardFocusable may be acceptable.</value>
@@ -174,8 +174,8 @@
     <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable", "IsOffscreen"}</comment>
   </data>
   <data name="IsKeyboardFocusableForCustomShouldBeTrue" xml:space="preserve">
-    <value>The IsKeyboardFocusable property for a custom element should be true when the element supports actionable patterns.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable"}</comment>
+    <value>The IsKeyboardFocusable property for a Custom element should be true when the element supports actionable patterns.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Custom", "IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableDescendantTextPattern" xml:space="preserve">
     <value>The IsKeyboardFocusable property may be false when the given element supports the Text pattern and is the descendant of an element that also supports the Text pattern. Please consider if the given element should or should not be focusable.</value>
@@ -186,8 +186,8 @@
     <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeFalse" xml:space="preserve">
-    <value>The IsKeyboardFocusable property for the given element is expected to be false because of the element's control type.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable"}</comment>
+    <value>The IsKeyboardFocusable property for the given element is expected to be false because of the element's ControlType.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableTopLevelTextPattern" xml:space="preserve">
     <value>The IsKeyboardFocusable property should be true for an element that supports the Text pattern, is not a descendant of an element that supports the Text pattern, and which supports text selection.</value>
@@ -315,7 +315,7 @@
   </data>
   <data name="ControlShouldSupportTextPattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Text pattern.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "Table"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "Text"}</comment>
   </data>
   <data name="ControlShouldSupportTogglePattern" xml:space="preserve">
     <value>An element of the given ControlType must support the Toggle pattern.</value>
@@ -347,7 +347,7 @@
   </data>
   <data name="SiblingUniqueAndFocusable" xml:space="preserve">
     <value>Focusable sibling elements must not have the same Name and LocalizedControlType.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection.</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedControlType", "Name"}</comment>
   </data>
   <data name="ControlShouldSupportSetInfo" xml:space="preserve">
     <value>The element's ControlType requires valid values for SizeOfSet and PositionInSet.</value>
@@ -423,7 +423,7 @@
   </data>
   <data name="LocalizedLandmarkTypeNotCustom" xml:space="preserve">
     <value>The LandmarkType and LocalizedLandmarkType must not both be set to "custom".</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LandmarkType", "LocalizedLandmarkType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="custom", "LandmarkType", "LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotEmpty" xml:space="preserve">
     <value>An element with LandmarkType set must not have an empty LocalizedLandmarkType.</value>
@@ -439,7 +439,7 @@
   </data>
   <data name="LocalizedControlTypeNotCustom" xml:space="preserve">
     <value>The ControlType and LocalizedControlType must not both be set to "custom."</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "LocalizedControlType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "LocalizedControlType", "custom"}</comment>
   </data>
   <data name="LocalizedControlTypeNotEmpty" xml:space="preserve">
     <value>The LocalizedControlType property must not be an empty string.</value>
@@ -467,7 +467,7 @@
   </data>
   <data name="NameIsInformative" xml:space="preserve">
     <value>The Name property of an element should not contain class names like 'Microsoft.*.*' or 'Windows.*.*' as these are not usually informative.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Microsoft.*.*", "Name", "Windows.*.*"}</comment>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">
     <value>The Name property of a focusable element must not be an empty string.</value>
@@ -478,7 +478,7 @@
     <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
   </data>
   <data name="NameNotWhiteSpace" xml:space="preserve">
-    <value>The Name property must not contain only space characters.</value>
+    <value>The Name property must not contain only whitespace.</value>
     <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
   </data>
   <data name="NameReasonableLength" xml:space="preserve">
@@ -506,12 +506,12 @@
     <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsOffScreen"}</comment>
   </data>
   <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
-    <value>The framework used to build this application does not support.</value>
+    <value>The framework used to build this application does not support UI Automation.</value>
     <comment>The description of an accessibility problem with an application currently under inspection.</comment>
   </data>
   <data name="EdgeBrowserHasBeenDeprecated" xml:space="preserve">
     <value>The non-Chromium version of Microsoft Edge has been deprecated.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection.</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Chromium", "Microsoft Edge"}</comment>
   </data>
   <data name="SummaryFormat" xml:space="preserve">
     <value>ID:   {0}
@@ -522,6 +522,6 @@ Condition:  {3}</value>
   </data>
   <data name="ChromiumComponentsShouldUseWebScanner" xml:space="preserve">
     <value>Chromium components should be scanned with a web-based scanner.</value>
-    <comment>The description of a problem with an element currently under inspection.</comment>
+    <comment>The description of a problem with an element currently under inspection.  {Locked="Chromium"}</comment>
   </data>
 </root>

--- a/src/Rules/Resources/HowToFix.Designer.cs
+++ b/src/Rules/Resources/HowToFix.Designer.cs
@@ -778,12 +778,12 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide string for the LocalizedLandmarkType property that does not include &quot;custom.&quot;
+        ///   Looks up a localized string similar to Provide a string for the LocalizedLandmarkType property that does not include &quot;custom.&quot;
         ///Where appropriate, use a standard localized landmark type:
         /// · Use &quot;banner&quot; for an area at the beginning of the page with site-oriented content.
         /// · Use &quot;complementary&quot; for an area with supporting content that remains meaningful when separated from the primary content.
         /// · Use &quot;contentinfo&quot; for an area at the end of the page containing information about the site or the primary content.
-        /// · Use &quot;form&quot; for an area containin [rest of string was truncated]&quot;;.
+        /// · Use &quot;form&quot; for an area contain [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string LocalizedLandmarkTypeNotCustom {
             get {

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -182,7 +182,7 @@
   </data>
   <data name="IsKeyboardFocusableDescendantTextPattern" xml:space="preserve">
     <value>Set the IsKeyboardFocusable property to be false.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "Text"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableOnEmptyContainer" xml:space="preserve">
     <value>If this container should be discoverable by keyboard users, set the IsKeyboardFocusable UI Automation property to true. Otherwise, consider changing the ControlType.</value>
@@ -234,7 +234,7 @@
   </data>
   <data name="Structure" xml:space="preserve">
     <value>Set the element to conform to the following structure: {0}.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. Developers: {0} is the element structure.</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {0} is the element structure.</comment>
   </data>
   <data name="SelectionPatternSelectionRequired" xml:space="preserve">
     <value>Set the element's IsSelectionRequired property of the SelectionPattern to TRUE.</value>
@@ -244,7 +244,7 @@
     <value>Modify the button to support exactly one of the following patterns:
  · Support the Invoke pattern if the button performs a command at the request of the user.
  · Support the ExpandCollapse pattern if the button shows or hides additional content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Invoke", "Toggle", "ExpandCollapse"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Invoke", "ExpandCollapse"}</comment>
   </data>
   <data name="ButtonShouldHavePatterns" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
@@ -487,7 +487,7 @@ If none of the standard landmark types is applicable, provide a string that conc
     <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotCustom" xml:space="preserve">
-    <value>Provide string for the LocalizedLandmarkType property that does not include "custom."
+    <value>Provide a string for the LocalizedLandmarkType property that does not include "custom."
 Where appropriate, use a standard localized landmark type:
  · Use "banner" for an area at the beginning of the page with site-oriented content.
  · Use "complementary" for an area with supporting content that remains meaningful when separated from the primary content.
@@ -497,7 +497,7 @@ Where appropriate, use a standard localized landmark type:
     ·         Use "navigation" for an area containing links for page or site navigation.
     ·         Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="banner", "complementary", "contentinfo", "custom", "form", "LocalizedLandmarkType", "navigation", "search"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotEmpty" xml:space="preserve">
     <value>Provide a string for the LocalizedLandmarkType property.
@@ -510,7 +510,7 @@ Where appropriate, use a standard localized landmark type:
     ·         Use "navigation" for an area containing links for page or site navigation.
     ·         Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="banner", "complementary", "contentinfo", "form", "LocalizedLandmarkType", "navigation", "search"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotNull" xml:space="preserve">
     <value>Provide a LocalizedLandmarkType property for the element.
@@ -523,7 +523,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="banner", "complementary", "contentinfo", "form", "LocalizedLandmarkType", "navigation", "search"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotWhiteSpace" xml:space="preserve">
     <value>Provide a string for the LocalizedLandmarkType property.
@@ -536,7 +536,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="banner", "complementary", "contentinfo", "form", "LocalizedLandmarkType", "navigation", "search"}</comment>
   </data>
   <data name="LocalizedControlTypeNotCustom" xml:space="preserve">
     <value>Sufficient:
@@ -584,7 +584,7 @@ If your application targets a version of .NET Framework before 4.7.1, but is run
     <value>Examine the UI Automation Name property of this element:
  · If the Name property contains "Microsoft" or "Windows" and is closely related to the on-screen text (for example, a reference to "Microsoft.com"), you may safely ignore this issue.
  · If the Name property is not closely related to the on-screen text (and provides no meaningful information to end-users), update the Name to a concise, user-facing label that is closely related to the on-screen text.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Microsoft", "Name", "Windows"}</comment>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">
     <value>Provide a UI Automation Name property that concisely identifies the element.</value>
@@ -632,10 +632,10 @@ If the element's ClickablePoint property is incorrect, please ensure it returns 
   </data>
   <data name="EdgeBrowserHasBeenDeprecated" xml:space="preserve">
     <value>The non-Chromium version of Edge has reached its end of life and should not be used for current product development. Please migrate your application to a supported browser.</value>
-    <comment>Brief guidance on how to fix an accessibility problem.</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Chromium", "Edge"}</comment>
   </data>
   <data name="ChromiumComponentsShouldUseWebScanner" xml:space="preserve">
     <value>Use a web-based scanner (for example, Accessibility Insights for Web) to scan this component.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Accessibility Insights for Web"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Accessibility Insights"}</comment>
   </data>
 </root>

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -493,11 +493,11 @@ Where appropriate, use a standard localized landmark type:
  · Use "complementary" for an area with supporting content that remains meaningful when separated from the primary content.
  · Use "contentinfo" for an area at the end of the page containing information about the site or the primary content.
  · Use "form" for an area containing a set of form-related elements.
-    ·         Use "main" for the area with the page's primary content.
-    ·         Use "navigation" for an area containing links for page or site navigation.
-    ·         Use "search" for an area of the page containing search functionality.
+ ·         Use "main" for the area with the page's primary content.
+ ·         Use "navigation" for an area containing links for page or site navigation.
+ ·         Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="banner", "complementary", "contentinfo", "custom", "form", "LocalizedLandmarkType", "navigation", "search"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="custom", "LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotEmpty" xml:space="preserve">
     <value>Provide a string for the LocalizedLandmarkType property.
@@ -507,10 +507,10 @@ Where appropriate, use a standard localized landmark type:
  · Use "contentinfo" for an area at the end of the page containing information about the site or the primary content.
  · Use "form" for an area containing a set of form-related elements.
  · Use "main" for the area with the page's primary content.
-    ·         Use "navigation" for an area containing links for page or site navigation.
-    ·         Use "search" for an area of the page containing search functionality.
+ ·         Use "navigation" for an area containing links for page or site navigation.
+ ·         Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="banner", "complementary", "contentinfo", "form", "LocalizedLandmarkType", "navigation", "search"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotNull" xml:space="preserve">
     <value>Provide a LocalizedLandmarkType property for the element.
@@ -523,7 +523,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="banner", "complementary", "contentinfo", "form", "LocalizedLandmarkType", "navigation", "search"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotWhiteSpace" xml:space="preserve">
     <value>Provide a string for the LocalizedLandmarkType property.
@@ -536,7 +536,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="banner", "complementary", "contentinfo", "form", "LocalizedLandmarkType", "navigation", "search"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotCustom" xml:space="preserve">
     <value>Sufficient:


### PR DESCRIPTION
#### Details
This PR:
* Removes some strings from `Locked` comments where they aren't used in the original message.
* Sets more appropriate scoping on some `Locked` usage.
* Adds some `Locked` keywords that were missed previously.
* General cleanup of strings (opportunistic typo fixing, etc.)

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
