### PR TITLE
chore: Update Wix packages to version 4.0.5

### DIFF
--- a/src/CLI_Installer/CLI_Installer.wixproj
+++ b/src/CLI_Installer/CLI_Installer.wixproj
@@ -1,34 +1,28 @@
 <Project Sdk="WixToolset.Sdk/4.0.1">
   <Import Project="..\props\version.props" Condition="Exists('..\props\version.props')" />
-
   <PropertyGroup>
     <OutputName>AxeWindowsCLI</OutputName>
     <SignOutput>true</SignOutput>
     <Name>AxeWindowsCLI</Name>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DefineConstants>Debug;SemVer=$(SemVerNumber);</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DefineConstants>SemVer=$(SemVerNumber);</DefineConstants>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="WixToolset.NetFx.wixext" Version="4.0.1" />
-    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.1" />
-    <PackageReference Include="WixToolset.Util.wixext" Version="4.0.1" />
+    <PackageReference Include="WixToolset.NetFx.wixext" Version="4.0.5" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.5" />
+    <PackageReference Include="WixToolset.Util.wixext" Version="4.0.5" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\CLI\CLI.csproj" />
   </ItemGroup>
-
   <Target Condition=" '$(CreateAxeWindowsZippedCLI)' == 'true' AND '$(ConfigurationName)' == 'Release' " Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\BuildZippedCLI.ps1 -SrcDir $(SolutionDir)CLI_Full\bin\$(ConfigurationName)\net6.0\win7-x86 -TargetDir $(TargetDir) " />
   </Target>


### PR DESCRIPTION
#### Details

Update WixToolset.*.* to address CVE-2024-29188. The existing code does not appear to actually be vulnerable, but this is cheap insurance. 

The change was made via Visual Studio, which removed the extra newlines. I'm not a fan of having the tool pull these out but it's not worth the hassle of trying to keep them in if Visual Studio insists on removing them.

##### Motivation

CVE

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: https://mseng.visualstudio.com/1ES/_workitems/edit/2162355
