### PR TITLE
fix: MSI installer should warn user about unsupported OS. 

### DIFF
--- a/src/CLI_Installer/Product.wxs
+++ b/src/CLI_Installer/Product.wxs
@@ -2,88 +2,91 @@
 <!-- Copyright (c) Microsoft. All rights reserved.
 Licensed under the MIT license. See LICENSE file in the project root for full license information.-->
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
-  <Package Name="Axe.Windows Command Line Interface (CLI)" Language="1033" Version="$(var.SemVer)" Manufacturer="Microsoft" UpgradeCode="186aeebb-f5d4-4161-a0ba-0f22d8d8a15a" InstallerVersion="200">
+    <Package Name="Axe.Windows Command Line Interface (CLI)" Language="1033" Version="$(var.SemVer)" Manufacturer="Microsoft" UpgradeCode="186aeebb-f5d4-4161-a0ba-0f22d8d8a15a" InstallerVersion="200">
 
-    <MajorUpgrade Schedule="afterInstallInitialize" RemoveFeatures="All"
-                  AllowDowngrades="no"
-                  DowngradeErrorMessage="A newer version of [ProductName] is already installed." 
-                  AllowSameVersionUpgrades="no"/>
+        <MajorUpgrade Schedule="afterInstallInitialize" RemoveFeatures="All"
+                      AllowDowngrades="no"
+                      DowngradeErrorMessage="A newer version of [ProductName] is already installed."
+                      AllowSameVersionUpgrades="no"/>
 
-    <ui:WixUI Id="WixUI_InstallDir" />
+        <ui:WixUI Id="WixUI_InstallDir" />
 
-    <WixVariable Id="WixUIDialogBmp" Value="Resources\DialogBackground.png" />
-    <WixVariable Id="WixUIBannerBmp" Value="Resources\WixDialogBanner.png" />
-    <WixVariable Id="WixUILicenseRtf" Value="Resources\eula.rtf" />
+        <WixVariable Id="WixUIDialogBmp" Value="Resources\DialogBackground.png" />
+        <WixVariable Id="WixUIBannerBmp" Value="Resources\WixDialogBanner.png" />
+        <WixVariable Id="WixUILicenseRtf" Value="Resources\eula.rtf" />
 
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER"/>
+        <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER"/>
 
-    <Property Id="NETCORERUNTIMEFOUNDX86">
-      <DirectorySearch Id="NetCoreDirectoryFoundx86" Path="[ProgramFilesFolder]dotnet" >
-        <FileSearch Name="dotnet.exe" MinVersion="6.0"/>
-      </DirectorySearch>
-    </Property>
+        <Property Id="NETCORERUNTIMEFOUNDX86">
+            <DirectorySearch Id="NetCoreDirectoryFoundx86" Path="[ProgramFilesFolder]dotnet" >
+                <FileSearch Name="dotnet.exe" MinVersion="6.0"/>
+            </DirectorySearch>
+        </Property>
 
-    <Property Id="NETCORERUNTIMEFOUNDX64">
-      <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="[ProgramFiles64Folder]dotnet" >
-        <FileSearch Name="dotnet.exe" MinVersion="6.0"/>
-      </DirectorySearch>
-    </Property>
+        <Property Id="NETCORERUNTIMEFOUNDX64">
+            <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="[ProgramFiles64Folder]dotnet" >
+                <FileSearch Name="dotnet.exe" MinVersion="6.0"/>
+            </DirectorySearch>
+        </Property>
 
-    <MediaTemplate EmbedCab="yes" />
+        <MediaTemplate EmbedCab="yes" />
 
-    <Feature Id="ProductFeature" Title="Axe.Windows CLI" Level="1">
-      <ComponentGroupRef Id="ProductComponents" />
-      <ComponentGroupRef Id="Net60ComponentGroup" />
-    </Feature>
+        <Feature Id="ProductFeature" Title="Axe.Windows CLI" Level="1">
+            <ComponentGroupRef Id="ProductComponents" />
+            <ComponentGroupRef Id="Net60ComponentGroup" />
+        </Feature>
 
