### PR TITLE
fix: Exclude the Alt+Tab "task switching" UI from focus tracking on Sun Valley

### DIFF
--- a/src/Actions/Trackers/FocusTracker.cs
+++ b/src/Actions/Trackers/FocusTracker.cs
@@ -118,9 +118,9 @@ namespace Axe.Windows.Actions.Trackers
         {
             if (element.ClassName == className)
             {
-                DesktopElementAncestry anc = new DesktopElementAncestry(Axe.Windows.Core.Enums.TreeViewMode.Control, element, true);
-                bool res = f(anc);
-                ListHelper.DisposeAllItems(anc.Items);
+                DesktopElementAncestry ancestry = new DesktopElementAncestry(Axe.Windows.Core.Enums.TreeViewMode.Control, element, true);
+                bool res = f(ancestry);
+                ListHelper.DisposeAllItems(ancestry.Items);
                 return res;
             }
             return false;

--- a/src/Actions/Trackers/FocusTracker.cs
+++ b/src/Actions/Trackers/FocusTracker.cs
@@ -102,12 +102,12 @@ namespace Axe.Windows.Actions.Trackers
                 DesktopElementAncestry anc = new DesktopElementAncestry(Axe.Windows.Core.Enums.TreeViewMode.Control, element, true);
                 return anc.Items.Count == 1;
             }
-            else if (element.ClassName == "ListViewItem") // Individual "task switching" item
+            if (element.ClassName == "ListViewItem") // Individual "task switching" item
             {
                 DesktopElementAncestry anc = new DesktopElementAncestry(Axe.Windows.Core.Enums.TreeViewMode.Control, element, true);
                 return anc.Items.Count > 0 && anc.Items[0].AutomationId == "SwitchItemListControl";
             }
-            else return false;
+            return false;
         }
 
         protected override void Dispose(bool disposing)

--- a/src/Actions/Trackers/FocusTracker.cs
+++ b/src/Actions/Trackers/FocusTracker.cs
@@ -9,7 +9,6 @@ using Axe.Windows.Desktop.Types;
 using Axe.Windows.Desktop.UIAutomation.EventHandlers;
 using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using System;
-using System.IO;
 
 namespace Axe.Windows.Actions.Trackers
 {
@@ -116,17 +115,13 @@ namespace Axe.Windows.Actions.Trackers
 
         private bool DoesAncestryMatchCondition(A11yElement element, string className, Func<DesktopElementAncestry, bool> f)
         {
-            File.AppendAllText(@"c:\anc.txt", $"In DoesAncestryMatchCondition for {className}\n");
             if (element?.ClassName == className)
             {
-                File.AppendAllText(@"c:\anc.txt", "Class name match hit\n");
                 DesktopElementAncestry ancestry = new DesktopElementAncestry(Axe.Windows.Core.Enums.TreeViewMode.Control, element, true);
                 bool res = f(ancestry);
-                File.AppendAllText(@"c:\anc.txt", $"Check returned {res}\n");
                 ListHelper.DisposeAllItems(ancestry.Items);
                 return res;
             }
-            File.AppendAllText(@"c:\anc.txt", $"Class name match miss: {element.ClassName}\n");
             return false;
         }
 

--- a/src/Actions/Trackers/FocusTracker.cs
+++ b/src/Actions/Trackers/FocusTracker.cs
@@ -113,7 +113,7 @@ namespace Axe.Windows.Actions.Trackers
             );
         }
 
