### PR TITLE
Chore: Set dependabot PR limit to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/src"
   schedule:
     interval: daily
-    time: "8:30"  # UTC
+    time: "08:30"  # UTC
   ignore:
   - dependency-name: Axe.Windows
     versions:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,4 @@ updates:
   - dependency-name: Moq
     versions:
     - ">= 4.20"  # moq/moq#1372
+  open-pull-requests-limit: 10  # Default value of 5 has been problematic


### PR DESCRIPTION
#### Details
Explicitly set the Dependabot PR limit to 10.

##### Motivation
Consistency is good.

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
