### PR TITLE
updated the certificate for sign in

### DIFF
--- a/build/settings.targets
+++ b/build/settings.targets
@@ -15,7 +15,7 @@
       </ItemGroup>
       <ItemGroup>
         <FilesToSign Include="@(DropSignedFile)">
-          <Authenticode>3PartySHA2</Authenticode>
+          <Authenticode>Microsoft400</Authenticode>
           <StrongName>StrongName</StrongName>
         </FilesToSign>
       </ItemGroup>


### PR DESCRIPTION
#### Details
Changed certificate from 3rd Party to Microsoft for signing output files.

Verified the artifacts generated and files have Microsoft corporation signature. Link for test run https://dev.azure.com/mseng/1ES/_build/results?buildId=26036565&view=results
Steps used for verification:
1. Download .nupkg file from artifacts of the pipeline run
2. Change the .nupkg extension to .zip
3. Extract the contents of the .zip file
4. Examine the properties of any of the DLL's under the lib\netstandard20 folder
5. Check the details of the digital signature

##### Motivation

addresses issue #995 

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #995 
