### PR TITLE
feat(logical-size): Implement the LogicalSize property in Axe.Windows

### DIFF
--- a/src/Core/Bases/A11yElement.cs
+++ b/src/Core/Bases/A11yElement.cs
@@ -316,6 +316,15 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        [JsonIgnore]
+        public Size LogicalSize
+        {
+            get
+            {
+                return GetPropertySafely(PropertyType.Axe_LogicalSizePseudoPropertyId).ToSize();
+            }
+        }
+
         /// <summary>
         /// the heading level if it exists; otherwise, 0
         /// </summary>

--- a/src/Core/Bases/A11yProperty.cs
+++ b/src/Core/Bases/A11yProperty.cs
@@ -82,7 +82,10 @@ namespace Axe.Windows.Core.Bases
             if (Value != null)
             {
                 switch (Id)
-                {
+                    {
+                    case PropertyType.Axe_LogicalSizePseudoPropertyId:
+                        txt = $"[w={Value[0]},h={Value[1]}]";
+                        break;
                     case PropertyType.UIA_RuntimeIdPropertyId:
                         txt = this.ConvertIntArrayToString();
                         break;

--- a/src/Core/Bases/IA11yElement.cs
+++ b/src/Core/Bases/IA11yElement.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Axe.Windows.Core.Enums;
@@ -30,6 +30,7 @@ namespace Axe.Windows.Core.Bases
         OrientationType Orientation { get; }
         int LandmarkType { get; }
         string LocalizedLandmarkType { get; }
+        Size LogicalSize { get; }
         int HeadingLevel { get; }
         string RuntimeId { get; }
         int ProcessId { get; }

--- a/src/Core/Misc/ExtensionMethods.cs
+++ b/src/Core/Misc/ExtensionMethods.cs
@@ -599,6 +599,17 @@ namespace Axe.Windows.Core.Misc
             return retVal;
         }
 
+        /// <summary>
+        /// Convert Element Property value to Size
+        /// </summary>
+        /// <param name="property"></param>
+        /// <returns>A Size object</returns>
+        public static Size ToSize(this A11yProperty property)
+        {
+            if (property?.Value is null) return Size.Empty;
+            return new Size(property.Value[0], property.Value[1]);
+        }
+
         public static string ToLeftTopRightBottomString(this Rectangle r)
         {
             return string.Format(CultureInfo.CurrentCulture, DisplayStrings.LeftTopRightBottomFormat, r.Left, r.Top, r.Right, r.Bottom);

--- a/src/Core/Types/PropertyType.cs
+++ b/src/Core/Types/PropertyType.cs
@@ -17,6 +17,8 @@ namespace Axe.Windows.Core.Types
     public class PropertyType : TypeBase
     {
 #pragma warning disable CA1707 // Identifiers should not contain underscores
+        public const int Axe_LogicalSizePseudoPropertyId = 29999;
+
         public const int UIA_RuntimeIdPropertyId = 30000;
         public const int UIA_BoundingRectanglePropertyId = 30001;
         public const int UIA_ProcessIdPropertyId = 30002;
@@ -211,7 +213,11 @@ namespace Axe.Windows.Core.Types
         /// <summary>
         /// private constructor since this uses a singleton model
         /// </summary>
-        private PropertyType() : base() { }
+        private PropertyType() : base()
+        {
+            // Explicitly add pseudo-properties
+            Dic[Axe_LogicalSizePseudoPropertyId] = GetNameInProperFormat("Axe_LogicalSizePseudoPropertyId", Axe_LogicalSizePseudoPropertyId);
+        }
 
         /// <summary>
         /// change name into right format in dictionary and list.
@@ -221,6 +227,10 @@ namespace Axe.Windows.Core.Types
         protected override string GetNameInProperFormat(string name, int id)
         {
             StringBuilder sb = new StringBuilder(name);
+
+            // Handle pseudo-properties
+            sb.Replace("Axe_", "");
+            sb.Replace("PseudoPropertyId", "");
 
             sb.Replace("UIA_", "");
             sb.Replace("PropertyId", "");

--- a/src/CoreTests/Bases/A11yPropertyTests.cs
+++ b/src/CoreTests/Bases/A11yPropertyTests.cs
@@ -42,6 +42,9 @@ namespace Axe.Windows.CoreTests.Bases
 
             kpVal = element.Properties[PropertyType.UIA_HasKeyboardFocusPropertyId].ToString();
             Assert.AreEqual("False", kpVal);
+
+            kpVal = element.Properties[PropertyType.Axe_LogicalSizePseudoPropertyId].ToString();
+            Assert.AreEqual("[w=995,h=78]", kpVal);
         }
 
         [TestMethod]

--- a/src/CoreTests/Resources/A11yPropertyTest.hier
+++ b/src/CoreTests/Resources/A11yPropertyTest.hier
@@ -234,6 +234,14 @@
       "Value": 0,
       "LabeledBy": null,
       "TextValue": "0"
+    },
+    "29999": {
+      "Value": [
+        995,
+        78
+      ],
+      "Id": 29999,
+      "Name": "LogicalSize"
     }
   },
   "Patterns": [

--- a/src/Win32/NativeMethods.cs
+++ b/src/Win32/NativeMethods.cs
@@ -1,7 +1,8 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Data;
 using System.Drawing;
 using System.Runtime.InteropServices;
 
@@ -38,5 +39,16 @@ namespace Axe.Windows.Win32
 
         [DllImport("user32.dll", EntryPoint = "SystemParametersInfoW", SetLastError = true)]
         internal static extern bool SystemParametersInfoHighContrast(uint action, uint param, ref HighContrastData vparam, uint init);
+
+        //https://msdn.microsoft.com/en-us/library/windows/desktop/dd145062(v=vs.85).aspx
+        [DllImport("User32.dll")]
+        internal static extern IntPtr MonitorFromPoint([In] Point pt, [In] uint dwFlags);
+
+        //https://msdn.microsoft.com/en-us/library/windows/desktop/dn280510(v=vs.85).aspx
+        [DllImport("Shcore.dll")]
+        internal static extern uint GetDpiForMonitor([In] IntPtr hmonitor, [In] DpiType dpiType, [Out] out uint dpiX, [Out] out uint dpiY);
+
+        [DllImport("gdi32.dll", CharSet = CharSet.Auto, SetLastError = true, ExactSpelling = true)]
+        internal static extern uint GetDeviceCaps(IntPtr hDC, int nIndex);
     }
 }

--- a/src/Win32/Win32Enums.cs
+++ b/src/Win32/Win32Enums.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Axe.Windows.Win32
@@ -22,5 +22,31 @@ namespace Axe.Windows.Win32
         /// OS is newer than comparison point
         /// </summary>
         Newer
+    }
+
+    /// <summary>
+    /// https://msdn.microsoft.com/en-us/library/windows/desktop/dn280511(v=vs.85).aspx
+    /// </summary>
+    public enum DpiType
+    {
+        Effective = 0,
+        Angular = 1,
+        Raw = 2,
+    }
+
+    /// <summary>
+    /// Device Cap
+    /// https://docs.microsoft.com/en-us/windows/desktop/api/wingdi/nf-wingdi-getdevicecaps
+    /// </summary>
+    public enum DeviceCap
+    {
+        /// <summary>
+        /// Logical pixels inch in X
+        /// </summary>
+        LOGPIXELSX = 88,
+        /// <summary>
+        /// Logical pixels inch in Y
+        /// </summary>
+        LOGPIXELSY = 90
     }
 }

