### PR TITLE
chore: Remove variable that was added for Roslyn migration

### DIFF
--- a/src/RulesMD/RulesMD.csproj
+++ b/src/RulesMD/RulesMD.csproj
@@ -6,8 +6,6 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <!-- Keep the next element all on one line: -->
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <!-- Remove this line and the next line after moving to Roslyn V3 and build version set to 17.0 -->
-    <VSToolsPath>$(VSToolsPath)\..\v17.0</VSToolsPath>
     <TransformOnBuild>true</TransformOnBuild>
     <BeforeTransform>CustomPreTransform</BeforeTransform>
   </PropertyGroup>


### PR DESCRIPTION
#### Details

Revert #882. This was a temporary workaround while the build pipeline tools updated from VS16 to VS17. The signed validation build with this change is at https://dev.azure.com/mseng/1ES/_build/results?buildId=20035917&view=results.

##### Motivation

Code hygiene

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