-    <Launch Message="[ProductName] requires .NET Core Runtime 6.0 or newer. Please visit https://dotnet.microsoft.com/download/dotnet-core"
-            Condition="Installed OR NETCORERUNTIMEFOUNDX64 OR NETCORERUNTIMEFOUNDX86" />
+        <Launch Message="[ProductName] requires .NET 6, which is supported on Windows 10 or newer."
+         Condition="VersionNT >= 603"/>
 
-    <StandardDirectory Id="ProgramFilesFolder">
-      <Directory Id="AxeWindowsCLIFolder" Name="AxeWindowsCLI">
-        <Directory Id="INSTALLFOLDER" Name="$(var.SemVer)">
-          <Directory Id="RuntimesFolder" Name="runtimes">
-            <Directory Id="WinFolder" Name="win">
-              <Directory Id="LibFolder" Name="lib">
-                <Directory Id="Net60Folder" Name="net6.0" />
-              </Directory>
+        <Launch Message="[ProductName] requires .NET Core Runtime 6.0 or newer. Please visit https://dotnet.microsoft.com/download/dotnet-core"
+                Condition="Installed OR NETCORERUNTIMEFOUNDX64 OR NETCORERUNTIMEFOUNDX86" />
+
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="AxeWindowsCLIFolder" Name="AxeWindowsCLI">
+                <Directory Id="INSTALLFOLDER" Name="$(var.SemVer)">
+                    <Directory Id="RuntimesFolder" Name="runtimes">
+                        <Directory Id="WinFolder" Name="win">
+                            <Directory Id="LibFolder" Name="lib">
+                                <Directory Id="Net60Folder" Name="net6.0" />
+                            </Directory>
+                        </Directory>
+                    </Directory>
+                </Directory>
             </Directory>
-          </Directory>
-        </Directory>
-      </Directory>
-    </StandardDirectory>
+        </StandardDirectory>
 
