### PR TITLE
fix: Reduce noise in ChromiumComponentsShouldUseWebScanner rule

### DIFF
--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -26,8 +26,8 @@ namespace Axe.Windows.AutomationTests
         const int WindowsFormsControlSamplerKnownErrorCount = 6;
         const int WpfControlSamplerKnownErrorCount = 7;
         const int WindowsFormsMultiWindowSamplerAppAllErrorCount = 12;
-        // Note: This will be reduced to 1 when we add logic to ignore all but the top level chrome element
-        const int WebViewSampleKnownErrorCount = 21;
+        // Note: This should change to 159 after https://github.com/MicrosoftEdge/WebView2Feedback/issues/3530 is fixed and integrated
+        const int WebViewSampleKnownErrorCount = 6;
 
         readonly string _wildlifeManagerAppPath = Path.GetFullPath("../../../../../tools/WildlifeManager/WildlifeManager.exe");
         readonly string _win32ControlSamplerAppPath = Path.GetFullPath("../../../../../tools/Win32ControlSampler/Win32ControlSampler.exe");

--- a/src/Rules/Library/ChromiumComponentsShouldUseWebScanner.cs
+++ b/src/Rules/Library/ChromiumComponentsShouldUseWebScanner.cs
@@ -4,7 +4,9 @@
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.Resources;
+using static Axe.Windows.Rules.PropertyConditions.ControlType;
 using static Axe.Windows.Rules.PropertyConditions.Framework;
+using static Axe.Windows.Rules.PropertyConditions.Relationships;
 
 namespace Axe.Windows.Rules.Library
 {
@@ -25,7 +27,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            return Chrome;
+            return Chrome & (Document | AnyAncestor(Document));
         }
     } // class
 } // namespace

--- a/src/Rules/PropertyConditions/Relationships.cs
+++ b/src/Rules/PropertyConditions/Relationships.cs
@@ -43,7 +43,7 @@ namespace Axe.Windows.Rules.PropertyConditions
             if (siblings == null) return false;
             if (index < 1 || index > siblings.Count()) return false;
 
-            return e.Parent.Children.ElementAt(index - 1).RuntimeId == e.RuntimeId;
+            return siblings.ElementAt(index - 1).RuntimeId == e.RuntimeId;
         }
 
         private static bool HasSiblingsOfSameType(IA11yElement e)