--- a/src/Win32/Win32Helper.cs
+++ b/src/Win32/Win32Helper.cs
@@ -3,6 +3,7 @@
 
 using Axe.Windows.SystemAbstractions;
 using System;
+using System.Drawing;
 
 namespace Axe.Windows.Win32
 {
@@ -123,6 +124,46 @@ namespace Axe.Windows.Win32
         internal bool IsWindows11OrLater()
         {
             return IsAtLeastWin10WithSpecificBuild(22000);
+        }
+
+        /// <summary>
+        /// Get DPI value from point
+        /// </summary>
+        /// <param name="point"></param>
+        /// <param name="dpiType"></param>
+        /// <param name="dpiX"></param>
+        /// <param name="dpiY"></param>
+        internal static void GetDpi(Point point, DpiType dpiType, out uint dpiX, out uint dpiY)
+        {
+            const uint defaultDpi = 96;
+            const uint S_OK = 0;
+
+            var mon = NativeMethods.MonitorFromPoint(
+                point,
+                2 // MONITOR_DEFAULTTONEAREST
+            );
+
+            if (IsWindows7())
+            {
+                Graphics g = Graphics.FromHwnd(IntPtr.Zero);
+                IntPtr desktop = g.GetHdc();
+
+                dpiX = NativeMethods.GetDeviceCaps(desktop, (int)DeviceCap.LOGPIXELSX);
+                dpiY = NativeMethods.GetDeviceCaps(desktop, (int)DeviceCap.LOGPIXELSY);
+            }
+            else
+            {
+                if (NativeMethods.GetDpiForMonitor(mon, dpiType, out uint localDpiX, out uint localDpiY) == S_OK)
+                {
+                    dpiX = localDpiX;
+                    dpiY = localDpiY;
+                }
+                else
+                {
+                    dpiX = defaultDpi;
+                    dpiY = defaultDpi;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
#### Details
This PR adds a "pseudo-property", `LogicalSize`, a normalized size based on an element's `BoundingRectangle` to aid in touch size calculations. 

##### Motivation
Part of [Feature 2152841](https://mseng.visualstudio.com/1ES/_workitems/edit/2152841) (internal access required to view).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
