### PR TITLE
chore: Further changes to translator comments

### DIFF
--- a/src/Rules/Resources/Descriptions.Designer.cs
+++ b/src/Rules/Resources/Descriptions.Designer.cs
@@ -169,7 +169,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A separator must not have any children with IsContentElement set to TRUE..
+        ///   Looks up a localized string similar to A separator must not have any children with IsContentElement set to true..
         /// </summary>
         internal static string ChildrenNotAllowedInContentView {
             get {
@@ -484,7 +484,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The given ControlType must have the IsControlElement property set to TRUE..
+        ///   Looks up a localized string similar to The given ControlType must have the IsControlElement property set to true..
         /// </summary>
         internal static string IsControlElementTrueRequired {
             get {
@@ -907,7 +907,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An element of the given ControlType must have the IsSelectionRequired property set to TRUE..
+        ///   Looks up a localized string similar to An element of the given ControlType must have the IsSelectionRequired property set to true..
         /// </summary>
         internal static string SelectionPatternSelectionRequired {
             get {

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -507,7 +507,7 @@
   </data>
   <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
     <value>The framework used to build this application does not support UI Automation.</value>
-    <comment>The description of an accessibility problem with an application currently under inspection.</comment>
+    <comment>The description of an accessibility problem with an application currently under inspection. {Locked="UI Automation"}</comment>
   </data>
   <data name="EdgeBrowserHasBeenDeprecated" xml:space="preserve">
     <value>The non-Chromium version of Microsoft Edge has been deprecated.</value>

--- a/src/Rules/Resources/Descriptions.resx
+++ b/src/Rules/Resources/Descriptions.resx
@@ -147,51 +147,51 @@
   </data>
   <data name="IsContentElementFalseOptional" xml:space="preserve">
     <value>The recommended value of the IsContentElement property for the given control type is false. Please consider if this is an element that should be reported to an assistive technology user as content.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsContentElement"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="false", "IsContentElement"}</comment>
   </data>
   <data name="IsContentElementTrueOptional" xml:space="preserve">
     <value>The recommended value of the IsContentElement property for the given control type is true. Please consider if this is an element that should be reported to an assistive technology user as content.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsContentElement"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsContentElement", "true"}</comment>
   </data>
   <data name="IsControlElementTrueOptional" xml:space="preserve">
     <value>The recommended value of the IsControlElement property for the given control type is true. Please consider if this is an element that should be reported to an assistive technology user as a control. Note that almost all controls are required to have the IsControl Property set to true.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsControlElement"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsControlElement", "true"}</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element should be true based on its ControlType.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsKeyboardFocusable"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsKeyboardFocusable", "true"}</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButDisabled" xml:space="preserve">
     <value>The IsKeyboardFocusable property is false for an element where it would normally be true. However, the IsEnabled property on the element is also false, so the value of IsKeyboardFocusable may be acceptable.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable", "IsEnabled"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="false", "IsKeyboardFocusable", "IsEnabled", "true"}</comment>
   </data>
   <data name="IsKeyboardFocusableForListItemShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given list item is false, but the element has children that are focusable. The element should probably be focusable instead of its children.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="false", "IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButOffscreen" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element is false for an element where it would normally be true. However, the IsOffscreen property on the element is true, so the value of IsKeyboardFocusable may be acceptable.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable", "IsOffscreen"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="false", "IsKeyboardFocusable", "IsOffscreen", "true"}</comment>
   </data>
   <data name="IsKeyboardFocusableForCustomShouldBeTrue" xml:space="preserve">
     <value>The IsKeyboardFocusable property for a Custom element should be true when the element supports actionable patterns.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Custom", "IsKeyboardFocusable"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Custom", "IsKeyboardFocusable", "true"}</comment>
   </data>
   <data name="IsKeyboardFocusableDescendantTextPattern" xml:space="preserve">
     <value>The IsKeyboardFocusable property may be false when the given element supports the Text pattern and is the descendant of an element that also supports the Text pattern. Please consider if the given element should or should not be focusable.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable", "Text"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="false", "IsKeyboardFocusable", "Text"}</comment>
   </data>
   <data name="IsKeyboardFocusableOnEmptyContainer" xml:space="preserve">
     <value>The IsKeyboardFocusable property should be true when you want an empty container to be discoverable by assistive technology users. IsKeyboardFocusable may be false when you want an empty container not to be discoverable by assistive technology users.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="false", "IsKeyboardFocusable", "true"}</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeFalse" xml:space="preserve">
     <value>The IsKeyboardFocusable property for the given element is expected to be false because of the element's ControlType.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsKeyboardFocusable"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "false", "IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableTopLevelTextPattern" xml:space="preserve">
     <value>The IsKeyboardFocusable property should be true for an element that supports the Text pattern, is not a descendant of an element that supports the Text pattern, and which supports text selection.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable", "Text"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsKeyboardFocusable", "Text", "true"}</comment>
   </data>
   <data name="ItemStatusExists" xml:space="preserve">
     <value>The ItemStatus property for the given element should exist.</value>
