### PR TITLE
fix: Correct dependabot validation

### DIFF
--- a/tools/scripts/pipeline/build/clearly-defined/ValidateScript.bat
+++ b/tools/scripts/pipeline/build/clearly-defined/ValidateScript.bat
@@ -1,0 +1,68 @@
+@echo off
+:: Validator for check-clearly-defined.ps1
+::
+:: Executes check-clearly-defined.ps1 in various scenarios to check script correctness
+
+setlocal
+cls
+
+@echo Skipped case: Non-dependabot branch
+echo pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName fix-bug
+pwsh -f ./check-clearly-defined.ps1 -PipelineType ado -BranchName fix-bug
+if errorlevel 1 goto fail
+echo OK
+echo.
+
+echo Passing case: ADO PR build of dependabot branch
+echo set SYSTEM_PULLREQUEST_SOURCEBRANCH=dependabot/nuget/src/Moq-4.18.4
+set SYSTEM_PULLREQUEST_SOURCEBRANCH=dependabot/nuget/src/Moq-4.18.4
+echo pwsh -f ./check-clearly-defined.ps1 -PipelineType ado
+pwsh -f ./check-clearly-defined.ps1 -PipelineType ado
+if errorlevel 1 goto fail
+echo OK
+echo.
+
+@echo Passing case: ADO non-PR build of dependabot branch
+set SYSTEM_PULLREQUEST_SOURCEBRANCH=
+set BUILD_SOURCEBRANCH=refs/heads/dependabot/nuget/src/Axe.Windows-2.1.3
+echo set BUILD_SOURCEBRANCH=refs/heads/dependabot/nuget/src/Axe.Windows-2.1.3
+echo pwsh -f ./check-clearly-defined.ps1 -PipelineType ado
+pwsh -f ./check-clearly-defined.ps1 -PipelineType ado
+if errorlevel 1 goto fail
+echo OK
+echo.
+
+@echo Passing case: action PR build of dependabot branch without namespace
+set BUILD_SOURCEBRANCH=
+set GITHUB_HEAD_REF=dependabot/npm_and_yarn/eslint-config-prettier-8.9.0
+echo set GITHUB_HEAD_REF=dependabot/npm_and_yarn/eslint-config-prettier-8.9.0
+echo pwsh -f ./check-clearly-defined.ps1 -PipelineType action
+pwsh -f ./check-clearly-defined.ps1 -PipelineType action
+if errorlevel 1 goto fail
+echo OK
+echo.
+
+@echo Passing case: action PR build of dependabot branch with namespace
+set BUILD_SOURCEBRANCH=
+set GITHUB_HEAD_REF=dependabot/npm_and_yarn/typescript-eslint/eslint-plugin-6.3.0
+echo set GITHUB_HEAD_REF=dependabot/npm_and_yarn/typescript-eslint/eslint-plugin-6.3.0
+echo pwsh -f ./check-clearly-defined.ps1 -PipelineType action
+pwsh -f ./check-clearly-defined.ps1 -PipelineType action
+if errorlevel 1 goto fail
+echo OK
+echo.
+
+@echo Failing case: Package that does not exist in ClearlyDefined
+echo pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/nuget/src/Axe.Windows-2.99.99
+pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/nuget/src/Axe.Windows-2.99.99
+if errorlevel 2 goto succeeded
+goto fail
+
+:succeeded
+echo OK
+echo.
+echo ALL TESTS ARE OK :)
+goto :eof
+
+:fail
+echo TEST FAILED -- PLEASE DEBUG THE SCRIPT!

--- a/tools/scripts/pipeline/build/clearly-defined/check-clearly-defined.ps1
+++ b/tools/scripts/pipeline/build/clearly-defined/check-clearly-defined.ps1
@@ -108,6 +108,18 @@ function IsPackageExcluded([string]$namespaceAndPackage) {
     return $exclusions -ne $null -and $exclusions.Contains($namespaceAndPackage)
 }
 
