### PR TITLE
chore: Update installer message for .NET version

### DIFF
--- a/src/CLI_Installer/Product.wxs
+++ b/src/CLI_Installer/Product.wxs
@@ -36,7 +36,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
       <ComponentGroupRef Id="Net60ComponentGroup" />
     </Feature>
 
-    <Launch Message="[ProductName] requires .NET Core Runtime 3.1 or newer. Please visit https://dotnet.microsoft.com/download/dotnet-core"
+    <Launch Message="[ProductName] requires .NET Core Runtime 6.0 or newer. Please visit https://dotnet.microsoft.com/download/dotnet-core"
             Condition="Installed OR NETCORERUNTIMEFOUNDX64 OR NETCORERUNTIMEFOUNDX86" />
 
     <StandardDirectory Id="ProgramFilesFolder">


### PR DESCRIPTION
#### Details

#833 updated the CLI from .NET Core 3.1 to .NET 6.0 because .NET Core 3.1 had reached its end of life. Unfortunately, the error message that tells the user the minimum version was not updated. This PR simply corrects that omission and tells the user to install .NET 6.0 or newer.

##### Motivation

Usability

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
The CLI no longer supports Windows 7. This is tracked at #980 and not addressed here.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