-    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
-      <Component Id="ProductComponent" Guid="548A9965-21AD-4CDF-99AD-A6F2A47D0AE8">
-        <File Source="AxeWindowsCLI.exe" Id="AxeWindowsCLI.exe" />
-        <File Source="AxeWindowsCLI.dll" Id="AxeWindowsCLI.dll" />
-        <File Source="AxeWindowsCLI.deps.json" Id="AxeWindowsCLI.deps.json" />
-        <File Source="AxeWindowsCLI.runtimeconfig.json" Id="AxeWindowsCLI.runtimeconfig.json" />
-        <File Source="Axe.Windows.Actions.dll" Id="Axe.Windows.Actions.dll" />
-        <File Source="Axe.Windows.Automation.dll" Id="Axe.Windows.Automation.dll" />
-        <File Source="Axe.Windows.Core.dll" Id="Axe.Windows.Core.dll" />
-        <File Source="Axe.Windows.Desktop.dll" Id="Axe.Windows.Desktop.dll" />
-        <File Source="Axe.Windows.Rules.dll" Id="Axe.Windows.Rules.dll" />
-        <File Source="Axe.Windows.RuleSelection.dll" Id="Axe.Windows.RuleSelection.dll" />
-        <File Source="Axe.Windows.SystemAbstractions.dll" Id="Axe.Windows.SystemAbstractions.dll" />
-        <File Source="Axe.Windows.Telemetry.dll" Id="Axe.Windows.Telemetry.dll" />
-        <File Source="Axe.Windows.Win32.dll" Id="Axe.Windows.Win32.dll" />
-        <File Source="CommandLine.dll" Id="CommandLine.dll" />
-        <File Source="Microsoft.Win32.SystemEvents.dll" Id="Microsoft.Win32.SystemEvents.dll" />
-        <File Source="Newtonsoft.Json.dll" Id="Newtonsoft.Json.dll" />
-        <File Source="System.Drawing.Common.dll" Id="System.Drawing.Common.dll" />
-        <File Source="System.IO.Packaging.dll" Id="System.IO.Packaging.dll" />
-        <File Source="thirdpartynotices.html" Id="thirdpartynotices.html" />
-        <File Source="README.MD" Id="README.MD" />
-      </Component>
-    </ComponentGroup>
+        <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+            <Component Id="ProductComponent" Guid="548A9965-21AD-4CDF-99AD-A6F2A47D0AE8">
+                <File Source="AxeWindowsCLI.exe" Id="AxeWindowsCLI.exe" />
+                <File Source="AxeWindowsCLI.dll" Id="AxeWindowsCLI.dll" />
+                <File Source="AxeWindowsCLI.deps.json" Id="AxeWindowsCLI.deps.json" />
+                <File Source="AxeWindowsCLI.runtimeconfig.json" Id="AxeWindowsCLI.runtimeconfig.json" />
+                <File Source="Axe.Windows.Actions.dll" Id="Axe.Windows.Actions.dll" />
+                <File Source="Axe.Windows.Automation.dll" Id="Axe.Windows.Automation.dll" />
+                <File Source="Axe.Windows.Core.dll" Id="Axe.Windows.Core.dll" />
+                <File Source="Axe.Windows.Desktop.dll" Id="Axe.Windows.Desktop.dll" />
+                <File Source="Axe.Windows.Rules.dll" Id="Axe.Windows.Rules.dll" />
+                <File Source="Axe.Windows.RuleSelection.dll" Id="Axe.Windows.RuleSelection.dll" />
+                <File Source="Axe.Windows.SystemAbstractions.dll" Id="Axe.Windows.SystemAbstractions.dll" />
+                <File Source="Axe.Windows.Telemetry.dll" Id="Axe.Windows.Telemetry.dll" />
+                <File Source="Axe.Windows.Win32.dll" Id="Axe.Windows.Win32.dll" />
+                <File Source="CommandLine.dll" Id="CommandLine.dll" />
+                <File Source="Microsoft.Win32.SystemEvents.dll" Id="Microsoft.Win32.SystemEvents.dll" />
+                <File Source="Newtonsoft.Json.dll" Id="Newtonsoft.Json.dll" />
+                <File Source="System.Drawing.Common.dll" Id="System.Drawing.Common.dll" />
+                <File Source="System.IO.Packaging.dll" Id="System.IO.Packaging.dll" />
+                <File Source="thirdpartynotices.html" Id="thirdpartynotices.html" />
+                <File Source="README.MD" Id="README.MD" />
+            </Component>
+        </ComponentGroup>
 
-    <ComponentGroup Id="Net60ComponentGroup" Directory="Net60Folder">
-      <Component Id="Net60Components" Guid="5002A1F9-EB89-441C-B757-8E214EFE82CF">
-        <File Source="runtimes\win\lib\net6.0\Microsoft.Win32.SystemEvents.dll" Id="net60_systemevents" />
-      </Component>
-    </ComponentGroup>
+        <ComponentGroup Id="Net60ComponentGroup" Directory="Net60Folder">
+            <Component Id="Net60Components" Guid="5002A1F9-EB89-441C-B757-8E214EFE82CF">
+                <File Source="runtimes\win\lib\net6.0\Microsoft.Win32.SystemEvents.dll" Id="net60_systemevents" />
+            </Component>
+        </ComponentGroup>
 
-  </Package>
+    </Package>
 
 </Wix>