+function AdjustNamespace([string]$provider, [string]$rawNamespace) {
+    if (($provider -eq "npmjs") -and ($rawNamespace -ne "-")) {
+        return "@$rawNameSpace"
+    }
+    
+    if (($provider -eq "nuget") -and ($rawNamespace -eq "src")) {
+        return "-"
+    }
+    
+    return $rawNamespace
+}
+
 function GetUri([string]$branchName){
     $elements = $branchName.Split('/')
 
@@ -119,13 +131,13 @@ function GetUri([string]$branchName){
     $type = GetType $elements[1]
     $provider = GetProvider $elements[1]
     if ($elements.Length -eq 3) {
-        $namespace = "-"
+        $rawNamespace = "-"
         $fullPackage = $elements[2]
     } else {
-        $namespace = $elements[2]
+        $rawNamespace = $elements[2]
         $fullPackage = $elements[3]
     }
-
+    $nameSpace = AdjustNamespace $provider $rawNamespace
     $indexOfLastDash = $fullPackage.LastIndexOf('-') + 1
     $packageName = $fullPackage.Substring(0, $indexOfLastDash - 1)
     $packageVersion = $fullPackage.Substring($indexOfLastDash)


### PR DESCRIPTION
#### Details

Note: This change is a port of https://github.com/microsoft/accessibility-insights-windows/pull/1672

#954 had 2 bugs about namespaces:
1. Dependabot adds a `/src` component to the branch name of NuGet component. The script didn't take this into account and we ended up with an incorrect url
2. Dependabot omits the `@` from branch names of npm components that include a namespace. The script didn't take this into accoiunt and we ended up with an incorrect url

The fix in both cases is the same--we add a function to adjust the raw namespace that comes from parsing the branch name. 

It also includes a batch script to aid in script validation. If we encounter future branch names that go awry, we can just add additional test cases and have protection against breakage.

##### Motivation

Tune the desired friction of dependabot PR's, keep the generated notices file current

##### Output

Here is the output of the script:
```
C:>ValidateScript.bat
Skipped case: Non-dependabot branch
pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName fix-bug
Not a dependabot PR, skipping check
OK

Passing case: ADO PR build of dependabot branch
set SYSTEM_PULLREQUEST_SOURCEBRANCH=dependabot/nuget/src/Moq-4.18.4
pwsh -f ./check-clearly-defined.ps1 -PipelineType ado
Getting data from https://api.clearlydefined.io/definitions/nuget/nuget/-/Moq/4.18.4
ClearlyDefined has a definition for this package version.
OK

Passing case: ADO non-PR build of dependabot branch
set BUILD_SOURCEBRANCH=refs/heads/dependabot/nuget/src/Axe.Windows-2.1.3
pwsh -f ./check-clearly-defined.ps1 -PipelineType ado
Getting data from https://api.clearlydefined.io/definitions/nuget/nuget/-/Axe.Windows/2.1.3
ClearlyDefined has a definition for this package version.
OK

Passing case: action PR build of dependabot branch without namespace
set GITHUB_HEAD_REF=dependabot/npm_and_yarn/eslint-config-prettier-8.9.0
pwsh -f ./check-clearly-defined.ps1 -PipelineType action
Getting data from https://api.clearlydefined.io/definitions/npm/npmjs/-/eslint-config-prettier/8.9.0
ClearlyDefined has a definition for this package version.
OK

Passing case: action PR build of dependabot branch with namespace
set GITHUB_HEAD_REF=dependabot/npm_and_yarn/typescript-eslint/eslint-plugin-6.3.0
pwsh -f ./check-clearly-defined.ps1 -PipelineType action
Getting data from https://api.clearlydefined.io/definitions/npm/npmjs/@typescript-eslint/eslint-plugin/6.3.0
ClearlyDefined has a definition for this package version.
OK

Failing case: Package that does not exist in ClearlyDefined
pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/nuget/src/Axe.Windows-2.99.99
Getting data from https://api.clearlydefined.io/definitions/nuget/nuget/-/Axe.Windows/2.99.99
ClearlyDefined does not have a definition for this package version.
If this is a development component, you may safely ignore this warning.

If this is a production component, please do the following:
1. Request that ClearlyDefined harvest information for this package version
2. Wait for the harvest to complete -- check https://clearlydefined.io
3. Re-run the failed build
4. Once the PR build passes, merge the PR
5. If necessary, add this package to clearly-defined-exclusions.json and include it in your PR.
   Merge the PR once the build passes.
OK

ALL TESTS ARE OK :)
```
##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
The validation script could have been another PowerShell script if we were concerned about allowing validation cross-platform, but this seems like a sufficient option

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