@@ -211,11 +211,11 @@
   </data>
   <data name="NameNoSiblingsOfSameType" xml:space="preserve">
     <value>The Name property of the given element may be null or empty if the element has no siblings of the same type.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name", "null"}</comment>
   </data>
   <data name="NameNullButElementNotKeyboardFocusable" xml:space="preserve">
     <value>The Name property for the given element is null, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name", "null"}</comment>
   </data>
   <data name="NameOnCustomWithParentWPFDataItem" xml:space="preserve">
     <value>The Name property of a custom control may be empty if the parent is a WPF DataItem.</value>
@@ -227,7 +227,7 @@
   </data>
   <data name="NameWithValidBoundingRectangle" xml:space="preserve">
     <value>An interactive element with a valid Name property is usually expected to have a valid BoundingRectangle that is not null and has area.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name", "BoundingRectangle"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name", "BoundingRectangle", "null"}</comment>
   </data>
   <data name="Structure" xml:space="preserve">
     <value>The given element is expected to have the following structure: {0}.</value>
@@ -255,7 +255,7 @@
   </data>
   <data name="EditSupportsIncorrectRangeValuePattern" xml:space="preserve">
     <value>The RangeValue pattern of an edit control must have a null LargeChange property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="RangeValue", "LargeChange"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="RangeValue", "LargeChange", "null"}</comment>
   </data>
   <data name="SplitButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>A split button must support exactly one of the Invoke or Toggle patterns.</value>
@@ -326,12 +326,12 @@
     <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Transform"}</comment>
   </data>
   <data name="ChildrenNotAllowedInContentView" xml:space="preserve">
-    <value>A separator must not have any children with IsContentElement set to TRUE.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsContentElement"}</comment>
+    <value>A separator must not have any children with IsContentElement set to true.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsContentElement", "true"}</comment>
   </data>
   <data name="SelectionPatternSelectionRequired" xml:space="preserve">
-    <value>An element of the given ControlType must have the IsSelectionRequired property set to TRUE.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsSelectionRequired"}</comment>
+    <value>An element of the given ControlType must have the IsSelectionRequired property set to true.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsSelectionRequired", "true"}</comment>
   </data>
   <data name="SelectionPatternSingleSelection" xml:space="preserve">
     <value>An element of the given ControlType must not support multiple selection.</value>
@@ -371,7 +371,7 @@
   </data>
   <data name="BoundingRectangleNotNull" xml:space="preserve">
     <value>An on-screen element must not have a null BoundingRectangle property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="BoundingRectangle"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="BoundingRectangle", "null"}</comment>
   </data>
   <data name="BoundingRectangleSizeReasonable" xml:space="preserve">
     <value>The BoundingRectangle property must represent an area of at least 25 pixels.</value>
@@ -383,15 +383,15 @@
   </data>
   <data name="IsContentElementPropertyExists" xml:space="preserve">
     <value>The given ControlType must have a non-null IsContentElement property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsContentElement"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsContentElement", "null"}</comment>
   </data>
   <data name="IsControlElementPropertyExists" xml:space="preserve">
     <value>The given ControlType must have a non-null IsControlElement property.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsControlElement"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsControlElement", "null"}</comment>
   </data>
   <data name="IsControlElementTrueRequired" xml:space="preserve">
-    <value>The given ControlType must have the IsControlElement property set to TRUE.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsControlElement"}</comment>
+    <value>The given ControlType must have the IsControlElement property set to true.</value>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="ControlType", "IsControlElement", "true"}</comment>
   </data>
   <data name="LandmarkBannerIsTopLevel" xml:space="preserve">
     <value>An element with LocalizedLandmarkType "banner" must not descend from another landmark.</value>