-        private bool DoesAncestryMatchCondition(A11yElement element, string className, Func<DesktopElementAncestry, bool> f)
+        private static bool DoesAncestryMatchCondition(A11yElement element, string className, Func<DesktopElementAncestry, bool> f)
         {
             if (element?.ClassName == className)
             {

--- a/src/Actions/Trackers/FocusTracker.cs
+++ b/src/Actions/Trackers/FocusTracker.cs
@@ -98,12 +98,11 @@ namespace Axe.Windows.Actions.Trackers
         {
             return (
                 _isWin11
-                && element != null
-                && element.ProcessName == "explorer"
+                && element?.ProcessName == "explorer"
                 && (
                     DoesAncestryMatchCondition(
                         element,
-                        "XamlExplorerHostIslandWindow", // "PANE" WINDOW THAT SOMETIMES TAKES FOCUS WHEN initiating Alt+Tab
+                        "XamlExplorerHostIslandWindow", // "pane" window that sometimes takes focus when initiating Alt+Tab
                         (DesktopElementAncestry anc) => anc.Items.Count == 1
                     )
                     || DoesAncestryMatchCondition(
@@ -118,7 +117,7 @@ namespace Axe.Windows.Actions.Trackers
         private bool DoesAncestryMatchCondition(A11yElement element, string className, Func<DesktopElementAncestry, bool> f)
         {
             File.AppendAllText(@"c:\anc.txt", $"In DoesAncestryMatchCondition for {className}\n");
-            if (element.ClassName == className)
+            if (element?.ClassName == className)
             {
                 File.AppendAllText(@"c:\anc.txt", "Class name match hit\n");
                 DesktopElementAncestry ancestry = new DesktopElementAncestry(Axe.Windows.Core.Enums.TreeViewMode.Control, element, true);

--- a/src/Actions/Trackers/FocusTracker.cs
+++ b/src/Actions/Trackers/FocusTracker.cs
@@ -9,6 +9,7 @@ using Axe.Windows.Desktop.Types;
 using Axe.Windows.Desktop.UIAutomation.EventHandlers;
 using Axe.Windows.Desktop.UIAutomation.TreeWalkers;
 using System;
+using System.IO;
 
 namespace Axe.Windows.Actions.Trackers
 {
@@ -116,13 +117,17 @@ namespace Axe.Windows.Actions.Trackers
 
         private bool DoesAncestryMatchCondition(A11yElement element, string className, Func<DesktopElementAncestry, bool> f)
         {
+            File.AppendAllText(@"c:\anc.txt", $"In DoesAncestryMatchCondition for {className}\n");
             if (element.ClassName == className)
             {
+                File.AppendAllText(@"c:\anc.txt", "Class name match hit\n");
                 DesktopElementAncestry ancestry = new DesktopElementAncestry(Axe.Windows.Core.Enums.TreeViewMode.Control, element, true);
                 bool res = f(ancestry);
+                File.AppendAllText(@"c:\anc.txt", $"Check returned {res}\n");
                 ListHelper.DisposeAllItems(ancestry.Items);
                 return res;
             }
+            File.AppendAllText(@"c:\anc.txt", $"Class name match miss: {element.ClassName}\n");
             return false;
         }
 

--- a/src/Actions/Trackers/FocusTracker.cs
+++ b/src/Actions/Trackers/FocusTracker.cs
@@ -30,7 +30,7 @@ namespace Axe.Windows.Actions.Trackers
         public FocusTracker(Action<A11yElement> action) : base(action, DefaultActionContext.GetDefaultInstance())
         {
             _eventListenerFactory = new EventListenerFactory(null); // listen for all element. it works only for FocusChangedEvent
-            _isWin11 = new Win32.Win32Helper().IsWindowsSVOrLater();
+            _isWin11 = new Win32.Win32Helper().IsWindows11OrLater();
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace Axe.Windows.Actions.Trackers
                 if (IsStarted && message.Element != null)
                 {
                     A11yElement element = GetElementBasedOnScope(message.Element);
-                    if (element?.ControlTypeId != ControlType.UIA_ToolTipControlTypeId && !IsTaskSwitcher(element))
+                    if (element?.ControlTypeId != ControlType.UIA_ToolTipControlTypeId && !IsWin11TaskSwitcher(element))
                     {
                         SelectElementIfItIsEligible(element);
                     }
@@ -93,12 +93,12 @@ namespace Axe.Windows.Actions.Trackers
         /// </summary>
         /// <param name="element">The element to check.</param>
         /// <returns>true if the element is part of the Alt+Tab task switching UI, false otherwise.</returns>
-        private bool IsTaskSwitcher(A11yElement element)
+        private bool IsWin11TaskSwitcher(A11yElement element)
         {
             return (
                 _isWin11
                 && element != null
-                && element.ProcessName != "explorer"
+                && element.ProcessName == "explorer"
                 && (
                     DoesAncestryMatchCondition(
                         element,

--- a/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
+++ b/src/Desktop/UIAutomation/DesktopElementExtensionMethods.cs
@@ -29,7 +29,9 @@ namespace Axe.Windows.Desktop.UIAutomation
             PropertyType.UIA_ControlTypePropertyId,
             PropertyType.UIA_BoundingRectanglePropertyId,
             PropertyType.UIA_RuntimeIdPropertyId,
-            PropertyType.UIA_ProcessIdPropertyId
+            PropertyType.UIA_ProcessIdPropertyId,
+            PropertyType.UIA_AutomationIdPropertyId,
+            PropertyType.UIA_ClassNamePropertyId
         };
 
         /// <summary>

--- a/src/Win32/Win32Helper.cs
+++ b/src/Win32/Win32Helper.cs
@@ -115,5 +115,14 @@ namespace Axe.Windows.Win32
         {
             return IsAtLeastWin10WithSpecificBuild(17713); // Build 17713 is confirmed in the RS5 range
         }
+
+        /// <summary>
+        /// Check whether current OS is Win11 (Sun Valley) or later
+        /// </summary>
+        /// <returns>True if and only if the OS is at least Win11</returns>
+        internal bool IsWindowsSVOrLater()
+        {
+            return IsAtLeastWin10WithSpecificBuild(22000);
+        }
     }
 }

--- a/src/Win32/Win32Helper.cs
+++ b/src/Win32/Win32Helper.cs
@@ -120,7 +120,7 @@ namespace Axe.Windows.Win32
         /// Check whether current OS is Win11 (Sun Valley) or later
         /// </summary>
         /// <returns>True if and only if the OS is at least Win11</returns>
-        internal bool IsWindowsSVOrLater()
+        internal bool IsWindows11OrLater()
         {
             return IsAtLeastWin10WithSpecificBuild(22000);
         }

--- a/src/props/version.props
+++ b/src/props/version.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SemVerNumber Condition="$(SemVerNumber) == ''">2.1.3</SemVerNumber>
+    <SemVerNumber Condition="$(SemVerNumber) == ''">2.99.1</SemVerNumber>
     <SemVerSuffix></SemVerSuffix>
   </PropertyGroup>
 </Project>

--- a/src/props/version.props
+++ b/src/props/version.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SemVerNumber Condition="$(SemVerNumber) == ''">2.99.1</SemVerNumber>
+    <SemVerNumber Condition="$(SemVerNumber) == ''">2.1.3</SemVerNumber>
     <SemVerSuffix></SemVerSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### Details
This PR excludes windows created on <kbd>Alt</kbd>+<kbd>Tab</kbd> from focus tracking that interfere with it, making apps that use focus tracking unusable for keyboard users on Windows 11.

##### Motivation
microsoft/accessibility-insights-windows#1610

#### Pull request checklist
- [x] Addresses an existing issue: microsoft/accessibility-insights-windows#1610