--- a/src/CLI_Installer/Product.wxs
+++ b/src/CLI_Installer/Product.wxs
@@ -2,91 +2,91 @@
 <!-- Copyright (c) Microsoft. All rights reserved.
 Licensed under the MIT license. See LICENSE file in the project root for full license information.-->
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
-    <Package Name="Axe.Windows Command Line Interface (CLI)" Language="1033" Version="$(var.SemVer)" Manufacturer="Microsoft" UpgradeCode="186aeebb-f5d4-4161-a0ba-0f22d8d8a15a" InstallerVersion="200">
+  <Package Name="Axe.Windows Command Line Interface (CLI)" Language="1033" Version="$(var.SemVer)" Manufacturer="Microsoft" UpgradeCode="186aeebb-f5d4-4161-a0ba-0f22d8d8a15a" InstallerVersion="200">
 
-        <MajorUpgrade Schedule="afterInstallInitialize" RemoveFeatures="All"
-                      AllowDowngrades="no"
-                      DowngradeErrorMessage="A newer version of [ProductName] is already installed."
-                      AllowSameVersionUpgrades="no"/>
+    <MajorUpgrade Schedule="afterInstallInitialize" RemoveFeatures="All"
+                  AllowDowngrades="no"
+                  DowngradeErrorMessage="A newer version of [ProductName] is already installed." 
+                  AllowSameVersionUpgrades="no"/>
 
-        <ui:WixUI Id="WixUI_InstallDir" />
+    <ui:WixUI Id="WixUI_InstallDir" />
 
-        <WixVariable Id="WixUIDialogBmp" Value="Resources\DialogBackground.png" />
-        <WixVariable Id="WixUIBannerBmp" Value="Resources\WixDialogBanner.png" />
-        <WixVariable Id="WixUILicenseRtf" Value="Resources\eula.rtf" />
+    <WixVariable Id="WixUIDialogBmp" Value="Resources\DialogBackground.png" />
+    <WixVariable Id="WixUIBannerBmp" Value="Resources\WixDialogBanner.png" />
+    <WixVariable Id="WixUILicenseRtf" Value="Resources\eula.rtf" />
 
-        <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER"/>
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER"/>
 
-        <Property Id="NETCORERUNTIMEFOUNDX86">
-            <DirectorySearch Id="NetCoreDirectoryFoundx86" Path="[ProgramFilesFolder]dotnet" >
-                <FileSearch Name="dotnet.exe" MinVersion="6.0"/>
-            </DirectorySearch>
-        </Property>
+    <Property Id="NETCORERUNTIMEFOUNDX86">
+      <DirectorySearch Id="NetCoreDirectoryFoundx86" Path="[ProgramFilesFolder]dotnet" >
+        <FileSearch Name="dotnet.exe" MinVersion="6.0"/>
+      </DirectorySearch>
+    </Property>
 
-        <Property Id="NETCORERUNTIMEFOUNDX64">
-            <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="[ProgramFiles64Folder]dotnet" >
-                <FileSearch Name="dotnet.exe" MinVersion="6.0"/>
-            </DirectorySearch>
-        </Property>
+    <Property Id="NETCORERUNTIMEFOUNDX64">
+      <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="[ProgramFiles64Folder]dotnet" >
+        <FileSearch Name="dotnet.exe" MinVersion="6.0"/>
+      </DirectorySearch>
+    </Property>
 
-        <MediaTemplate EmbedCab="yes" />
+    <MediaTemplate EmbedCab="yes" />
 
-        <Feature Id="ProductFeature" Title="Axe.Windows CLI" Level="1">
-            <ComponentGroupRef Id="ProductComponents" />
-            <ComponentGroupRef Id="Net60ComponentGroup" />
-        </Feature>
+    <Feature Id="ProductFeature" Title="Axe.Windows CLI" Level="1">
+      <ComponentGroupRef Id="ProductComponents" />
+      <ComponentGroupRef Id="Net60ComponentGroup" />
+    </Feature>
+      
+    <Launch Message="[ProductName] requires .NET 6, which is supported on Windows 10 or newer."
+            Condition="VersionNT >= 603"/>
 