@@ -431,7 +431,7 @@
   </data>
   <data name="LocalizedLandmarkTypeNotNull" xml:space="preserve">
     <value>An element with LandmarkType set must not have a null LocalizedLandmarkType.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LandmarkType", "LocalizedLandmarkType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LandmarkType", "LocalizedLandmarkType", "null"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotWhiteSpace" xml:space="preserve">
     <value>The LocalizedLandmarkType property must not contain only white space.</value>
@@ -447,7 +447,7 @@
   </data>
   <data name="LocalizedControlTypeNotNull" xml:space="preserve">
     <value>The LocalizedControlType property must not be null.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedControlType"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="LocalizedControlType", "null"}</comment>
   </data>
   <data name="LocalizedControlTypeNotWhiteSpace" xml:space="preserve">
     <value>The LocalizedControlType property must not contain only white space.</value>
@@ -475,7 +475,7 @@
   </data>
   <data name="NameNotNull" xml:space="preserve">
     <value>The Name property of a focusable element must not be null.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="Name", "null"}</comment>
   </data>
   <data name="NameNotWhiteSpace" xml:space="preserve">
     <value>The Name property must not contain only whitespace.</value>
@@ -499,7 +499,7 @@
   </data>
   <data name="ClickablePointOnScreen" xml:space="preserve">
     <value>An element's IsOffScreen property must be false when its clickable point is on-screen.</value>
-    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="IsOffScreen"}</comment>
+    <comment>The description of an accessibility problem with an element currently under inspection. {Locked="false", "IsOffScreen"}</comment>
   </data>
   <data name="ClickablePointOffScreen" xml:space="preserve">
     <value>An element's IsOffScreen property must be true when its clickable point is off-screen.</value>

