### PR TITLE
chore: Fix test irregularities

### DIFF
--- a/src/ActionsTests/Misc/ExtensionMethodsTests.cs
+++ b/src/ActionsTests/Misc/ExtensionMethodsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Actions.Misc;
@@ -12,14 +12,14 @@ using System.Linq;
 
 namespace Axe.Windows.ActionsTests.Misc
 {
-    [TestClass()]
+    [TestClass]
     public class ExtensionMethodsTests
     {
         /// <summary>
         /// Create 10 elements with bounding rectangle (i, i, i, i) from [0, 9]
         /// See which one is identified as smallest enclosing area of (5, 5)
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void GetSmallestElementFromPointTest()
         {
             var boundingRects = new List<System.Drawing.Rectangle>();
@@ -39,7 +39,7 @@ namespace Axe.Windows.ActionsTests.Misc
         /// See which one is identified as smallest enclosing area of (5, 5)
         /// Normal answer (3, 3, 3, 3) is off-screen
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void GetSmallestElementFromPointTest_Offscreen()
         {
             var boundingRects = new List<System.Drawing.Rectangle>();
@@ -59,7 +59,7 @@ namespace Axe.Windows.ActionsTests.Misc
         /// Create 10 elements with bounding rectangle (i, i, i, i) from [0, 9]
         /// See which one is identified as smallest enclosing area of (200, 200)
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void GetSmallestElementFromPointTest_NoneOverlaps()
         {
             var boundingRects = new List<System.Drawing.Rectangle>();
@@ -74,13 +74,13 @@ namespace Axe.Windows.ActionsTests.Misc
             Assert.AreEqual(null, answer);
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void GetSmallestElementFromPointTest_NullArgument()
         {
             Assert.ThrowsException<ArgumentNullException>(() => ExtensionMethods.GetSmallestElementFromPoint(null, System.Drawing.Point.Empty));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void GetSmallestElementFromPointTest_NoElementsProvided()
         {
             Assert.ThrowsException<ArgumentException>(() => ExtensionMethods.GetSmallestElementFromPoint(new Dictionary<int, ICoreA11yElement>(), System.Drawing.Point.Empty));

--- a/src/AutomationTests/ScanResultsAssemblerTests.cs
+++ b/src/AutomationTests/ScanResultsAssemblerTests.cs
@@ -13,7 +13,7 @@ using System.Linq;
 
 namespace Axe.Windows.AutomationTests
 {
-    [TestClass()]
+    [TestClass]
     public class ScanResultsAssemblerTests
     {
         readonly ScanResultsAssembler _assembler = new ScanResultsAssembler();

--- a/src/CoreTests/Bases/A11yElementTests.cs
+++ b/src/CoreTests/Bases/A11yElementTests.cs
@@ -12,10 +12,10 @@ namespace Axe.Windows.CoreTests.Bases
     /// <summary>
     /// Tests A11yElement class
     /// </summary>
-    [TestClass()]
+    [TestClass]
     public class A11yElementTests
     {
-        [TestMethod()]
+        [TestMethod]
         [Timeout(2000)]
         public void FindDescendent_SimpleCondition_ReturnsChild()
         {
@@ -31,7 +31,7 @@ namespace Axe.Windows.CoreTests.Bases
             Assert.AreEqual(result, child);
         }
 
-        [TestMethod()]
+        [TestMethod]
         [Timeout(2000)]
         public void FindDescendent_SimpleCondition_ReturnsNull()
         {
@@ -47,7 +47,7 @@ namespace Axe.Windows.CoreTests.Bases
             Assert.IsNull(result);
         }
 
-        [TestMethod()]
+        [TestMethod]
         [Timeout(2000)]
         public void FindDescendent_SimpleCondition_ReturnsGrandchild()
         {
@@ -73,7 +73,7 @@ namespace Axe.Windows.CoreTests.Bases
             Assert.AreEqual(result, grandChild);
         }
 
-        [TestMethod()]
+        [TestMethod]
         [Timeout(2000)]
         public void FindDescendent_SimpleConditionNonePass_ReturnsNull()
         {
@@ -99,7 +99,7 @@ namespace Axe.Windows.CoreTests.Bases
         /// <summary>
         /// Test various getters which use GetPropertySafely
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void GetPropertySafelyTest()
         {
             A11yElement element = Utility.LoadA11yElementsFromJSON("Resources/A11yElementTest.hier");

--- a/src/CoreTests/Bases/A11yPatternPropertyTests.cs
+++ b/src/CoreTests/Bases/A11yPatternPropertyTests.cs
@@ -10,13 +10,13 @@ namespace Axe.Windows.CoreTests.Bases
     /// <summary>
     /// Tests A11yPatternProperty class
     /// </summary>
-    [TestClass()]
+    [TestClass]
     public class A11yPatternPropertyTests
     {
         /// <summary>
         /// Checks NodeValue string output
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void NodeValueTest()
         {
             A11yElement element = Utility.LoadA11yElementsFromJSON("Resources/A11yPatternTest.hier");

--- a/src/CoreTests/Bases/A11yPatternTests.cs
+++ b/src/CoreTests/Bases/A11yPatternTests.cs
@@ -10,13 +10,13 @@ namespace Axe.Windows.CoreTests.Bases
     /// <summary>
     /// Tests A11yPattern class
     /// </summary>
-    [TestClass()]
+    [TestClass]
     public class A11yPatternTests
     {
         /// <summary>
         /// Test ToString and constructor for A11yPattern
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void ToStringTest()
         {
             A11yElement element = Utility.LoadA11yElementsFromJSON("Resources/A11yPatternTest.hier");

--- a/src/CoreTests/Bases/A11yPropertyTests.cs
+++ b/src/CoreTests/Bases/A11yPropertyTests.cs
@@ -12,14 +12,14 @@ namespace Axe.Windows.CoreTests.Bases
     /// <summary>
     /// Tests A11yProperty class
     /// </summary>
-    [TestClass()]
+    [TestClass]
     public class A11yPropertyTests
     {
         /// <summary>
         /// Tests A11yProperty.ToString() through A11yProperty.TextValue.
         /// Also tests constructor.
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void ToStringTest()
         {
             A11yElement element = Utility.LoadA11yElementsFromJSON("Resources/A11yPropertyTest.hier");
@@ -44,7 +44,7 @@ namespace Axe.Windows.CoreTests.Bases
             Assert.AreEqual("False", kpVal);
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void SimpleCustomPropertyTest()
         {
             const int testId = 42;
@@ -55,7 +55,7 @@ namespace Axe.Windows.CoreTests.Bases
             Assert.AreEqual(expectedRendering, kp.ToString());
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void RegisterTwiceCustomPropertyTest()
         {
             const int testId = 42;

--- a/src/CoreTests/CustomObjects/ConfigTests.cs
+++ b/src/CoreTests/CustomObjects/ConfigTests.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace Axe.Windows.CoreTests.CustomObjects
 {
-    [TestClass()]
+    [TestClass]
     public class ConfigTests
     {
         [TestMethod, Timeout(1000)]

--- a/src/CoreTests/CustomObjects/Converters/BoolConverterTests.cs
+++ b/src/CoreTests/CustomObjects/Converters/BoolConverterTests.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace Axe.Windows.CoreTests.CustomObjects.Converters
 {
-    [TestClass()]
+    [TestClass]
     public class BoolConverterTests
     {
         [TestMethod, Timeout(1000)]

--- a/src/CoreTests/CustomObjects/Converters/DoubleConverterTests.cs
+++ b/src/CoreTests/CustomObjects/Converters/DoubleConverterTests.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace Axe.Windows.CoreTests.CustomObjects.Converters
 {
-    [TestClass()]
+    [TestClass]
     public class DoubleConverterTests
     {
         [TestMethod, Timeout(1000)]

--- a/src/CoreTests/CustomObjects/Converters/ElementConverterTests.cs
+++ b/src/CoreTests/CustomObjects/Converters/ElementConverterTests.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace Axe.Windows.CoreTests.CustomObjects.Converters
 {
-    [TestClass()]
+    [TestClass]
     public class ElementConverterTests
     {
         [TestMethod, Timeout(1000)]

--- a/src/CoreTests/CustomObjects/Converters/EnumConverterTests.cs
+++ b/src/CoreTests/CustomObjects/Converters/EnumConverterTests.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 
 namespace Axe.Windows.CoreTests.CustomObjects.Converters
 {
-    [TestClass()]
+    [TestClass]
     public class EnumConverterTests
     {
         [TestMethod, Timeout(1000)]

--- a/src/CoreTests/CustomObjects/Converters/IntConverterTests.cs
+++ b/src/CoreTests/CustomObjects/Converters/IntConverterTests.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace Axe.Windows.CoreTests.CustomObjects.Converters
 {
-    [TestClass()]
+    [TestClass]
     public class IntConverterTests
     {
         [TestMethod, Timeout(1000)]

--- a/src/CoreTests/CustomObjects/Converters/PointConverterTests.cs
+++ b/src/CoreTests/CustomObjects/Converters/PointConverterTests.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace Axe.Windows.CoreTests.CustomObjects.Converters
 {
-    [TestClass()]
+    [TestClass]
     public class PointConverterTests
     {
         [TestMethod, Timeout(1000)]

--- a/src/CoreTests/CustomObjects/Converters/StringConverterTests.cs
+++ b/src/CoreTests/CustomObjects/Converters/StringConverterTests.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace Axe.Windows.CoreTests.CustomObjects.Converters
 {
-    [TestClass()]
+    [TestClass]
     public class StringConverterTests
     {
         [TestMethod, Timeout(1000)]

--- a/src/CoreTests/CustomObjects/CustomPropertyTests.cs
+++ b/src/CoreTests/CustomObjects/CustomPropertyTests.cs
@@ -10,7 +10,7 @@ using System.IO;
 
 namespace Axe.Windows.CoreTests.CustomObjects
 {
-    [TestClass()]
+    [TestClass]
     public class CustomPropertyTests
     {
         [TestMethod, Timeout(1000)]

--- a/src/CoreTests/Misc/MiscTests.cs
+++ b/src/CoreTests/Misc/MiscTests.cs
@@ -13,14 +13,14 @@ namespace Axe.Windows.CoreTests.Misc
     /// <summary>
     /// Tests for the misc folder in Axe.Windows.Core
     /// </summary>
-    [TestClass()]
+    [TestClass]
     public class MiscTests
     {
         /// <summary>
         /// Tests whether the aggregates status counts of a monster
         /// snapshot are accurate
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void GetStatusCounts()
         {
             A11yElement element = UnitTestSharedLibrary.Utility.LoadA11yElementsFromJSON("Snapshots/Taskbar.snapshot");

--- a/src/CoreTests/Results/ScanMetaInfoTests.cs
+++ b/src/CoreTests/Results/ScanMetaInfoTests.cs
@@ -9,13 +9,13 @@ using System.Collections.Generic;
 
 namespace Axe.Windows.CoreTests.Results
 {
-    [TestClass()]
+    [TestClass]
     public class ScanMetaInfoTests
     {
         /// <summary>
         /// Test with PropertyId Set
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void ScanMetaInfoTest()
         {
             A11yElement e = new A11yElement
@@ -37,7 +37,7 @@ namespace Axe.Windows.CoreTests.Results
         /// <summary>
         /// Test without PropertyId
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void ScanMetaInfoTest2()
         {
             A11yElement e = new A11yElement

--- a/src/CoreTests/Types/ControlTypesTests.cs
+++ b/src/CoreTests/Types/ControlTypesTests.cs
@@ -7,23 +7,23 @@ using System.Linq;
 
 namespace Axe.Windows.CoreTests.Types
 {
-    [TestClass()]
+    [TestClass]
     public class ControlTypesTest
     {
-        [TestMethod()]
+        [TestMethod]
         public void CheckExists()
         {
             Assert.AreEqual(true, ControlType.GetInstance().Exists(ControlType.UIA_AppBarControlTypeId));
             Assert.AreEqual(false, ControlType.GetInstance().Exists(0));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void CheckGetNameById()
         {
             Assert.AreEqual("AppBar(50040)", ControlType.GetInstance().GetNameById(ControlType.UIA_AppBarControlTypeId));
         }
 
-        [TestMethod()]
+        [TestMethod]
         [Timeout(1000)]
         public void CheckHasExpectedValues()
         {

--- a/src/CoreTests/Types/HeadingLevelTypeTests.cs
+++ b/src/CoreTests/Types/HeadingLevelTypeTests.cs
@@ -9,64 +9,64 @@ namespace Axe.Windows.CoreTests.Types
     /// <summary>
     /// Tests for HeadingLevelType class
     /// </summary>
-    [TestClass()]
+    [TestClass]
     public class HeadingLevelTypeTests
     {
-        [TestMethod()]
+        [TestMethod]
         public void HeadingLevelNone()
         {
             Assert.AreEqual("HeadingLevel_None (80050)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevelNone));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void HeadingLevel1()
         {
             Assert.AreEqual("HeadingLevel1 (80051)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel1));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void HeadingLevel2()
         {
             Assert.AreEqual("HeadingLevel2 (80052)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel2));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void HeadingLevel3()
         {
             Assert.AreEqual("HeadingLevel3 (80053)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel3));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void HeadingLevel4()
         {
             Assert.AreEqual("HeadingLevel4 (80054)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel4));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void HeadingLevel5()
         {
             Assert.AreEqual("HeadingLevel5 (80055)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel5));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void HeadingLevel6()
         {
             Assert.AreEqual("HeadingLevel6 (80056)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel6));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void HeadingLevel7()
         {
             Assert.AreEqual("HeadingLevel7 (80057)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel7));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void HeadingLevel8()
         {
             Assert.AreEqual("HeadingLevel8 (80058)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel8));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void HeadingLevel9()
         {
             Assert.AreEqual("HeadingLevel9 (80059)", HeadingLevelType.GetInstance().GetNameById(HeadingLevelType.HeadingLevel9));

--- a/src/CoreTests/Types/LegacyIAccessibleRuleTypeTests.cs
+++ b/src/CoreTests/Types/LegacyIAccessibleRuleTypeTests.cs
@@ -7,10 +7,10 @@ using System.Linq;
 
 namespace Axe.Windows.CoreTests.Types
 {
-    [TestClass()]
+    [TestClass]
     public class LegacyIAccessibleRuleTypeTests
     {
-        [TestMethod()]
+        [TestMethod]
         [Timeout(1000)]
         public void CheckExists()
         {
@@ -18,14 +18,14 @@ namespace Axe.Windows.CoreTests.Types
             Assert.AreEqual(false, LegacyIAccessibleRoleType.GetInstance().Exists(0));
         }
 
-        [TestMethod()]
+        [TestMethod]
         [Timeout(1000)]
         public void CheckGetNameById()
         {
             Assert.AreEqual("ROLE_SYSTEM_OUTLINEBUTTON(64)", LegacyIAccessibleRoleType.GetInstance().GetNameById(LegacyIAccessibleRoleType.ROLE_SYSTEM_OUTLINEBUTTON));
         }
 
-        [TestMethod()]
+        [TestMethod]
         [Timeout(1000)]
         public void CheckHasExpectedValues()
         {

--- a/src/CoreTests/Types/PatternTypesTests.cs
+++ b/src/CoreTests/Types/PatternTypesTests.cs
@@ -6,10 +6,10 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.CoreTests.Types
 {
-    [TestClass()]
+    [TestClass]
     public class PatternTypesTests
     {
-        [TestMethod()]
+        [TestMethod]
         public void CheckExists()
         {
             Assert.AreEqual(PatternType.GetInstance().Exists(PatternType.UIA_DockPatternId), true);

--- a/src/CoreTests/Types/PropertyTypesTests.cs
+++ b/src/CoreTests/Types/PropertyTypesTests.cs
@@ -9,30 +9,30 @@ namespace Axe.Windows.CoreTests.Types
     /// <summary>
     /// For PropertyTypes and PlatformPropertyTypes
     /// </summary>
-    [TestClass()]
+    [TestClass]
     public class PropertyTypesTest
     {
-        [TestMethod()]
+        [TestMethod]
         public void CheckExists()
         {
             Assert.AreEqual(true, PropertyType.GetInstance().Exists(PropertyType.UIA_AnnotationPattern_AnnotationTypeNamePropertyId));
             Assert.AreEqual(false, PropertyType.GetInstance().Exists(0));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void CheckGetNameById()
         {
             Assert.AreEqual("AnnotationPattern.AnnotationTypeName", PropertyType.GetInstance().GetNameById(PropertyType.UIA_AnnotationPattern_AnnotationTypeNamePropertyId));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void CheckExistsPlatform()
         {
             Assert.AreEqual(true, PlatformPropertyType.GetInstance().Exists(PlatformPropertyType.Platform_ProcessNamePropertyId));
             Assert.AreEqual(false, PlatformPropertyType.GetInstance().Exists(0));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void CheckGetNameByIdPlatform()
         {
             Assert.AreEqual("ProcessName", PlatformPropertyType.GetInstance().GetNameById(PlatformPropertyType.Platform_ProcessNamePropertyId));

--- a/src/DesktopTests/ColorContrastAnalyzer/BitmapCollectionTests.cs
+++ b/src/DesktopTests/ColorContrastAnalyzer/BitmapCollectionTests.cs
@@ -7,7 +7,7 @@ using Moq;
 
 namespace Axe.Windows.DesktopTests.ColorContrastAnalyzer
 {
-    [TestClass()]
+    [TestClass]
     public class BitmapCollectionTests
     {
         private Mock<IColorContrastConfig> _configMock;

--- a/src/DesktopTests/ColorContrastAnalyzer/ColorPairTests.cs
+++ b/src/DesktopTests/ColorContrastAnalyzer/ColorPairTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Axe.Windows.DesktopTests.ColorContrastAnalyzer
 {
-    [TestClass()]
+    [TestClass]
     public class ColorPairTests
     {
         [TestMethod, Timeout(2000)]

--- a/src/DesktopTests/ColorContrastAnalyzer/ColorTests.cs
+++ b/src/DesktopTests/ColorContrastAnalyzer/ColorTests.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace Axe.Windows.DesktopTests.ColorContrastAnalyzer
 {
-    [TestClass()]
+    [TestClass]
     public class ColorTests
     {
         [TestMethod, Timeout(2000)]

--- a/src/DesktopTests/ColorContrastAnalyzer/ImageTests.cs
+++ b/src/DesktopTests/ColorContrastAnalyzer/ImageTests.cs
@@ -13,7 +13,7 @@ using CCColor = Axe.Windows.Desktop.ColorContrastAnalyzer.Color;
 
 namespace Axe.Windows.DesktopTests.ColorContrastAnalyzer
 {
-    [TestClass()]
+    [TestClass]
     public class ImageTests
     {
         private static readonly IColorContrastConfig ColorContrastConfig =

--- a/src/DesktopTests/ColorContrastAnalyzer/ImageTestsV2.cs
+++ b/src/DesktopTests/ColorContrastAnalyzer/ImageTestsV2.cs
@@ -11,7 +11,7 @@ using CCColor = Axe.Windows.Desktop.ColorContrastAnalyzer.Color;
 
 namespace Axe.Windows.DesktopTests.ColorContrastAnalyzer
 {
-    [TestClass()]
+    [TestClass]
     public class ImageTestsV2
     {
         private static readonly IColorContrastConfig ColorContrastConfig =

--- a/src/DesktopTests/Styles/StyleIdTests.cs
+++ b/src/DesktopTests/Styles/StyleIdTests.cs
@@ -9,112 +9,112 @@ namespace Axe.Windows.DesktopTests.Styles
     /// <summary>
     /// Tests for StyleId class
     /// </summary>
-    [TestClass()]
+    [TestClass]
     public class StyleIdTests
     {
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_Custom()
         {
             Assert.AreEqual("Custom (70000)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Custom));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_Heading1()
         {
             Assert.AreEqual("Heading1 (70001)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading1));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_Heading2()
         {
             Assert.AreEqual("Heading2 (70002)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading2));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_Heading3()
         {
             Assert.AreEqual("Heading3 (70003)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading3));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_Heading4()
         {
             Assert.AreEqual("Heading4 (70004)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading4));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_Heading5()
         {
             Assert.AreEqual("Heading5 (70005)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading5));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_Heading6()
         {
             Assert.AreEqual("Heading6 (70006)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading6));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_Heading7()
         {
             Assert.AreEqual("Heading7 (70007)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading7));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_Heading8()
         {
             Assert.AreEqual("Heading8 (70008)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading8));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_Heading9()
         {
             Assert.AreEqual("Heading9 (70009)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Heading9));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_Title()
         {
             Assert.AreEqual("Title (70010)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Title));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_Subtitle()
         {
             Assert.AreEqual("Subtitle (70011)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Subtitle));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_Normal()
         {
             Assert.AreEqual("Normal (70012)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Normal));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_Emphasis()
         {
             Assert.AreEqual("Emphasis (70013)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Emphasis));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_Quote()
         {
             Assert.AreEqual("Quote (70014)", StyleId.GetInstance().GetNameById(StyleId.StyleId_Quote));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_BulletedList()
         {
             Assert.AreEqual("BulletedList (70015)", StyleId.GetInstance().GetNameById(StyleId.StyleId_BulletedList));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_NumberedList()
         {
             Assert.AreEqual("NumberedList (70016)", StyleId.GetInstance().GetNameById(StyleId.StyleId_NumberedList));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void StyleId_Unknown()
         {
             Assert.AreEqual("Unknown (70099)", StyleId.GetInstance().GetNameById(70099));

--- a/src/DesktopTests/Utility/SupportedEventsTests.cs
+++ b/src/DesktopTests/Utility/SupportedEventsTests.cs
@@ -9,13 +9,13 @@ using System.Linq;
 
 namespace Axe.Windows.DesktopTests.Utility
 {
-    [TestClass()]
+    [TestClass]
     public class SupportedEventsTests
     {
         /// <summary>
         /// Testing whether the mappings contain / don't contain correct button events
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void EventTypeMappingsTest()
         {
             var mappings = SupportedEvents.EventTypeMappings.ToList();

--- a/src/RulesTest/MonsterTest.cs
+++ b/src/RulesTest/MonsterTest.cs
@@ -21,7 +21,7 @@ namespace Axe.Windows.RulesTests
             RuleId.LocalizedControlTypeReasonable,
         };
 
-        [TestMethod()]
+        [TestMethod]
         public void MonsterButtonTest()
         {
             A11yElement e = Utility.LoadA11yElementsFromJSON("Snapshots/MonsterButton.snapshot");


### PR DESCRIPTION
#### Details

Similar to https://github.com/microsoft/accessibility-insights-windows/pull/1687, there are some irregularities in our test decorators. This PR is made up of the following global search & replace operations:
- `[TestClass()]` becomes `[TestClass]`
- `[TestMethod()]` becomes `[TestMethod]`

The extra parentheses on the decorators don't break anything, but they are non-standard and don't add any value. I've confirmed that all unit tests run as expected.

##### Motivation

Code consistency

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