-        <Launch Message="[ProductName] requires .NET 6, which is supported on Windows 10 or newer."
-         Condition="VersionNT >= 603"/>
+    <Launch Message="[ProductName] requires .NET Core Runtime 6.0 or newer. Please visit https://dotnet.microsoft.com/download/dotnet-core"
+            Condition="Installed OR NETCORERUNTIMEFOUNDX64 OR NETCORERUNTIMEFOUNDX86" />
 
-        <Launch Message="[ProductName] requires .NET Core Runtime 6.0 or newer. Please visit https://dotnet.microsoft.com/download/dotnet-core"
-                Condition="Installed OR NETCORERUNTIMEFOUNDX64 OR NETCORERUNTIMEFOUNDX86" />
-
-        <StandardDirectory Id="ProgramFilesFolder">
-            <Directory Id="AxeWindowsCLIFolder" Name="AxeWindowsCLI">
-                <Directory Id="INSTALLFOLDER" Name="$(var.SemVer)">
-                    <Directory Id="RuntimesFolder" Name="runtimes">
-                        <Directory Id="WinFolder" Name="win">
-                            <Directory Id="LibFolder" Name="lib">
-                                <Directory Id="Net60Folder" Name="net6.0" />
-                            </Directory>
-                        </Directory>
-                    </Directory>
-                </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="AxeWindowsCLIFolder" Name="AxeWindowsCLI">
+        <Directory Id="INSTALLFOLDER" Name="$(var.SemVer)">
+          <Directory Id="RuntimesFolder" Name="runtimes">
+            <Directory Id="WinFolder" Name="win">
+              <Directory Id="LibFolder" Name="lib">
+                <Directory Id="Net60Folder" Name="net6.0" />
+              </Directory>
             </Directory>
-        </StandardDirectory>
+          </Directory>
+        </Directory>
+      </Directory>
+    </StandardDirectory>
 