--- a/src/Rules/Resources/HowToFix.Designer.cs
+++ b/src/Rules/Resources/HowToFix.Designer.cs
@@ -107,7 +107,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If the element is off-screen, set its IsOffscreen property to TRUE.
+        ///   Looks up a localized string similar to If the element is off-screen, set its IsOffscreen property to true.
         ///If the element is on-screen, provide a BoundingRectangle property..
         /// </summary>
         internal static string BoundingRectangleNotNull {
@@ -194,7 +194,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Make sure all of the element&apos;s children have the IsContentElement property set to FALSE..
+        ///   Looks up a localized string similar to Make sure all of the element&apos;s children have the IsContentElement property set to false..
         /// </summary>
         internal static string ChildrenNotAllowedInContentView {
             get {
@@ -415,7 +415,7 @@ namespace Axe.Windows.Rules.Resources {
         
         /// <summary>
         ///   Looks up a localized string similar to If the element can be resized, implement the Transform pattern.
-        ///If the element can&apos;t be resized, ensure the TransformPattern_CanResize property is FALSE..
+        ///If the element can&apos;t be resized, ensure the TransformPattern_CanResize property is false..
         /// </summary>
         internal static string ControlShouldSupportTransformPattern {
             get {
@@ -489,8 +489,8 @@ namespace Axe.Windows.Rules.Resources {
         
         /// <summary>
         ///   Looks up a localized string similar to Provide a value for the element&apos;s IsContentElement property:
-        /// · If the element should be included in the content view, set the property to TRUE.
-        /// · If the element should not be included in the content view, set the property to FALSE..
+        /// · If the element should be included in the content view, set the property to true.
+        /// · If the element should not be included in the content view, set the property to false..
         /// </summary>
         internal static string IsContentElementPropertyExists {
             get {
@@ -509,8 +509,8 @@ namespace Axe.Windows.Rules.Resources {
         
         /// <summary>
         ///   Looks up a localized string similar to Provide a value for the element&apos;s IsControlElement property:
-        /// · If the element should be included in the control view, set the property to TRUE.
-        /// · If the element should not be included in the control view, set the property to FALSE..
+        /// · If the element should be included in the control view, set the property to true.
+        /// · If the element should not be included in the control view, set the property to false..
         /// </summary>
         internal static string IsControlElementPropertyExists {
             get {
@@ -528,7 +528,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Set the element&apos;s IsControlElement property to TRUE..
+        ///   Looks up a localized string similar to Set the element&apos;s IsControlElement property to true..
         /// </summary>
         internal static string IsControlElementTrueRequired {
             get {
@@ -980,7 +980,7 @@ namespace Axe.Windows.Rules.Resources {
         ///   Looks up a localized string similar to Implement the progress bar&apos;s RangeValue pattern using the following properties and values:
         /// · Minimum: 0.0
         /// · Maximum: 100.0
-        /// · IsReadOnly: TRUE.
+        /// · IsReadOnly: true.
         /// </summary>
         internal static string ProgressBarRangeValue {
             get {
@@ -1000,7 +1000,7 @@ namespace Axe.Windows.Rules.Resources {
         /// <summary>
         ///   Looks up a localized string similar to Do one of the following:
         /// 1. Modify the element and/or its siblings so that only one of them is selected at any given time, OR
-        /// 2. Modify the parent element so its CanSelectMultiple property is TRUE..
+        /// 2. Modify the parent element so its CanSelectMultiple property is true..
         /// </summary>
         internal static string SelectionItemPatternSingleSelection {
             get {
@@ -1009,7 +1009,7 @@ namespace Axe.Windows.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Set the element&apos;s IsSelectionRequired property of the SelectionPattern to TRUE..
+        ///   Looks up a localized string similar to Set the element&apos;s IsSelectionRequired property of the SelectionPattern to true..
         /// </summary>
         internal static string SelectionPatternSelectionRequired {
             get {
@@ -1020,7 +1020,7 @@ namespace Axe.Windows.Rules.Resources {
         /// <summary>
         ///   Looks up a localized string similar to 1. Make sure the element has the appropriate ControlType property for its function.
         ///2. Make sure Selection is the correct pattern.
-        ///3. Set the element&apos;s CanSelectMultiple property to FALSE..
+        ///3. Set the element&apos;s CanSelectMultiple property to false..
         /// </summary>
         internal static string SelectionPatternSingleSelection {
             get {

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -130,7 +130,7 @@
   </data>
   <data name="SiblingUniqueAndNotFocusable" xml:space="preserve">
     <value>Verify that each element has a meaningful UI Automation Name property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "UI Automation"}</comment>
   </data>
   <data name="ComboBoxShouldNotSupportScrollPattern" xml:space="preserve">
     <value>Modify the combo box to not support the Scroll pattern.</value>
@@ -146,27 +146,27 @@
   </data>
   <data name="HelpTextNotEqualToName" xml:space="preserve">
     <value>Write meaningful text for the element's UI Automation HelpText property. This text is typically similar to, or taken from, a tooltip or placeholder, such as "type here to search".</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="HelpText"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="HelpText", "UI Automation"}</comment>
   </data>
   <data name="IsContentElementFalseOptional" xml:space="preserve">
     <value>Set the IsContentElement UI Automation property to false.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="false", "IsContentElement"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="false", "IsContentElement", "UI Automation"}</comment>
   </data>
   <data name="IsContentElementTrueOptional" xml:space="preserve">
     <value>Set the IsContentElement UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsContentElement", "true"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsContentElement", "true", "UI Automation"}</comment>
   </data>
   <data name="IsControlElementTrueOptional" xml:space="preserve">
     <value>Set the IsControlElement UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsControlElement", "true"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsControlElement", "true", "UI Automation"}</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeTrue" xml:space="preserve">
     <value>Set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "true"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "true", "UI Automation"}</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButDisabled" xml:space="preserve">
     <value>If this element is still reachable via the keyboard even when it is disabled, set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "true"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "true", "UI Automation"}</comment>
   </data>
   <data name="IsKeyboardFocusableForListItemShouldBeTrue" xml:space="preserve">
     <value>Make this element focusable instead of its children.</value>
@@ -174,11 +174,11 @@
   </data>
   <data name="IsKeyboardFocusableFalseButOffscreen" xml:space="preserve">
     <value>If this element is still reachable via the keyboard even when it is off-screen, set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "true"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "true", "UI Automation"}</comment>
   </data>
   <data name="IsKeyboardFocusableForCustomShouldBeTrue" xml:space="preserve">
     <value>Ensure that this element can be manipulated via the keyboard, then set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "true"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "true", "UI Automation"}</comment>
   </data>
   <data name="IsKeyboardFocusableDescendantTextPattern" xml:space="preserve">
     <value>Set the IsKeyboardFocusable property to be false.</value>
@@ -186,51 +186,51 @@
   </data>
   <data name="IsKeyboardFocusableOnEmptyContainer" xml:space="preserve">
     <value>If this container should be discoverable by keyboard users, set the IsKeyboardFocusable UI Automation property to true. Otherwise, consider changing the ControlType.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "ControlType", "true"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "ControlType", "true", "UI Automation"}</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeFalse" xml:space="preserve">
     <value>Set the IsKeyboardFocusable UI Automation property to false. If this element really should be reachable via the keyboard, verify its ControlType.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "ControlType", "false"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "ControlType", "false", "UI Automation"}</comment>
   </data>
   <data name="IsKeyboardFocusableTopLevelTextPattern" xml:space="preserve">
     <value>Set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "true"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "true", "UI Automation"}</comment>
   </data>
   <data name="ItemStatusExists" xml:space="preserve">
     <value>Add a meaningful ItemStatus UI Automation property to this element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ItemStatus"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ItemStatus", "UI Automation"}</comment>
   </data>
   <data name="LocalizedControlTypeReasonable" xml:space="preserve">
     <value>Set a meaningful LocalizedControlType UI Automation property for this element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedControlType", "UI Automation"}</comment>
   </data>
   <data name="ItemTypeRecommended" xml:space="preserve">
     <value>If necessary, set the ItemType UI Automation property for this element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ItemType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ItemType", "UI Automation"}</comment>
   </data>
   <data name="NameEmptyButElementNotKeyboardFocusable" xml:space="preserve">
     <value>Set the UI Automation Name property for the given element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "UI Automation"}</comment>
   </data>
   <data name="NameNoSiblingsOfSameType" xml:space="preserve">
     <value>Set the UI Automation Name property of this element to be null or empty if the element has no siblings of the same type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "null"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "null", "UI Automation"}</comment>
   </data>
   <data name="NameNullButElementNotKeyboardFocusable" xml:space="preserve">
     <value>Set the UI Automation Name property for the given element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "UI Automation"}</comment>
   </data>
   <data name="NameOnCustomWithParentWPFDataItem" xml:space="preserve">
     <value>Set the UI Automation Name property of this custom control to be empty.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "UI Automation"}</comment>
   </data>
   <data name="NameOnOptionalType" xml:space="preserve">
     <value>Remove the UI Automation Name property for this element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "UI Automation"}</comment>
   </data>
   <data name="NameWithValidBoundingRectangle" xml:space="preserve">
     <value>Modify the UI Automation Name property to have a valid BoundingRectangle (i.e. the BoundingRectangle is not null and has area).</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "BoundingRectangle", "null"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "BoundingRectangle", "null", "UI Automation"}</comment>
   </data>
   <data name="Structure" xml:space="preserve">
     <value>Set the element to conform to the following structure: {0}.</value>
@@ -543,8 +543,8 @@ If none of the standard landmark types is applicable, provide a string that conc
 Provide a string for the LocalizedControlType property that concisely describes the control's function or purpose.
 
 Better:
-If possible, use a predefined (non-custom) control type and the default localized control type. The UIA framework will provide the correct localized control type automatically.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedControlType"}</comment>
+If possible, use a predefined (non-custom) control type and the default localized control type. The UI Automation framework will provide the correct localized control type automatically.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedControlType", "UI Automation"}</comment>
   </data>
   <data name="LocalizedControlTypeNotCustomWPFGridCell" xml:space="preserve">
     <value>{0}
@@ -572,37 +572,37 @@ If your application targets a version of .NET Framework before 4.7.1, but is run
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the control type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "UI Automation"}</comment>
   </data>
   <data name="NameExcludesLocalizedControlType" xml:space="preserve">
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the same text as the element's LocalizedControlType property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "LocalizedControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "LocalizedControlType", "UI Automation"}</comment>
   </data>
   <data name="NameIsInformative" xml:space="preserve">
     <value>Examine the UI Automation Name property of this element:
  · If the Name property contains "Microsoft" or "Windows" and is closely related to the on-screen text (for example, a reference to "Microsoft.com"), you may safely ignore this issue.
  · If the Name property is not closely related to the on-screen text (and provides no meaningful information to end-users), update the Name to a concise, user-facing label that is closely related to the on-screen text.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Microsoft", "Name", "Windows"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Microsoft", "Name", "UI Automation", "Windows"}</comment>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">
     <value>Provide a UI Automation Name property that concisely identifies the element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "UI Automation"}</comment>
   </data>
   <data name="NameNotNull" xml:space="preserve">
     <value>Provide a UI Automation Name property that concisely identifies the element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "UI Automation"}</comment>
   </data>
   <data name="NameNotWhiteSpace" xml:space="preserve">
     <value>Provide a UI Automation Name property that concisely identifies the element.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "UI Automation"}</comment>
   </data>
   <data name="NameReasonableLength" xml:space="preserve">
     <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Contains at most 512 characters.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "UI Automation"}</comment>
   </data>
   <data name="ListItemSiblingsUnique" xml:space="preserve">
     <value>Provide unique names for sibling list items.</value>
@@ -628,7 +628,7 @@ If the element's ClickablePoint property is incorrect, please ensure it returns 
   </data>
   <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
     <value>Switch your application to a framework that supports UI Automation.</value>
-    <comment>Brief guidance on how to fix an accessibility problem.</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="UI Automation"}</comment>
   </data>
   <data name="EdgeBrowserHasBeenDeprecated" xml:space="preserve">
     <value>The non-Chromium version of Edge has reached its end of life and should not be used for current product development. Please migrate your application to a supported browser.</value>