--- a/src/Rules/PropertyConditions/Relationships.cs
+++ b/src/Rules/PropertyConditions/Relationships.cs
@@ -6,6 +6,7 @@ using Axe.Windows.Core.Exceptions;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Rules.Resources;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Axe.Windows.Rules.PropertyConditions
@@ -38,17 +39,19 @@ namespace Axe.Windows.Rules.PropertyConditions
         private static bool MatchOrderInSiblings(IA11yElement e, int index)
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
-            if (e.Parent == null || e.Parent.Children == null) return false;
-            if (index < 1 || index > e.Parent.Children.Count()) return false;
+            IEnumerable<IA11yElement> siblings = e.Parent?.Children;
+            if (siblings == null) return false;
+            if (index < 1 || index > siblings.Count()) return false;
 
             return e.Parent.Children.ElementAt(index - 1).RuntimeId == e.RuntimeId;
         }
 
         private static bool HasSiblingsOfSameType(IA11yElement e)
         {
-            if (e?.Parent == null) return false;
+            IA11yElement parent = e?.Parent;
+            if (parent == null) return false;
 
-            var count = (from c in e.Parent.Children
+            var count = (from c in parent.Children
                          where c.ControlTypeId == e.ControlTypeId
                          select c).Count();
 
@@ -66,9 +69,10 @@ namespace Axe.Windows.Rules.PropertyConditions
         {
             if (c == null) throw new ArgumentNullException(nameof(c));
             if (e == null) throw new ArgumentNullException(nameof(e));
-            if (e.Parent == null) return false;
+            IA11yElement parent = e.Parent;
+            if (parent == null) return false;
 
-            return c.Matches(e.Parent);
+            return c.Matches(parent);
         }
 
         public static ValueCondition<int> SiblingCount(Condition c)
@@ -86,11 +90,11 @@ namespace Axe.Windows.Rules.PropertyConditions
         {
             if (c == null) throw new ArgumentNullException(nameof(c));
             if (e == null) throw new ArgumentNullException(nameof(e));
-            if (e.Parent == null) return -1;
-            if (e.Parent.Children == null) return -1;
+            IEnumerable<IA11yElement> children = e.Parent?.Children;
+            if (children == null) return -1;
 
             int count = 0;
-            foreach (var child in e.Parent.Children)
+            foreach (var child in children)
             {
                 if (c.Matches(child))
                     ++count;

--- a/src/RulesTest/Library/ChromiumComponentsShouldUseWebScannerTests.cs
+++ b/src/RulesTest/Library/ChromiumComponentsShouldUseWebScannerTests.cs
@@ -83,7 +83,7 @@ namespace Axe.Windows.RulesTests.Library
 
             _elementMock.Verify(m => m.Framework, Times.Exactly(nonDocumentTypes.Count()));
             _elementMock.Verify(m => m.ControlTypeId, Times.Exactly(nonDocumentTypes.Count()));
-            _elementMock.Verify(m => m.Parent, Times.Exactly(2 * nonDocumentTypes.Count()));
+            _elementMock.Verify(m => m.Parent, Times.Exactly(nonDocumentTypes.Count()));
             _parentMock.Verify(m => m.ControlTypeId, Times.Exactly(nonDocumentTypes.Count()));
             _parentMock.Verify(m => m.Parent, Times.Exactly(nonDocumentTypes.Count()));
         }
@@ -100,7 +100,7 @@ namespace Axe.Windows.RulesTests.Library
 
             _elementMock.Verify(m => m.Framework, Times.Once());
             _elementMock.Verify(m => m.ControlTypeId, Times.Once());
-            _elementMock.Verify(m => m.Parent, Times.Exactly(2));
+            _elementMock.Verify(m => m.Parent, Times.Once());
             _parentMock.Verify(m => m.ControlTypeId, Times.Once());
         }
 

--- a/src/RulesTest/Library/ChromiumComponentsShouldUseWebScannerTests.cs
+++ b/src/RulesTest/Library/ChromiumComponentsShouldUseWebScannerTests.cs
@@ -15,11 +15,13 @@ namespace Axe.Windows.RulesTests.Library
     {
         private static readonly Rules.IRule Rule = new Rules.Library.ChromiumComponentsShouldUseWebScanner();
         private Mock<IA11yElement> _elementMock;
+        private Mock<IA11yElement> _parentMock;
 
         [TestInitialize]
         public void BeforeEach()
         {
             _elementMock = new Mock<IA11yElement>(MockBehavior.Strict);
+            _parentMock = new Mock<IA11yElement>(MockBehavior.Strict);
         }
 
         [TestMethod]
@@ -37,16 +39,81 @@ namespace Axe.Windows.RulesTests.Library
             }
 
             _elementMock.Verify(m => m.Framework, Times.Exactly(nonChromeValues.Count()));
+            _elementMock.Verify(m => m.Framework, Times.Exactly(nonChromeValues.Count()));
         }
 
         [TestMethod]
-        public void Condition_FrameworkIsChrome_ReturnsTrue()
+        public void Condition_FrameworkIsChrome_ControlTypeIsNotDocument_NoParent_ReturnsFalse()
+        {
+            IEnumerable<int> nonDocumentTypes = ControlType.All.Except(new int[] { ControlType.Document });
+            _elementMock.Setup(m => m.Framework).Returns(FrameworkId.Chrome).Verifiable();
+            _elementMock.Setup(m => m.Parent).Returns<IA11yElement>(null).Verifiable();
+
+            foreach (int nonDocumentType in nonDocumentTypes)
+            {
+                _elementMock.Setup(m => m.ControlTypeId)
+                    .Returns(nonDocumentType)
+                    .Verifiable();
+
+                Assert.IsFalse(Rule.Condition.Matches(_elementMock.Object));
+            }
+
+            _elementMock.Verify(m => m.Framework, Times.Exactly(nonDocumentTypes.Count()));
+            _elementMock.Verify(m => m.ControlTypeId, Times.Exactly(nonDocumentTypes.Count()));
+            _elementMock.Verify(m => m.Parent, Times.Exactly(nonDocumentTypes.Count()));
+        }
+
+        [TestMethod]
+        public void Condition_FrameworkIsChrome_ParentControlTypeIsNotDocument_ReturnsFalse()
+        {
+            IEnumerable<int> nonDocumentTypes = ControlType.All.Except(new int[] { ControlType.Document });
+            _elementMock.Setup(m => m.ControlTypeId).Returns(ControlType.Window).Verifiable();  // Arbitrary type
+            _elementMock.Setup(m => m.Framework).Returns(FrameworkId.Chrome).Verifiable();
+            _elementMock.Setup(m => m.Parent).Returns(_parentMock.Object).Verifiable();
+            _parentMock.Setup(m => m.Parent).Returns<IA11yElement>(null).Verifiable();
+
+            foreach (int nonDocumentType in nonDocumentTypes)
+            {
+                _parentMock.Setup(m => m.ControlTypeId)
+                    .Returns(nonDocumentType)
+                    .Verifiable();
+
+                Assert.IsFalse(Rule.Condition.Matches(_elementMock.Object));
+            }
+
+            _elementMock.Verify(m => m.Framework, Times.Exactly(nonDocumentTypes.Count()));
+            _elementMock.Verify(m => m.ControlTypeId, Times.Exactly(nonDocumentTypes.Count()));
+            _elementMock.Verify(m => m.Parent, Times.Exactly(2 * nonDocumentTypes.Count()));
+            _parentMock.Verify(m => m.ControlTypeId, Times.Exactly(nonDocumentTypes.Count()));
+            _parentMock.Verify(m => m.Parent, Times.Exactly(nonDocumentTypes.Count()));
+        }
+
+        [TestMethod]
+        public void Condition_FrameworkIsChrome_ParentControlTypeIsDocument_ReturnsTrue()
         {
             _elementMock.Setup(m => m.Framework).Returns(FrameworkId.Chrome).Verifiable();
+            _elementMock.Setup(m => m.ControlTypeId).Returns(ControlType.Window).Verifiable();  // Arbitrary value
+            _elementMock.Setup(m => m.Parent).Returns(_parentMock.Object).Verifiable();
+            _parentMock.Setup(m => m.ControlTypeId).Returns(ControlType.Document).Verifiable();
 
             Assert.IsTrue(Rule.Condition.Matches(_elementMock.Object));
 
             _elementMock.Verify(m => m.Framework, Times.Once());
+            _elementMock.Verify(m => m.ControlTypeId, Times.Once());
+            _elementMock.Verify(m => m.Parent, Times.Exactly(2));
+            _parentMock.Verify(m => m.ControlTypeId, Times.Once());
+        }
+
+        [TestMethod]
+        public void Condition_FrameworkIsChrome_ControlTypeIsDocument_ReturnsTrue()
+        {
+            _elementMock.Setup(m => m.Framework).Returns(FrameworkId.Chrome).Verifiable();
+            _elementMock.Setup(m => m.ControlTypeId).Returns(ControlType.Document).Verifiable();
+
+            Assert.IsTrue(Rule.Condition.Matches(_elementMock.Object));
+
+            _elementMock.Verify(m => m.Framework, Times.Once());
+            _elementMock.Verify(m => m.ControlTypeId, Times.Once());
         }
 
         [TestMethod]


### PR DESCRIPTION
#### Details

https://github.com/microsoft/accessibility-insights-windows/issues/1625 points out that the `ChromiumComponentsShouldUseWebScanner` rule is flagging items that are outside the context of a web page, which goes against the rule's primary purpose. This change limits the `ChromiumComponentsShouldUseWebScanner` rule to elements within a HTML document (including the document itself).

While working on this, we discovered a bug in WebView2, which is tracked at https://github.com/MicrosoftEdge/WebView2Feedback/issues/3530.

##### Motivation

Address https://github.com/microsoft/accessibility-insights-windows/issues/1625

##### Before & after

###### Text results using Edge

As expected, only the `ChromiumComponentsShouldUseWebScanner` rule is impacted
Rule | Count Before | Count After
--- | --- | ---
An element of the given ControlType must not support the invoke pattern | 1 | 1
An on-screen element must not have a null BoundingRectangle property | 7 | 7
Chromium components should be scanned with a web-based scanner | 211 | 135
The Name must not include the same text as the LocalizedControlType | 5 | 5
The Name property must not contain only whitespace | 3 | 3
The Name property must not include the element's control type | 1 | 1
The Name property of a focusable element must not be null | 10 | 10

###### Screenshots using Edge

These screenshots are limited to just the `ChromiumComponentsShouldUseWebScanner` rule:

State | Screenshot
--- | ---
Before change | ![image](https://github.com/microsoft/axe-windows/assets/45672944/13040b65-3ac7-475e-b6ef-6ca2d2a98907)
After change | ![image](https://github.com/microsoft/axe-windows/assets/45672944/07b7faac-d0fe-46c7-a6b4-7991f9f88838)


##### Context

This includes an opportunistic optimization to some of the code in `Relationships`, because the unit test code looked odd with arbitrary multipliers to compensate for hoe `Relationships` is coded. This could be a separate PR if that's preferred.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: https://github.com/microsoft/accessibility-insights-windows/issues/1625
