### PR TITLE
Upgrade WixToolset to v4.0.1

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -310,6 +310,12 @@ jobs:
       Contents: '**\bin\release\**'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
+  - task: CopyFiles@2
+    displayName: 'Copy MSI File to: $(Build.ArtifactStagingDirectory)'
+    inputs:
+      Contents: '**\CLI_Installer\bin\x86\Release\**'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'
 
@@ -328,13 +334,13 @@ jobs:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: CLI (msi)'
     inputs:
-      PathtoPublish: 'src\CLI_Installer\bin\Release\AxeWindowsCLI.msi'
+      PathtoPublish: 'src\CLI_Installer\bin\x86\Release\AxeWindowsCLI.msi'
       ArtifactName: 'CLI-msi'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: CLI (zip)'
     inputs:
-      PathtoPublish: 'src\CLI_Installer\bin\Release\AxeWindowsCLI.zip'
+      PathtoPublish: 'src\CLI_Installer\bin\x86\Release\AxeWindowsCLI.zip'
       ArtifactName: 'CLI-zip'
 
   - task: CopyFiles@2

--- a/docs/BuildingTheCode.md
+++ b/docs/BuildingTheCode.md
@@ -17,10 +17,13 @@
   cd axe-windows
   ```
 
-### 2. Open the solution in Visual Studio
+### 2. Install the HeatWave extension for Visual Studio
+The `CLI_Installer` project uses WiX 4.X. It will build correctly from the command line, but if you intend to use Visual Studio's IDE, you should consider installing the [HeatWave extension for VS2022](https://marketplace.visualstudio.com/items?itemName=FireGiant.FireGiantHeatWaveDev17). The IDE will continue to work without this extension, but you may encounter errors from the `CLI_Installer` project.
+
+### 3. Open the solution in Visual Studio
 - Use the `src/AxeWindows.sln` file to open the solution.
 
-### 3. Build and run unit tests
+### 4. Build and run unit tests
 
 For details about how the code is organized, please visit the [solution overview](./solution.md).
 

--- a/src/CLI_Installer/CLI_Installer.wixproj
+++ b/src/CLI_Installer/CLI_Installer.wixproj
@@ -1,74 +1,29 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" Condition="Exists('..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props')" />
-  <Import Project="..\packages\WiX.3.11.2\build\wix.props" Condition="Exists('..\packages\WiX.3.11.2\build\wix.props')" />
+<Project Sdk="WixToolset.Sdk/4.0.1">
   <Import Project="..\props\version.props" Condition="Exists('..\props\version.props')" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProductVersion>3.10</ProductVersion>
-    <ProjectGuid>8a086b12-cd59-4b37-89db-499820d9435d</ProjectGuid>
-    <SchemaVersion>2.0</SchemaVersion>
     <OutputName>AxeWindowsCLI</OutputName>
-    <OutputType>Package</OutputType>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
     <SignOutput>true</SignOutput>
     <Name>AxeWindowsCLI</Name>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <OutputPath>bin\$(Configuration)\</OutputPath>
-    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <DefineConstants>Debug;SemVer=$(SemVerNumber);</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <OutputPath>bin\$(Configuration)\</OutputPath>
-    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <DefineConstants>SemVer=$(SemVerNumber);</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Product.wxs" />
+    <PackageReference Include="WixToolset.NetFx.wixext" Version="4.0.1" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.1" />
+    <PackageReference Include="WixToolset.Util.wixext" Version="4.0.1" />
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="packages.config" />
+    <ProjectReference Include="..\CLI\CLI.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <WixExtension Include="WixNetFxExtension">
-      <HintPath>..\packages\WiX.3.11.0\tools\WixNetFxExtension.dll</HintPath>
-      <Name>WixNetFxExtension</Name>
-    </WixExtension>
-    <WixExtension Include="WixUIExtension">
-      <HintPath>$(WixExtDir)\WixUIExtension.dll</HintPath>
-      <Name>WixUIExtension</Name>
-    </WixExtension>
-    <WixExtension Include="WixUtilExtension">
-      <HintPath>$(WixExtDir)\WixUtilExtension.dll</HintPath>
-      <Name>WixUtilExtension</Name>
-    </WixExtension>
-  </ItemGroup>
-  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
-  <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
-    <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
-  </Target>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\WiX.3.11.2\build\wix.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WiX.3.11.2\build\wix.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets'))" />
-  </Target>
-  <!--
-	To modify your build process, add your task inside one of the targets below and uncomment it.
-	Other similar extension points exist, see Wix.targets.
-	<Target Name="BeforeBuild">
-	</Target>
-	<Target Name="AfterBuild">
-	</Target>
-	-->
   <Target Condition=" '$(CreateAxeWindowsZippedCLI)' == 'true' AND '$(ConfigurationName)' == 'Release' " Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\BuildZippedCLI.ps1 -SrcDir $(SolutionDir)CLI_Full\bin\$(ConfigurationName)\net6.0\win7-x86 -TargetDir $(TargetDir) " />
   </Target>
-  <Import Project="..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" Condition="Exists('..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" />
 </Project>

--- a/src/CLI_Installer/CLI_Installer.wixproj
+++ b/src/CLI_Installer/CLI_Installer.wixproj
@@ -1,16 +1,20 @@
 <Project Sdk="WixToolset.Sdk/4.0.1">
   <Import Project="..\props\version.props" Condition="Exists('..\props\version.props')" />
+
   <PropertyGroup>
     <OutputName>AxeWindowsCLI</OutputName>
     <SignOutput>true</SignOutput>
     <Name>AxeWindowsCLI</Name>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DefineConstants>Debug;SemVer=$(SemVerNumber);</DefineConstants>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DefineConstants>SemVer=$(SemVerNumber);</DefineConstants>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="WixToolset.NetFx.wixext" Version="4.0.1" />
     <PackageReference Include="WixToolset.UI.wixext" Version="4.0.1" />
@@ -20,9 +24,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\CLI\CLI.csproj" />
   </ItemGroup>
+
   <Target Condition=" '$(CreateAxeWindowsZippedCLI)' == 'true' AND '$(ConfigurationName)' == 'Release' " Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\BuildZippedCLI.ps1 -SrcDir $(SolutionDir)CLI_Full\bin\$(ConfigurationName)\net6.0\win7-x86 -TargetDir $(TargetDir) " />
   </Target>

--- a/src/CLI_Installer/Product.wxs
+++ b/src/CLI_Installer/Product.wxs
@@ -6,8 +6,8 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <MajorUpgrade Schedule="afterInstallInitialize" RemoveFeatures="All"
                   AllowDowngrades="no"
-                  DowngradeErrorMessage="A newer version of [ProductName] is already installed."
-                  AllowSameVersionUpgrades="no" />
+                  DowngradeErrorMessage="A newer version of [ProductName] is already installed." 
+                  AllowSameVersionUpgrades="no"/>
 
     <ui:WixUI Id="WixUI_InstallDir" />
 
@@ -15,17 +15,17 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <WixVariable Id="WixUIBannerBmp" Value="Resources\WixDialogBanner.png" />
     <WixVariable Id="WixUILicenseRtf" Value="Resources\eula.rtf" />
 
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER"/>
 
     <Property Id="NETCORERUNTIMEFOUNDX86">
-      <DirectorySearch Id="NetCoreDirectoryFoundx86" Path="[ProgramFilesFolder]dotnet">
-        <FileSearch Name="dotnet.exe" MinVersion="6.0" />
+      <DirectorySearch Id="NetCoreDirectoryFoundx86" Path="[ProgramFilesFolder]dotnet" >
+        <FileSearch Name="dotnet.exe" MinVersion="6.0"/>
       </DirectorySearch>
     </Property>
 
     <Property Id="NETCORERUNTIMEFOUNDX64">
-      <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="[ProgramFiles64Folder]dotnet">
-        <FileSearch Name="dotnet.exe" MinVersion="6.0" />
+      <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="[ProgramFiles64Folder]dotnet" >
+        <FileSearch Name="dotnet.exe" MinVersion="6.0"/>
       </DirectorySearch>
     </Property>
 
@@ -80,8 +80,8 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <ComponentGroup Id="Net60ComponentGroup" Directory="Net60Folder">
       <Component Id="Net60Components" Guid="5002A1F9-EB89-441C-B757-8E214EFE82CF">
-        <File Source="..\CLI\bin\Release\net6.0\runtimes\win\lib\net6.0\Microsoft.Win32.SystemEvents.dll" Id="net60_systemevents" />
-        <File Source="..\CLI\bin\Release\net6.0\runtimes\win\lib\net6.0\System.Drawing.Common.dll" Id="net60_systemdrawing" />
+        <File Source="runtimes\win\lib\net6.0\Microsoft.Win32.SystemEvents.dll" Id="net60_systemevents" />
+        <File Source="runtimes\win\lib\net6.0\System.Drawing.Common.dll" Id="net60_systemdrawing" />
       </Component>
     </ComponentGroup>
 

--- a/src/CLI_Installer/Product.wxs
+++ b/src/CLI_Installer/Product.wxs
@@ -1,32 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (c) Microsoft. All rights reserved.
 Licensed under the MIT license. See LICENSE file in the project root for full license information.-->
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Name="Axe.Windows Command Line Interface (CLI)" Language="1033" Version="$(var.SemVer)" Manufacturer="Microsoft" UpgradeCode="186aeebb-f5d4-4161-a0ba-0f22d8d8a15a">
-    <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" Platform="x86" />
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package Name="Axe.Windows Command Line Interface (CLI)" Language="1033" Version="$(var.SemVer)" Manufacturer="Microsoft" UpgradeCode="186aeebb-f5d4-4161-a0ba-0f22d8d8a15a" InstallerVersion="200">
 
     <MajorUpgrade Schedule="afterInstallInitialize" RemoveFeatures="All"
                   AllowDowngrades="no"
-                  DowngradeErrorMessage="A newer version of [ProductName] is already installed." 
-                  AllowSameVersionUpgrades="no"/>
+                  DowngradeErrorMessage="A newer version of [ProductName] is already installed."
+                  AllowSameVersionUpgrades="no" />
 
-    <UIRef Id="WixUI_InstallDir"/>
+    <ui:WixUI Id="WixUI_InstallDir" />
 
     <WixVariable Id="WixUIDialogBmp" Value="Resources\DialogBackground.png" />
     <WixVariable Id="WixUIBannerBmp" Value="Resources\WixDialogBanner.png" />
     <WixVariable Id="WixUILicenseRtf" Value="Resources\eula.rtf" />
 
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER"/>
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
 
     <Property Id="NETCORERUNTIMEFOUNDX86">
-      <DirectorySearch Id="NetCoreDirectoryFoundx86" Path="[ProgramFilesFolder]dotnet" >
-        <FileSearch Name="dotnet.exe" MinVersion="6.0"/>
+      <DirectorySearch Id="NetCoreDirectoryFoundx86" Path="[ProgramFilesFolder]dotnet">
+        <FileSearch Name="dotnet.exe" MinVersion="6.0" />
       </DirectorySearch>
     </Property>
 
     <Property Id="NETCORERUNTIMEFOUNDX64">
-      <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="[ProgramFiles64Folder]dotnet" >
-        <FileSearch Name="dotnet.exe" MinVersion="6.0"/>
+      <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="[ProgramFiles64Folder]dotnet">
+        <FileSearch Name="dotnet.exe" MinVersion="6.0" />
       </DirectorySearch>
     </Property>
 
@@ -37,48 +36,45 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
       <ComponentGroupRef Id="Net60ComponentGroup" />
     </Feature>
 
-    <Condition Message="[ProductName] requires .NET Core Runtime 3.1 or newer. Please visit https://dotnet.microsoft.com/download/dotnet-core">
-      <![CDATA[Installed OR NETCORERUNTIMEFOUNDX64 OR NETCORERUNTIMEFOUNDX86]]>
-    </Condition>
+    <Launch Message="[ProductName] requires .NET Core Runtime 3.1 or newer. Please visit https://dotnet.microsoft.com/download/dotnet-core"
+            Condition="Installed OR NETCORERUNTIMEFOUNDX64 OR NETCORERUNTIMEFOUNDX86" />
 
-    <Directory Id="TARGETDIR" Name="SourceDir" >
-      <Directory Id="ProgramFilesFolder" >
-        <Directory Id="AxeWindowsCLIFolder" Name ="AxeWindowsCLI" >
-          <Directory Id="INSTALLFOLDER" Name="$(var.SemVer)" >
-            <Directory Id="RuntimesFolder" Name="runtimes" >
-              <Directory Id="WinFolder" Name="win" >
-                <Directory Id="LibFolder" Name="lib" >
-                  <Directory Id="Net60Folder" Name="net6.0" />
-                </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="AxeWindowsCLIFolder" Name="AxeWindowsCLI">
+        <Directory Id="INSTALLFOLDER" Name="$(var.SemVer)">
+          <Directory Id="RuntimesFolder" Name="runtimes">
+            <Directory Id="WinFolder" Name="win">
+              <Directory Id="LibFolder" Name="lib">
+                <Directory Id="Net60Folder" Name="net6.0" />
               </Directory>
             </Directory>
           </Directory>
         </Directory>
       </Directory>
-    </Directory>
+    </StandardDirectory>
 
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
       <Component Id="ProductComponent" Guid="548A9965-21AD-4CDF-99AD-A6F2A47D0AE8">
-        <File Source="..\CLI\bin\Release\net6.0\AxeWindowsCLI.exe" />
-        <File Source="..\CLI\bin\Release\net6.0\AxeWindowsCLI.dll" />
-        <File Source="..\CLI\bin\Release\net6.0\AxeWindowsCLI.deps.json" />
-        <File Source="..\CLI\bin\Release\net6.0\AxeWindowsCLI.runtimeconfig.json" />
-        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.Actions.dll" />
-        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.Automation.dll" />
-        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.Core.dll" />
-        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.Desktop.dll" />
-        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.Rules.dll" />
-        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.RuleSelection.dll" />
-        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.SystemAbstractions.dll" />
-        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.Telemetry.dll" />
-        <File Source="..\CLI\bin\Release\net6.0\Axe.Windows.Win32.dll" />
-        <File Source="..\CLI\bin\Release\net6.0\CommandLine.dll" />
-        <File Source="..\CLI\bin\Release\net6.0\Microsoft.Win32.SystemEvents.dll" />
-        <File Source="..\CLI\bin\Release\net6.0\Newtonsoft.Json.dll" />
-        <File Source="..\CLI\bin\Release\net6.0\System.Drawing.Common.dll" />
-        <File Source="..\CLI\bin\Release\net6.0\System.IO.Packaging.dll" />
-        <File Source="..\CLI\bin\Release\net6.0\thirdpartynotices.html" />
-        <File Source="..\CLI\bin\Release\net6.0\README.MD" />
+        <File Source="AxeWindowsCLI.exe" Id="AxeWindowsCLI.exe" />
+        <File Source="AxeWindowsCLI.dll" Id="AxeWindowsCLI.dll" />
+        <File Source="AxeWindowsCLI.deps.json" Id="AxeWindowsCLI.deps.json" />
+        <File Source="AxeWindowsCLI.runtimeconfig.json" Id="AxeWindowsCLI.runtimeconfig.json" />
+        <File Source="Axe.Windows.Actions.dll" Id="Axe.Windows.Actions.dll" />
+        <File Source="Axe.Windows.Automation.dll" Id="Axe.Windows.Automation.dll" />
+        <File Source="Axe.Windows.Core.dll" Id="Axe.Windows.Core.dll" />
+        <File Source="Axe.Windows.Desktop.dll" Id="Axe.Windows.Desktop.dll" />
+        <File Source="Axe.Windows.Rules.dll" Id="Axe.Windows.Rules.dll" />
+        <File Source="Axe.Windows.RuleSelection.dll" Id="Axe.Windows.RuleSelection.dll" />
+        <File Source="Axe.Windows.SystemAbstractions.dll" Id="Axe.Windows.SystemAbstractions.dll" />
+        <File Source="Axe.Windows.Telemetry.dll" Id="Axe.Windows.Telemetry.dll" />
+        <File Source="Axe.Windows.Win32.dll" Id="Axe.Windows.Win32.dll" />
+        <File Source="CommandLine.dll" Id="CommandLine.dll" />
+        <File Source="Microsoft.Win32.SystemEvents.dll" Id="Microsoft.Win32.SystemEvents.dll" />
+        <File Source="Newtonsoft.Json.dll" Id="Newtonsoft.Json.dll" />
+        <File Source="System.Drawing.Common.dll" Id="System.Drawing.Common.dll" />
+        <File Source="System.IO.Packaging.dll" Id="System.IO.Packaging.dll" />
+        <File Source="thirdpartynotices.html" Id="thirdpartynotices.html" />
+        <File Source="README.MD" Id="README.MD" />
       </Component>
     </ComponentGroup>
 
@@ -89,6 +85,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
       </Component>
     </ComponentGroup>
 
-  </Product>
+  </Package>
 
 </Wix>

--- a/src/CLI_Installer/packages.config
+++ b/src/CLI_Installer/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" developmentDependency="true" />
-  <package id="WiX" version="3.11.2" />
-</packages>

--- a/src/MsiFileTests/WxsValidationTests.cs
+++ b/src/MsiFileTests/WxsValidationTests.cs
@@ -89,7 +89,7 @@ namespace MsiFileTests
                         else if (reader.Name == "File" && thisIsTheCorrectComponent)
                         {
                             string relativeFile = reader.GetAttribute("Source");
-                            filesInSection.Add(Path.GetFileName(relativeFile.Substring(2)));
+                            filesInSection.Add(Path.GetFileName(relativeFile));
                         }
                     }
                 }


### PR DESCRIPTION
#### Details

Upgrade WixToolset to v4.0.1

##### Motivation

Address issue #946

##### Context

In WiX v4, it's easier than ever to build MSIs for each platform (x86, x64, arm64) using the exact same sources (with no conditional code).

The default build output directory for the MSI changes from `bin\$(Configuration)\...` to `bin\$(Platform)\$(Configuration)\...` where Platform = `x86`

This MSI contains suboptimal authoring, especially concerning the Windows Installer Best Practices relating to Component/File relationships. Generally speaking, each Component should have only one File. You can create ComponentGroups to group components as needed, but ComponentGroups don't survive in the MSI (they are an authoring-only concept).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #946