--- a/src/Rules/Resources/HowToFix.resx
+++ b/src/Rules/Resources/HowToFix.resx
@@ -150,23 +150,23 @@
   </data>
   <data name="IsContentElementFalseOptional" xml:space="preserve">
     <value>Set the IsContentElement UI Automation property to false.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsContentElement"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="false", "IsContentElement"}</comment>
   </data>
   <data name="IsContentElementTrueOptional" xml:space="preserve">
     <value>Set the IsContentElement UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsContentElement"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsContentElement", "true"}</comment>
   </data>
   <data name="IsControlElementTrueOptional" xml:space="preserve">
     <value>Set the IsControlElement UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsControlElement"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsControlElement", "true"}</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeTrue" xml:space="preserve">
     <value>Set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "true"}</comment>
   </data>
   <data name="IsKeyboardFocusableFalseButDisabled" xml:space="preserve">
     <value>If this element is still reachable via the keyboard even when it is disabled, set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "true"}</comment>
   </data>
   <data name="IsKeyboardFocusableForListItemShouldBeTrue" xml:space="preserve">
     <value>Make this element focusable instead of its children.</value>
@@ -174,27 +174,27 @@
   </data>
   <data name="IsKeyboardFocusableFalseButOffscreen" xml:space="preserve">
     <value>If this element is still reachable via the keyboard even when it is off-screen, set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "true"}</comment>
   </data>
   <data name="IsKeyboardFocusableForCustomShouldBeTrue" xml:space="preserve">
     <value>Ensure that this element can be manipulated via the keyboard, then set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "true"}</comment>
   </data>
   <data name="IsKeyboardFocusableDescendantTextPattern" xml:space="preserve">
     <value>Set the IsKeyboardFocusable property to be false.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="false", "IsKeyboardFocusable"}</comment>
   </data>
   <data name="IsKeyboardFocusableOnEmptyContainer" xml:space="preserve">
     <value>If this container should be discoverable by keyboard users, set the IsKeyboardFocusable UI Automation property to true. Otherwise, consider changing the ControlType.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "ControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "ControlType", "true"}</comment>
   </data>
   <data name="IsKeyboardFocusableShouldBeFalse" xml:space="preserve">
     <value>Set the IsKeyboardFocusable UI Automation property to false. If this element really should be reachable via the keyboard, verify its ControlType.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "ControlType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "ControlType", "false"}</comment>
   </data>
   <data name="IsKeyboardFocusableTopLevelTextPattern" xml:space="preserve">
     <value>Set the IsKeyboardFocusable UI Automation property to true.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsKeyboardFocusable", "true"}</comment>
   </data>
   <data name="ItemStatusExists" xml:space="preserve">
     <value>Add a meaningful ItemStatus UI Automation property to this element.</value>
