### PR TITLE
feat(oncall-vendor-transition): Move Dependabot to 09:00 UTC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/src"
   schedule:
     interval: daily
-    time: "9:00"  # UTC
+    time: "8:30"  # UTC
   ignore:
   - dependency-name: Axe.Windows
     versions:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/src"
   schedule:
     interval: daily
-    time: "13:00"
+    time: "9:00"  # UTC
   ignore:
   - dependency-name: Axe.Windows
     versions:


### PR DESCRIPTION
#### Details
Dependabot for our repos is scheduled to run at fairly different times that are inconvenient for some geographies. This PR moves this repo's dependabot time to 09:00 UTC (14:30 IST, 02:00 PDT, 01:00 PST).

##### Motivation
Part of [Feature 2083093](https://mseng.visualstudio.com/1ES/_queries/edit/2083093) (internal access required to view).

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