-        <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
-            <Component Id="ProductComponent" Guid="548A9965-21AD-4CDF-99AD-A6F2A47D0AE8">
-                <File Source="AxeWindowsCLI.exe" Id="AxeWindowsCLI.exe" />
-                <File Source="AxeWindowsCLI.dll" Id="AxeWindowsCLI.dll" />
-                <File Source="AxeWindowsCLI.deps.json" Id="AxeWindowsCLI.deps.json" />
-                <File Source="AxeWindowsCLI.runtimeconfig.json" Id="AxeWindowsCLI.runtimeconfig.json" />
-                <File Source="Axe.Windows.Actions.dll" Id="Axe.Windows.Actions.dll" />
-                <File Source="Axe.Windows.Automation.dll" Id="Axe.Windows.Automation.dll" />
-                <File Source="Axe.Windows.Core.dll" Id="Axe.Windows.Core.dll" />
-                <File Source="Axe.Windows.Desktop.dll" Id="Axe.Windows.Desktop.dll" />
-                <File Source="Axe.Windows.Rules.dll" Id="Axe.Windows.Rules.dll" />
-                <File Source="Axe.Windows.RuleSelection.dll" Id="Axe.Windows.RuleSelection.dll" />
-                <File Source="Axe.Windows.SystemAbstractions.dll" Id="Axe.Windows.SystemAbstractions.dll" />
-                <File Source="Axe.Windows.Telemetry.dll" Id="Axe.Windows.Telemetry.dll" />
-                <File Source="Axe.Windows.Win32.dll" Id="Axe.Windows.Win32.dll" />
-                <File Source="CommandLine.dll" Id="CommandLine.dll" />
-                <File Source="Microsoft.Win32.SystemEvents.dll" Id="Microsoft.Win32.SystemEvents.dll" />
-                <File Source="Newtonsoft.Json.dll" Id="Newtonsoft.Json.dll" />
-                <File Source="System.Drawing.Common.dll" Id="System.Drawing.Common.dll" />
-                <File Source="System.IO.Packaging.dll" Id="System.IO.Packaging.dll" />
-                <File Source="thirdpartynotices.html" Id="thirdpartynotices.html" />
-                <File Source="README.MD" Id="README.MD" />
-            </Component>
-        </ComponentGroup>
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+      <Component Id="ProductComponent" Guid="548A9965-21AD-4CDF-99AD-A6F2A47D0AE8">
+        <File Source="AxeWindowsCLI.exe" Id="AxeWindowsCLI.exe" />
+        <File Source="AxeWindowsCLI.dll" Id="AxeWindowsCLI.dll" />
+        <File Source="AxeWindowsCLI.deps.json" Id="AxeWindowsCLI.deps.json" />
+        <File Source="AxeWindowsCLI.runtimeconfig.json" Id="AxeWindowsCLI.runtimeconfig.json" />
+        <File Source="Axe.Windows.Actions.dll" Id="Axe.Windows.Actions.dll" />
+        <File Source="Axe.Windows.Automation.dll" Id="Axe.Windows.Automation.dll" />
+        <File Source="Axe.Windows.Core.dll" Id="Axe.Windows.Core.dll" />
+        <File Source="Axe.Windows.Desktop.dll" Id="Axe.Windows.Desktop.dll" />
+        <File Source="Axe.Windows.Rules.dll" Id="Axe.Windows.Rules.dll" />
+        <File Source="Axe.Windows.RuleSelection.dll" Id="Axe.Windows.RuleSelection.dll" />
+        <File Source="Axe.Windows.SystemAbstractions.dll" Id="Axe.Windows.SystemAbstractions.dll" />
+        <File Source="Axe.Windows.Telemetry.dll" Id="Axe.Windows.Telemetry.dll" />
+        <File Source="Axe.Windows.Win32.dll" Id="Axe.Windows.Win32.dll" />
+        <File Source="CommandLine.dll" Id="CommandLine.dll" />
+        <File Source="Microsoft.Win32.SystemEvents.dll" Id="Microsoft.Win32.SystemEvents.dll" />
+        <File Source="Newtonsoft.Json.dll" Id="Newtonsoft.Json.dll" />
+        <File Source="System.Drawing.Common.dll" Id="System.Drawing.Common.dll" />
+        <File Source="System.IO.Packaging.dll" Id="System.IO.Packaging.dll" />
+        <File Source="thirdpartynotices.html" Id="thirdpartynotices.html" />
+        <File Source="README.MD" Id="README.MD" />
+      </Component>
+    </ComponentGroup>
 
-        <ComponentGroup Id="Net60ComponentGroup" Directory="Net60Folder">
-            <Component Id="Net60Components" Guid="5002A1F9-EB89-441C-B757-8E214EFE82CF">
-                <File Source="runtimes\win\lib\net6.0\Microsoft.Win32.SystemEvents.dll" Id="net60_systemevents" />
-            </Component>
-        </ComponentGroup>
+    <ComponentGroup Id="Net60ComponentGroup" Directory="Net60Folder">
+      <Component Id="Net60Components" Guid="5002A1F9-EB89-441C-B757-8E214EFE82CF">
+        <File Source="runtimes\win\lib\net6.0\Microsoft.Win32.SystemEvents.dll" Id="net60_systemevents" />
+      </Component>
+    </ComponentGroup>
 
-    </Package>
+  </Package>
 
 </Wix>


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
MSI installer should warn user about unsupported Operating System.
Associated Issue: https://github.com/microsoft/axe-windows/issues/980

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Fix implemented for:

- To warn user about unsupported Operating System by displaying a message as: Axe.Windows Command Line Interface (CLI)

  requires .NET 6, which is supported on Windows 10 or newer.

- Screenshot of the implemented fix: 
  
![image](https://github.com/microsoft/axe-windows/assets/150343275/35a12a0f-0e47-44d4-9309-6916a193dcfa)

- Locally tested all the changes and they are working as expected.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: https://github.com/microsoft/axe-windows/issues/980
- [x] Added screenshots/GIFs to description above