@@ -214,7 +214,7 @@
   </data>
   <data name="NameNoSiblingsOfSameType" xml:space="preserve">
     <value>Set the UI Automation Name property of this element to be null or empty if the element has no siblings of the same type.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "null"}</comment>
   </data>
   <data name="NameNullButElementNotKeyboardFocusable" xml:space="preserve">
     <value>Set the UI Automation Name property for the given element.</value>
@@ -230,15 +230,15 @@
   </data>
   <data name="NameWithValidBoundingRectangle" xml:space="preserve">
     <value>Modify the UI Automation Name property to have a valid BoundingRectangle (i.e. the BoundingRectangle is not null and has area).</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "BoundingRectangle"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Name", "BoundingRectangle", "null"}</comment>
   </data>
   <data name="Structure" xml:space="preserve">
     <value>Set the element to conform to the following structure: {0}.</value>
     <comment>Brief guidance on how to fix an accessibility problem. {0} is the element structure.</comment>
   </data>
   <data name="SelectionPatternSelectionRequired" xml:space="preserve">
-    <value>Set the element's IsSelectionRequired property of the SelectionPattern to TRUE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType", "IsSelectionRequired"}</comment>
+    <value>Set the element's IsSelectionRequired property of the SelectionPattern to true.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType", "IsSelectionRequired", "true"}</comment>
   </data>
   <data name="ButtonInvokeAndExpandCollapsePatterns" xml:space="preserve">
     <value>Modify the button to support exactly one of the following patterns:
@@ -271,12 +271,12 @@
     <value>Implement the progress bar's RangeValue pattern using the following properties and values:
  · Minimum: 0.0
  · Maximum: 100.0
- · IsReadOnly: TRUE</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="RangeValue", "Minimum", "Maximum", "IsReadOnly"}</comment>
+ · IsReadOnly: true</value>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="RangeValue", "Minimum", "Maximum", "IsReadOnly", "true"}</comment>
   </data>
   <data name="EditSupportsIncorrectRangeValuePattern" xml:space="preserve">
     <value>Implement the edit control's RangeValue pattern with a null LargeChange property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="RangeValue", "LargeChange"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="RangeValue", "LargeChange", "null"}</comment>
   </data>
   <data name="SplitButtonInvokeAndTogglePatterns" xml:space="preserve">
     <value>Modify the split button to support exactly one of the following patterns:
@@ -357,24 +357,24 @@
   </data>
   <data name="ControlShouldSupportTransformPattern" xml:space="preserve">
     <value>If the element can be resized, implement the Transform pattern.
-If the element can't be resized, ensure the TransformPattern_CanResize property is FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="Transform", "TransformPattern_CanResize"}</comment>
+If the element can't be resized, ensure the TransformPattern_CanResize property is false.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="false", "Transform", "TransformPattern_CanResize"}</comment>
   </data>
   <data name="ChildrenNotAllowedInContentView" xml:space="preserve">
-    <value>Make sure all of the element's children have the IsContentElement property set to FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsContentElement"}</comment>
+    <value>Make sure all of the element's children have the IsContentElement property set to false.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="false", "IsContentElement"}</comment>
   </data>
   <data name="SelectionPatternSingleSelection" xml:space="preserve">
     <value>1. Make sure the element has the appropriate ControlType property for its function.
 2. Make sure Selection is the correct pattern.
-3. Set the element's CanSelectMultiple property to FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType", "Selection", "CanSelectMultiple"}</comment>
+3. Set the element's CanSelectMultiple property to false.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ControlType", "Selection", "CanSelectMultiple", "false"}</comment>
   </data>
   <data name="SelectionItemPatternSingleSelection" xml:space="preserve">
     <value>Do one of the following:
  1. Modify the element and/or its siblings so that only one of them is selected at any given time, OR
- 2. Modify the parent element so its CanSelectMultiple property is TRUE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="CanSelectMultiple"}</comment>
+ 2. Modify the parent element so its CanSelectMultiple property is true.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="CanSelectMultiple", "true"}</comment>
   </data>
   <data name="ParentChildShouldNotHaveSameNameAndLocalizedControlType" xml:space="preserve">
     <value>Provide unique names for controls that have a parent/child relationship and the same ControlType property.</value>
@@ -415,9 +415,9 @@ If the element can't be resized, ensure the TransformPattern_CanResize property 
     <comment>Brief guidance on how to fix an accessibility problem.</comment>
   </data>
   <data name="BoundingRectangleNotNull" xml:space="preserve">
-    <value>If the element is off-screen, set its IsOffscreen property to TRUE.
+    <value>If the element is off-screen, set its IsOffscreen property to true.
 If the element is on-screen, provide a BoundingRectangle property.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsOffscreen", "BoundingRectangle"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsOffscreen", "BoundingRectangle", "true"}</comment>
   </data>
   <data name="BoundingRectangleSizeReasonable" xml:space="preserve">
     <value>Modify the BoundingRectangle property so that its width and height define an area of at least 25 pixels.</value>
@@ -430,19 +430,19 @@ For example, if an element has a level-5 heading, its descendants can have only 
   </data>
   <data name="IsContentElementPropertyExists" xml:space="preserve">
     <value>Provide a value for the element's IsContentElement property:
- · If the element should be included in the content view, set the property to TRUE.
- · If the element should not be included in the content view, set the property to FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsContentElement"}</comment>
+ · If the element should be included in the content view, set the property to true.
+ · If the element should not be included in the content view, set the property to false.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="false", "IsContentElement", "true"}</comment>
   </data>
   <data name="IsControlElementPropertyExists" xml:space="preserve">
     <value>Provide a value for the element's IsControlElement property:
- · If the element should be included in the control view, set the property to TRUE.
- · If the element should not be included in the control view, set the property to FALSE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsControlElement"}</comment>
+ · If the element should be included in the control view, set the property to true.
+ · If the element should not be included in the control view, set the property to false.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="false", "IsControlElement", "true"}</comment>
   </data>
   <data name="IsControlElementTrueRequired" xml:space="preserve">
-    <value>Set the element's IsControlElement property to TRUE.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsControlElement"}</comment>
+    <value>Set the element's IsControlElement property to true.</value>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="IsControlElement", "true"}</comment>
   </data>
   <data name="LandmarkBannerIsTopLevel" xml:space="preserve">
     <value>Modify the banner element so it does not descend from any other landmark.
@@ -484,7 +484,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The list of standard landmark types should be sorted alphabetically or equivalent. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotCustom" xml:space="preserve">
     <value>Provide a string for the LocalizedLandmarkType property that does not include "custom."
@@ -497,7 +497,7 @@ Where appropriate, use a standard localized landmark type:
  ·         Use "navigation" for an area containing links for page or site navigation.
  ·         Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="custom", "LocalizedLandmarkType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The list of standard landmark types should be sorted alphabetically or equivalent. {Locked="custom", "LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotEmpty" xml:space="preserve">
     <value>Provide a string for the LocalizedLandmarkType property.
@@ -510,7 +510,7 @@ Where appropriate, use a standard localized landmark type:
  ·         Use "navigation" for an area containing links for page or site navigation.
  ·         Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The list of standard landmark types should be sorted alphabetically or equivalent. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotNull" xml:space="preserve">
     <value>Provide a LocalizedLandmarkType property for the element.
@@ -523,7 +523,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The list of standard landmark types should be sorted alphabetically or equivalent. {Locked="LocalizedLandmarkType", "null"}</comment>
   </data>
   <data name="LocalizedLandmarkTypeNotWhiteSpace" xml:space="preserve">
     <value>Provide a string for the LocalizedLandmarkType property.
@@ -536,7 +536,7 @@ Where appropriate, use a standard localized landmark type:
  · Use "navigation" for an area containing links for page or site navigation.
  · Use "search" for an area of the page containing search functionality.
 If none of the standard landmark types is applicable, provide a string that concisely describes its content.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="LocalizedLandmarkType"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. The list of standard landmark types should be sorted alphabetically or equivalent. {Locked="LocalizedLandmarkType"}</comment>
   </data>
   <data name="LocalizedControlTypeNotCustom" xml:space="preserve">
     <value>Sufficient:
@@ -619,12 +619,12 @@ If your application targets a version of .NET Framework before 4.7.1, but is run
   <data name="ClickablePointOnScreen" xml:space="preserve">
     <value>If the element's ClickablePoint property is correct, set the element's IsOffScreen property to false.
 If the element's ClickablePoint property is incorrect, please ensure it returns the correct value.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ClickablePoint", "IsOffscreen"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ClickablePoint", "IsOffscreen", "false"}</comment>
   </data>
   <data name="ClickablePointOffScreen" xml:space="preserve">
     <value>If the element's ClickablePoint property is correct, set the element's IsOffScreen property to true.
 If the element's ClickablePoint property is incorrect, please ensure it returns the correct value.</value>
-    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ClickablePoint", "IsOffscreen"}</comment>
+    <comment>Brief guidance on how to fix an accessibility problem. {Locked="ClickablePoint", "IsOffscreen", "true"}</comment>
   </data>
   <data name="FrameworkDoesNotSupportUIAutomation" xml:space="preserve">
     <value>Switch your application to a framework that supports UI Automation.</value>


### PR DESCRIPTION
#### Details
This PR:
* Adds the C# keywords `true`, `false`, and `null` to `Locked` comments where used.
* Adds guidance to translators to alphabetize the list of standard landmark types, as done in English.

##### Motivation
Follow-up of #919 and esn updates in #926.