### PR TITLE
Add ScanOptions.NativeWindowHandle to scope Scans to rooted UIA sub-tree

### DIFF
--- a/docs/AutomationReference.md
+++ b/docs/AutomationReference.md
@@ -172,7 +172,7 @@ The `ScanOptions` constructor accepts the following arguments:
 **Name** | **Type** | **Description** | **Default value**
 ---|---|---|---
 scanId | `string` | A string identifier for the scan. If the scan produces output files based on the `Config` object used to create the scanner, the output files will be given the name of the scan id (e.g., MyScanId.a11ytest). | `null`
-scanRootWindowHandle | `IntPtr?` | The native window handle (HWND) of the UIA element whose sub-tree should be scanned. If not specified or no element matches the HWND, the process's full UIA tree will be scanned. | `null`
+scanRootWindowHandle | `IntPtr` | The native window handle (HWND) of the UIA element whose sub-tree should be scanned. If not specified or no element matches the HWND, the process's full UIA tree will be scanned. | `null`
 
 #### ScanOutput
 Methods of `IScanner` return a `ScanOutput` object with the following properties:

--- a/docs/AutomationReference.md
+++ b/docs/AutomationReference.md
@@ -172,6 +172,7 @@ The `ScanOptions` constructor accepts the following arguments:
 **Name** | **Type** | **Description** | **Default value**
 ---|---|---|---
 scanId | `string` | A string identifier for the scan. If the scan produces output files based on the `Config` object used to create the scanner, the output files will be given the name of the scan id (e.g., MyScanId.a11ytest). | `null`
+scanRootWindowHandle | `IntPtr?` | The native window handle (HWND) of the UIA element whose sub-tree should be scanned. If not specified or no element matches the HWND, the process's full UIA tree will be scanned. | `null`
 
 #### ScanOutput
 Methods of `IScanner` return a `ScanOutput` object with the following properties:

--- a/src/Automation/Data/ScanOptions.cs
+++ b/src/Automation/Data/ScanOptions.cs
@@ -15,6 +15,11 @@ namespace Axe.Windows.Automation.Data
         public string ScanId { get; }
 
         /// <summary>
+        /// The window handle for the root of the UIA subtree to scan.
+        /// </summary>
+        public System.IntPtr WindowHandle { get; set; } = System.IntPtr.Zero;
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="scanId">The ID of this scan. Must be null or meet the requirements for a file name.</param>

--- a/src/Automation/Data/ScanOptions.cs
+++ b/src/Automation/Data/ScanOptions.cs
@@ -17,7 +17,7 @@ namespace Axe.Windows.Automation.Data
         /// <summary>
         /// The window handle for the root of the UIA subtree to scan.
         /// </summary>
-        public System.IntPtr WindowHandle { get; set; } = System.IntPtr.Zero;
+        public System.IntPtr ScanRootWindowHandle { get; set; } = System.IntPtr.Zero;
 
         /// <summary>
         /// Constructor

--- a/src/Automation/Data/ScanOptions.cs
+++ b/src/Automation/Data/ScanOptions.cs
@@ -17,15 +17,17 @@ namespace Axe.Windows.Automation.Data
         /// <summary>
         /// The window handle for the root of the UIA subtree to scan.
         /// </summary>
-        public System.IntPtr ScanRootWindowHandle { get; set; } = System.IntPtr.Zero;
+        public System.IntPtr ScanRootWindowHandle { get; }
 
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="scanId">The ID of this scan. Must be null or meet the requirements for a file name.</param>
-        public ScanOptions(string scanId = null)
+        /// <param name="scanRootWindowHandle">The window handle for the root of the UIA subtree to scan.</param>
+        public ScanOptions(string scanId = null, System.IntPtr? scanRootWindowHandle = null)
         {
             ScanId = scanId;
+            ScanRootWindowHandle = scanRootWindowHandle.GetValueOrDefault(System.IntPtr.Zero);
         }
     }
 }

--- a/src/Automation/Interfaces/IScanTools.cs
+++ b/src/Automation/Interfaces/IScanTools.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Axe.Windows.Automation
 {
-    using System;
-
     /// <summary>
     /// Encapsulates the set of tools used to scan, assemble results, and write output files
     /// </summary>

--- a/src/Automation/Interfaces/IScanTools.cs
+++ b/src/Automation/Interfaces/IScanTools.cs
@@ -3,6 +3,8 @@
 
 namespace Axe.Windows.Automation
 {
+    using System;
+
     /// <summary>
     /// Encapsulates the set of tools used to scan, assemble results, and write output files
     /// </summary>
@@ -13,5 +15,6 @@ namespace Axe.Windows.Automation
         ITargetElementLocator TargetElementLocator { get; }
         IAxeWindowsActions Actions { get; }
         IDPIAwareness DpiAwareness { get; }
+        IntPtr ScanRootWindowHandle { get; set; }
     } // interface
 } // namespace

--- a/src/Automation/Interfaces/ITargetElementLocator.cs
+++ b/src/Automation/Interfaces/ITargetElementLocator.cs
@@ -9,7 +9,6 @@ namespace Axe.Windows.Automation
 {
     internal interface ITargetElementLocator
     {
-        IEnumerable<A11yElement> LocateRootElements(int processId, IActionContext actionContext);
-        void SetRootWindowHandle(System.IntPtr windowHandle);
+        IEnumerable<A11yElement> LocateRootElements(int processId, IActionContext actionContext, System.IntPtr rootWindowHandle);
     } // interface
 } // namespace

--- a/src/Automation/Interfaces/ITargetElementLocator.cs
+++ b/src/Automation/Interfaces/ITargetElementLocator.cs
@@ -10,5 +10,6 @@ namespace Axe.Windows.Automation
     internal interface ITargetElementLocator
     {
         IEnumerable<A11yElement> LocateRootElements(int processId, IActionContext actionContext);
+        void SetRootWindowHandle(System.IntPtr windowHandle);
     } // interface
 } // namespace

--- a/src/Automation/ScanTools.cs
+++ b/src/Automation/ScanTools.cs
@@ -12,6 +12,7 @@ namespace Axe.Windows.Automation
         public ITargetElementLocator TargetElementLocator { get; }
         public IAxeWindowsActions Actions { get; }
         public IDPIAwareness DpiAwareness { get; }
+        public IntPtr ScanRootWindowHandle { get; set; } = IntPtr.Zero;
 
         public ScanTools(IOutputFileHelper outputFileHelper, IScanResultsAssembler resultsAssembler, ITargetElementLocator targetElementLocator, IAxeWindowsActions actions, IDPIAwareness dpiAwareness)
         {

--- a/src/Automation/Scanner.cs
+++ b/src/Automation/Scanner.cs
@@ -42,7 +42,7 @@ namespace Axe.Windows.Automation
         {
             scanOptions = scanOptions ?? DefaultScanOptions;
             _scanTools.OutputFileHelper.SetScanId(scanOptions.ScanId);
-            _scanTools.TargetElementLocator.SetRootWindowHandle(scanOptions.WindowHandle);
+            _scanTools.TargetElementLocator.SetRootWindowHandle(scanOptions.ScanRootWindowHandle);
         }
     } // class
 } // namespace

--- a/src/Automation/Scanner.cs
+++ b/src/Automation/Scanner.cs
@@ -42,6 +42,7 @@ namespace Axe.Windows.Automation
         {
             scanOptions = scanOptions ?? DefaultScanOptions;
             _scanTools.OutputFileHelper.SetScanId(scanOptions.ScanId);
+            _scanTools.TargetElementLocator.SetRootWindowHandle(scanOptions.WindowHandle);
         }
     } // class
 } // namespace

--- a/src/Automation/Scanner.cs
+++ b/src/Automation/Scanner.cs
@@ -42,7 +42,7 @@ namespace Axe.Windows.Automation
         {
             scanOptions = scanOptions ?? DefaultScanOptions;
             _scanTools.OutputFileHelper.SetScanId(scanOptions.ScanId);
-            _scanTools.TargetElementLocator.SetRootWindowHandle(scanOptions.ScanRootWindowHandle);
+            _scanTools.ScanRootWindowHandle = scanOptions.ScanRootWindowHandle;
         }
     } // class
 } // namespace

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -66,7 +66,7 @@ namespace Axe.Windows.Automation
 
             using (var actionContext = ScopedActionContext.CreateInstance(cancellationToken))
             {
-                var rootElements = scanTools.TargetElementLocator.LocateRootElements(config.ProcessId, actionContext);
+                var rootElements = scanTools.TargetElementLocator.LocateRootElements(config.ProcessId, actionContext, scanTools.ScanRootWindowHandle);
 
                 if (rootElements is null || !rootElements.Any())
                 {

--- a/src/Automation/TargetElementLocator.cs
+++ b/src/Automation/TargetElementLocator.cs
@@ -14,11 +14,13 @@ namespace Axe.Windows.Automation
 {
     class TargetElementLocator : ITargetElementLocator
     {
+        private IntPtr _rootWindowHandle;
+
         public IEnumerable<A11yElement> LocateRootElements(int processId, IActionContext actionContext)
         {
             try
             {
-                var desktopElements = A11yAutomation.ElementsFromProcessId(processId, actionContext.DesktopDataContext);
+                var desktopElements = A11yAutomation.ElementsFromProcessId(processId, _rootWindowHandle, actionContext.DesktopDataContext);
                 return GetA11yElementsFromDesktopElements(desktopElements);
             }
             catch (Exception ex)
@@ -38,5 +40,7 @@ namespace Axe.Windows.Automation
 #pragma warning restore CA2000
             }
         }
+
+        public void SetRootWindowHandle(IntPtr rootWindowHandle) => _rootWindowHandle = rootWindowHandle;
     }
 }

--- a/src/Automation/TargetElementLocator.cs
+++ b/src/Automation/TargetElementLocator.cs
@@ -14,13 +14,11 @@ namespace Axe.Windows.Automation
 {
     class TargetElementLocator : ITargetElementLocator
     {
-        private IntPtr _rootWindowHandle;
-
-        public IEnumerable<A11yElement> LocateRootElements(int processId, IActionContext actionContext)
+        public IEnumerable<A11yElement> LocateRootElements(int processId, IActionContext actionContext, IntPtr rootWindowHandle)
         {
             try
             {
-                var desktopElements = A11yAutomation.ElementsFromProcessId(processId, _rootWindowHandle, actionContext.DesktopDataContext);
+                var desktopElements = A11yAutomation.ElementsFromProcessId(processId, rootWindowHandle, actionContext.DesktopDataContext);
                 return GetA11yElementsFromDesktopElements(desktopElements);
             }
             catch (Exception ex)
@@ -40,7 +38,5 @@ namespace Axe.Windows.Automation
 #pragma warning restore CA2000
             }
         }
-
-        public void SetRootWindowHandle(IntPtr rootWindowHandle) => _rootWindowHandle = rootWindowHandle;
     }
 }

--- a/src/AutomationTests/A11yAutomationUtilities.cs
+++ b/src/AutomationTests/A11yAutomationUtilities.cs
@@ -3,6 +3,10 @@
 
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Desktop.UIAutomation;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
 using UIAutomationClient;
 
@@ -13,6 +17,13 @@ namespace Axe.Windows.AutomationTests
     /// </summary>
     public class A11yAutomationUtilities
     {
+        internal static DesktopElement GetRootElement()
+        {
+            IUIAutomation uiAutomation = A11yAutomation.GetDefaultInstance().UIAutomation;
+            IUIAutomationElement focusedElement = uiAutomation.GetRootElement();
+            return new DesktopElement(focusedElement, keepElement: true, setMembers: true);
+        }
+
         internal static DesktopElement GetFocusedElement()
         {
             IUIAutomation uiAutomation = A11yAutomation.GetDefaultInstance().UIAutomation;
@@ -20,17 +31,13 @@ namespace Axe.Windows.AutomationTests
             return new DesktopElement(focusedElement, keepElement: true, setMembers: true);
         }
 
-        internal static DesktopElement GetDepthFirstLastLeafControlElement(DesktopElement rootElement)
+        internal static DesktopElement GetDepthFirstLastLeafHWNDElement(DesktopElement rootElement)
         {
             var walker = A11yAutomation.GetDefaultInstance().GetTreeWalker(TreeViewMode.Control);
             try
             {
-                IUIAutomationElement leafElement = (IUIAutomationElement)rootElement.PlatformObject;
-                for (IUIAutomationElement currentElement = walker.GetLastChildElement(leafElement); currentElement != null; currentElement = walker.GetLastChildElement(leafElement))
-                {
-                    Marshal.ReleaseComObject(leafElement);
-                    leafElement = currentElement;
-                }
+                IUIAutomationElement rootAutomationElement = rootElement.PlatformObject;
+                IUIAutomationElement leafElement = FindLastWindowHandleElement(rootAutomationElement);
 
                 return leafElement is null
                     ? rootElement
@@ -39,6 +46,52 @@ namespace Axe.Windows.AutomationTests
             finally
             {
                 Marshal.ReleaseComObject(walker);
+            }
+
+            IUIAutomationElement FindLastWindowHandleElement(IUIAutomationElement parent)
+            {
+                List<IUIAutomationElement> matchingElements = new();
+                for (var child = walker.GetFirstChildElement(parent); child != null; child = MatchAndMoveNext(child))
+                {
+                }
+
+                foreach (var element in matchingElements)
+                {
+                    FindLastWindowHandleElement(element);
+                }
+
+                foreach (var element in matchingElements.Take(matchingElements.Count - 1))
+                {
+                    Marshal.ReleaseComObject(element);
+                }
+
+                return matchingElements.LastOrDefault();
+
+                IUIAutomationElement MatchAndMoveNext(IUIAutomationElement element)
+                {
+                    IUIAutomationElement next;
+                    try
+                    {
+                        next = walker.GetNextSiblingElement(element);
+                    }
+                    catch(COMException e)
+                    {
+                        Debug.WriteLine(message: $"Error getting sibling of {element.CurrentName}: {e}");
+                        next = null;
+                    }
+
+                    if (element.CurrentNativeWindowHandle != IntPtr.Zero)
+                    {
+                        Debug.WriteLine(message: $"HWND={element.CurrentNativeWindowHandle}; Name='{element.CurrentName}'; ClassName='{element.CurrentClassName}'");
+                        matchingElements.Add(element);
+                    }
+                    else
+                    {
+                        Marshal.ReleaseComObject(element);
+                    }
+
+                    return next;
+                }
             }
         }
     }

--- a/src/AutomationTests/A11yAutomationUtilities.cs
+++ b/src/AutomationTests/A11yAutomationUtilities.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Desktop.UIAutomation;
+using System.Runtime.InteropServices;
+using UIAutomationClient;
+
+namespace Axe.Windows.AutomationTests
+{
+    /// <summary>
+    /// Wrapper for CUIAutomation COM object
+    /// </summary>
+    public class A11yAutomationUtilities
+    {
+        internal static DesktopElement GetFocusedElement()
+        {
+            IUIAutomation uiAutomation = A11yAutomation.GetDefaultInstance().UIAutomation;
+            IUIAutomationElement focusedElement = uiAutomation.GetFocusedElement();
+            return new DesktopElement(focusedElement, keepElement: true, setMembers: true);
+        }
+
+        internal static DesktopElement GetDepthFirstLastLeafControlElement(DesktopElement rootElement)
+        {
+            var walker = A11yAutomation.GetDefaultInstance().GetTreeWalker(TreeViewMode.Control);
+            try
+            {
+                IUIAutomationElement leafElement = (IUIAutomationElement)rootElement.PlatformObject;
+                for (IUIAutomationElement currentElement = walker.GetLastChildElement(leafElement); currentElement != null; currentElement = walker.GetLastChildElement(leafElement))
+                {
+                    Marshal.ReleaseComObject(leafElement);
+                    leafElement = currentElement;
+                }
+
+                return leafElement is null
+                    ? rootElement
+                    : new DesktopElement(leafElement, keepElement: true, setMembers: true);
+            }
+            finally
+            {
+                Marshal.ReleaseComObject(walker);
+            }
+        }
+    }
+}

--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -28,7 +28,7 @@ namespace Axe.Windows.AutomationTests
         const int WpfControlSamplerKnownErrorCount = 7;
         const int WindowsFormsMultiWindowSamplerAppAllErrorCount = 12;
         // Note: This should change to 159 after https://github.com/MicrosoftEdge/WebView2Feedback/issues/3530 is fixed and integrated
-        const int WebViewSampleKnownErrorCount = 6;
+        const int WebViewSampleKnownErrorCount = 7;
 
         readonly string _wildlifeManagerAppPath = Path.GetFullPath("../../../../../tools/WildlifeManager/WildlifeManager.exe");
         readonly string _win32ControlSamplerAppPath = Path.GetFullPath("../../../../../tools/Win32ControlSampler/Win32ControlSampler.exe");

--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -102,9 +102,9 @@ namespace Axe.Windows.AutomationTests
             {
                 static ScanOptions makeScopedScanOptions(int pid)
                 {
-                    using (DesktopElement focusedElement = A11yAutomation.GetFocusedElement())
+                    using (DesktopElement focusedElement = A11yAutomationUtilities.GetFocusedElement())
                     {
-                        var leafElement = A11yAutomation.GetDepthFirstLastLeafControlElement(focusedElement);
+                        var leafElement = A11yAutomationUtilities.GetDepthFirstLastLeafControlElement(focusedElement);
                         return new ScanOptions(scanRootWindowHandle: leafElement.NativeWindowHandle);
                     }
                 }

--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -105,7 +105,7 @@ namespace Axe.Windows.AutomationTests
                     using (DesktopElement focusedElement = A11yAutomation.GetFocusedElement())
                     {
                         var leafElement = A11yAutomation.GetDepthFirstLastLeafControlElement(focusedElement);
-                        return new ScanOptions() { WindowHandle = leafElement.NativeWindowHandle };
+                        return new() { ScanRootWindowHandle = leafElement.NativeWindowHandle };
                     }
                 }
                 ScanIntegrationCore(sync, _wildlifeManagerAppPath, WildlifeManagerKnownErrorCount, expectedWindowCount: 1, processId: null, makeScopedScanOptions);

--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -80,6 +80,14 @@ namespace Axe.Windows.AutomationTests
             CleanupTestOutput();
         }
 
+        [TestMethod]
+        [ExpectedException(typeof(AxeWindowsAutomationException))]
+        public void Scan_Integration_InvalidProcessId()
+        {
+            const int BogusProcessId = 47;
+            ScanIntegrationCore(sync: true, testAppPath: null, expectedErrorCount: 0, processId: BogusProcessId);
+        }
+
         [DataTestMethod]
         [DataRow(true)]
         [DataRow(false)]

--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -100,7 +100,7 @@ namespace Axe.Windows.AutomationTests
         {
             RunWithTimedExecutionWrapper(TimeSpan.FromSeconds(30), () =>
             {
-                static ScanOptions makeScopedScanOptions(int pid)
+                static ScanOptions makeScopedScanOptions(int _)
                 {
                     using (DesktopElement focusedElement = A11yAutomationUtilities.GetFocusedElement())
                     {
@@ -109,6 +109,18 @@ namespace Axe.Windows.AutomationTests
                     }
                 }
                 ScanIntegrationCore(sync, _wildlifeManagerAppPath, WildlifeManagerKnownErrorCount, expectedWindowCount: 1, processId: null, makeScopedScanOptions);
+            });
+        }
+
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void Scan_Integration_WildlifeManager_InvalidRoot(bool sync)
+        {
+            RunWithTimedExecutionWrapper(TimeSpan.FromSeconds(30), () =>
+            {
+                static ScanOptions makeScanOptionsWithInvalidRoot(int _) => new(scanRootWindowHandle: new IntPtr(42));
+                ScanIntegrationCore(sync, _wildlifeManagerAppPath, WildlifeManagerKnownErrorCount, expectedWindowCount: WildlifeManagerKnownErrorCount, processId: null, makeScanOptionsWithInvalidRoot);
             });
         }
 

--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -105,7 +105,7 @@ namespace Axe.Windows.AutomationTests
                     using (DesktopElement focusedElement = A11yAutomation.GetFocusedElement())
                     {
                         var leafElement = A11yAutomation.GetDepthFirstLastLeafControlElement(focusedElement);
-                        return new() { ScanRootWindowHandle = leafElement.NativeWindowHandle };
+                        return new ScanOptions(scanRootWindowHandle: leafElement.NativeWindowHandle);
                     }
                 }
                 ScanIntegrationCore(sync, _wildlifeManagerAppPath, WildlifeManagerKnownErrorCount, expectedWindowCount: 1, processId: null, makeScopedScanOptions);

--- a/src/AutomationTests/AutomationIntegrationTests.cs
+++ b/src/AutomationTests/AutomationIntegrationTests.cs
@@ -360,7 +360,7 @@ namespace Axe.Windows.AutomationTests
 
             int aggregateErrorCount = output.Sum(x => x.ErrorCount);
             int totalErrors = output.Sum(x => x.Errors.Count());
-            Assert.AreEqual(expectedErrorCount, aggregateErrorCount, message: PrintOutput());
+            Assert.AreEqual(expectedErrorCount, aggregateErrorCount, message: IsTestRunningInPipeline() ? string.Empty : PrintAll(output));
             Assert.AreEqual(expectedErrorCount, totalErrors);
 
             string PrintOutput() => StringJoin(output.Select(PrintErrors),Environment.NewLine);
@@ -483,5 +483,11 @@ namespace Axe.Windows.AutomationTests
             // The BUILD_BUILDID environment variable is only set on build agents
             return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_BUILDID"));
         }
+
+        static string PrintAll(IReadOnlyCollection<WindowScanOutput> output) => StringJoin(output.Select(PrintErrors), Environment.NewLine);
+        static string PrintErrors(WindowScanOutput output, int index) => $"Output #{index}:\r\n\t{StringJoin(output.Errors.Select(PrintError), "\r\n\t")}";
+        static string PrintError(ScanResult error, int index) => $"Error #{index}: {error.Rule}\r\n\t\t{PrintElementProperties(error.Element)}";
+        static string PrintElementProperties(ElementInfo e) => StringJoin(e.Properties.Select(p => $"{p.Key}='{p.Value}'"), "\r\n\t\t");
+        static string StringJoin(IEnumerable<string> lines, string separator) => string.Join(separator, lines);
     }
 }

--- a/src/AutomationTests/AutomationTests.csproj
+++ b/src/AutomationTests/AutomationTests.csproj
@@ -26,6 +26,20 @@
     <ProjectReference Include="..\UnitTestSharedLibrary\UnitTestSharedLibrary.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="Interop.UIAutomationClient">
+      <HintPath>..\UIAAssemblies\Win10.17713\Interop.UIAutomationClient.dll</HintPath>
+      <EmbedInteropTypes>true</EmbedInteropTypes>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Interop.UIAutomationCore">
+      <HintPath>..\InteropDummy\bin\$(Configuration)\net6.0\Interop.UIAutomationCore.dll</HintPath>
+      <EmbedInteropTypes>true</EmbedInteropTypes>
+    </Reference>
+  </ItemGroup>
+
   <Import Project="..\..\build\NetStandardTest.targets" />
 
 </Project>

--- a/src/AutomationTests/SnapshotCommandTests.cs
+++ b/src/AutomationTests/SnapshotCommandTests.cs
@@ -120,7 +120,7 @@ namespace Axe.Windows.AutomationTests
         private void SetupTargetElementLocatorMock(int processId = -1, bool overrideElements = false, IEnumerable<A11yElement> elements = null)
         {
             var overriddenElements = overrideElements ? elements : CreateMockElementArray();
-            _targetElementLocatorMock.Setup(x => x.LocateRootElements(processId, It.IsAny<IActionContext>())).Returns(overriddenElements);
+            _targetElementLocatorMock.Setup(x => x.LocateRootElements(processId, It.IsAny<IActionContext>(), IntPtr.Zero)).Returns(overriddenElements);
         }
 
         private void SetupOutputFileHelperMock(string filePath = "Test.File")

--- a/src/AutomationTests/SnapshotCommandTests.cs
+++ b/src/AutomationTests/SnapshotCommandTests.cs
@@ -80,7 +80,7 @@ namespace Axe.Windows.AutomationTests
             _scanToolsMock.Setup(x => x.DpiAwareness).Returns(_dpiAwarenessMock.Object);
         }
 
-        private void SetupScanToolsMock(bool withResultsAssembler = true, bool withOutputFileHelper = false, bool withShouldTestAllChromiumContent = true)
+        private void SetupScanToolsMock(bool withResultsAssembler = true, bool withOutputFileHelper = false, bool withShouldTestAllChromiumContent = true, bool setupRootHandle = true)
         {
             _scanToolsMock.Setup(x => x.TargetElementLocator).Returns(_targetElementLocatorMock.Object);
             _scanToolsMock.Setup(x => x.Actions).Returns(_actionsMock.Object);
@@ -95,6 +95,10 @@ namespace Axe.Windows.AutomationTests
             if (withShouldTestAllChromiumContent)
             {
                 _actionsMock.Setup(x => x.SetShouldTestAllChromiumContent(false));
+            }
+            if (setupRootHandle)
+            {
+                _scanToolsMock.Setup(x => x.ScanRootWindowHandle).Returns(IntPtr.Zero);
             }
         }
 
@@ -194,7 +198,7 @@ namespace Axe.Windows.AutomationTests
         [Timeout(1000)]
         public async Task ExecuteAsync_NullDpiAwareness_ThrowsException()
         {
-            SetupScanToolsMock(withResultsAssembler: false, withShouldTestAllChromiumContent: false);
+            SetupScanToolsMock(withResultsAssembler: false, withShouldTestAllChromiumContent: false, setupRootHandle: false);
             _scanToolsMock.Setup(x => x.DpiAwareness).Returns<IDPIAwareness>(null);
 
             var action = new Func<Task>(() => SnapshotCommand.ExecuteAsync(_minimalConfig, _scanToolsMock.Object, CancellationToken.None));

--- a/src/CLI/IOptions.cs
+++ b/src/CLI/IOptions.cs
@@ -7,6 +7,7 @@ namespace AxeWindowsCLI
     {
         string OutputDirectory { get; }
         string ScanId { get; }
+        System.IntPtr ScanRootWindowHandle { get; }
         int ProcessId { get; }
         string ProcessName { get; }
         VerbosityLevel VerbosityLevel { get; }

--- a/src/CLI/Options.cs
+++ b/src/CLI/Options.cs
@@ -19,6 +19,9 @@ namespace AxeWindowsCLI
 
         [Option(Required = false, HelpText = "ScanId", ResourceType = typeof(Resources.OptionsHelpText))]
         public string ScanId { get; set; }
+        
+        [Option(Required = false, HelpText = "ScanRootWindowHandle", ResourceType = typeof(Resources.OptionsHelpText))]
+        public System.IntPtr ScanRootWindowHandle { get; set; } = System.IntPtr.Zero;
 
         [Option(Required = false, HelpText = "Verbosity", ResourceType = typeof(Resources.OptionsHelpText))]
         public string Verbosity { get; set; }

--- a/src/CLI/OptionsEvaluator.cs
+++ b/src/CLI/OptionsEvaluator.cs
@@ -61,6 +61,7 @@ namespace AxeWindowsCLI
                 ProcessId = processId,
                 ProcessName = processName,
                 ScanId = rawInputs.ScanId,
+                ScanRootWindowHandle = rawInputs.ScanRootWindowHandle,
                 VerbosityLevel = verbosityLevel,
                 DelayInSeconds = delayInSeconds,
                 CustomUia = rawInputs.CustomUia,

--- a/src/CLI/OutputGenerator.cs
+++ b/src/CLI/OutputGenerator.cs
@@ -84,6 +84,13 @@ namespace AxeWindowsCLI
                     {
                         _writer.Write(DisplayStrings.ScanTargetProcessIdFormat, options.ProcessId);
                     }
+
+                    bool haveScanRootWindowHandle = options.ScanRootWindowHandle != IntPtr.Zero;
+                    if (haveScanRootWindowHandle)
+                    {
+                        _writer.Write(DisplayStrings.ScanTargetSeparator);
+                        _writer.Write(DisplayStrings.ScanTargetRootWindowHandleFormat, options.ScanRootWindowHandle);
+                    }
                     _writer.WriteLine();
                 }
                 if (!string.IsNullOrEmpty(options.ScanId))

--- a/src/CLI/README.MD
+++ b/src/CLI/README.MD
@@ -27,6 +27,8 @@ Copyright c 2020
 
   --scanid                    Scan ID
 
+  --scanrootwindowhandle      The HWND of the window to scan.
+
   --verbosity                 Verbosity level (Quiet/Default/Verbose)
 
   --showthirdpartynotices     Display Third Party Notices (opens file in browser
@@ -61,6 +63,7 @@ processId|Identifies the process ID of the application to be scanned. Must be sp
 processName|Identifies the name of the process to be scanned. Requires that the process to scan be the _only_ process of that name currently running on the system.
 outputDirectory|Identifies the folder where output files will be created. If not specified, this will default to `.\AxeWindowsOutputFiles` (relative to the current working directory)
 scanId|Identifies the specific ID of the scan. This allows you to preassign a name to the given scan (and output file). If omitted, an dynamic name in the format AxeWindows_YY-MM-DD_hh-mm-ss.fffffff will be used.
+scanRootWindowHandle|The HWND of the UIA element whose subtree should be scanned.  If omitted, the root's children/grandchildren with matching processId will be scanned.
 verbosity|Identifies the level of detail you want in the output. Valid values are `quiet` (minimal output), `default` (typical output), or `verbose` (maximum output).
 showThirdPartyNotices|If specified, displays the third party notices for components used by AxeWindowsCLI. This information is also available in the `thirdpartynotices.html` file that is installed with AxeWindowsCLI.
 delayInSeconds|Optionally inserts a delay before triggering the scan. This allows transient controls (menus, drop-down-lists, etc.) to be scanned.

--- a/src/CLI/Resources/DisplayStrings.Designer.cs
+++ b/src/CLI/Resources/DisplayStrings.Designer.cs
@@ -313,6 +313,15 @@ namespace AxeWindowsCLI.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to HWND = {0}.
+        /// </summary>
+        internal static string ScanTargetRootWindowHandleFormat {
+            get {
+                return ResourceManager.GetString("ScanTargetRootWindowHandleFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ,.
         /// </summary>
         internal static string ScanTargetSeparator {

--- a/src/CLI/Resources/DisplayStrings.Designer.cs
+++ b/src/CLI/Resources/DisplayStrings.Designer.cs
@@ -313,7 +313,7 @@ namespace AxeWindowsCLI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to HWND = {0}.
+        ///   Looks up a localized string similar to  HWND = {0}.
         /// </summary>
         internal static string ScanTargetRootWindowHandleFormat {
             get {

--- a/src/CLI/Resources/DisplayStrings.resx
+++ b/src/CLI/Resources/DisplayStrings.resx
@@ -223,7 +223,7 @@
     <comment>{0} is the process name. Leading space is intentional</comment>
   </data>
   <data name="ScanTargetRootWindowHandleFormat" xml:space="preserve">
-    <value>HWND = {0}</value>
+    <value> HWND = {0}</value>
     <comment>{0} is the scan root window handle</comment>
   </data>
   <data name="ScanTargetSeparator" xml:space="preserve">

--- a/src/CLI/Resources/DisplayStrings.resx
+++ b/src/CLI/Resources/DisplayStrings.resx
@@ -222,6 +222,10 @@
     <value> Process Name = {0}</value>
     <comment>{0} is the process name. Leading space is intentional</comment>
   </data>
+  <data name="ScanTargetRootWindowHandleFormat" xml:space="preserve">
+    <value>HWND = {0}</value>
+    <comment>{0} is the scan root window handle</comment>
+  </data>
   <data name="ScanTargetSeparator" xml:space="preserve">
     <value>,</value>
   </data>

--- a/src/CLI/Resources/OptionsHelpText.Designer.cs
+++ b/src/CLI/Resources/OptionsHelpText.Designer.cs
@@ -124,6 +124,15 @@ namespace AxeWindowsCLI.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The HWND for a UI Automation element whose sub-tree should be scanned.
+        /// </summary>
+        public static string ScanRootWindowHandle {
+            get {
+                return ResourceManager.GetString("ScanRootWindowHandle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Display Third Party Notices (opens file in browser without executing scan). If specified, all other options will be ignored..
         /// </summary>
         public static string ShowThirdPartyNotices {

--- a/src/CLI/Resources/OptionsHelpText.resx
+++ b/src/CLI/Resources/OptionsHelpText.resx
@@ -138,6 +138,9 @@
   <data name="ScanId" xml:space="preserve">
     <value>Scan ID</value>
   </data>
+  <data name="ScanRootWindowHandle" xml:space="preserve">
+    <value>The HWND for a UI Automation element whose sub-tree should be scanned</value>
+  </data>
   <data name="ShowThirdPartyNotices" xml:space="preserve">
     <value>Display Third Party Notices (opens file in browser without executing scan). If specified, all other options will be ignored.</value>
   </data>

--- a/src/CLI/ScanRunner.cs
+++ b/src/CLI/ScanRunner.cs
@@ -12,7 +12,7 @@ namespace AxeWindowsCLI
         public static IReadOnlyCollection<WindowScanOutput> RunScan(IOptions options)
         {
             IScanner scanner = BuildScanner(options);
-            return scanner.Scan(new ScanOptions(options.ScanId)).WindowScanOutputs;
+            return scanner.Scan(new ScanOptions(options.ScanId, options.ScanRootWindowHandle)).WindowScanOutputs;
         }
 
         private static IScanner BuildScanner(IOptions options)

--- a/src/CLITests/OptionsEvaluatorTests.cs
+++ b/src/CLITests/OptionsEvaluatorTests.cs
@@ -31,12 +31,14 @@ namespace AxeWindowsCLITests
 
         private static void ValidateOptions(IOptions options, string processName = TestProcessName,
             int processId = TestProcessId, string outputDirectory = null, string scanId = null,
+            IntPtr scanRootWindowHandle = default,
             VerbosityLevel verbosityLevel = VerbosityLevel.Default, int delayInSeconds = 0,
             bool alwaysWriteTestFile = false, bool testAllChromiumContent = false)
         {
             Assert.AreEqual(processName, options.ProcessName);
             Assert.AreEqual(processId, options.ProcessId);
             Assert.AreEqual(scanId, options.ScanId);
+            Assert.AreEqual(scanRootWindowHandle, options.ScanRootWindowHandle);
             Assert.AreEqual(outputDirectory, options.OutputDirectory);
             Assert.AreEqual(verbosityLevel, options.VerbosityLevel);
             Assert.AreEqual(delayInSeconds, options.DelayInSeconds);
@@ -156,7 +158,7 @@ namespace AxeWindowsCLITests
 
         [TestMethod]
         [Timeout(1000)]
-        public void ProcessInputs_SpecifiesScanId_RetainsOutputDirectory()
+        public void ProcessInputs_SpecifiesScanId_RetainsScanId()
         {
             const string testScanId = "SuperScan";
             _processHelperMock.Setup(x => x.ProcessIdFromName(TestProcessName)).Returns(TestProcessId);
@@ -167,6 +169,23 @@ namespace AxeWindowsCLITests
             };
             ValidateOptions(OptionsEvaluator.ProcessInputs(input, _processHelperMock.Object),
                 processId: TestProcessId, scanId: testScanId);
+            VerifyAllMocks();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ProcessInputs_SpecifiesScanRootWindowHandle_RetainsScanRootWindowHandle()
+        {
+            const int testScanRootWindowHandleValue = 42;
+            IntPtr testScanRootWindowHandle = new(testScanRootWindowHandleValue);
+            _processHelperMock.Setup(x => x.ProcessIdFromName(TestProcessName)).Returns(TestProcessId);
+            Options input = new Options
+            {
+                ProcessName = TestProcessName,
+                ScanRootWindowHandle = testScanRootWindowHandle,
+            };
+            ValidateOptions(OptionsEvaluator.ProcessInputs(input, _processHelperMock.Object),
+                processId: TestProcessId, scanRootWindowHandle: testScanRootWindowHandle);
             VerifyAllMocks();
         }
 

--- a/src/CLITests/OptionsTests.cs
+++ b/src/CLITests/OptionsTests.cs
@@ -35,12 +35,14 @@ namespace AxeWindowsCLITests
 
         private static int ValidateOptions(Options options, string processName = null,
             int processId = 0, string outputDirectory = null, string scanId = null,
+            System.IntPtr scanRootWindowHandle = default,
             string verbosity = null, bool showThirdPartyNotices = false,
             int delayInSeconds = 0, string customUia = null, bool alwaysSaveTestFile = false)
         {
             Assert.AreEqual(processName, options.ProcessName);
             Assert.AreEqual(processId, options.ProcessId);
             Assert.AreEqual(scanId, options.ScanId);
+            Assert.AreEqual(scanRootWindowHandle, options.ScanRootWindowHandle);
             Assert.AreEqual(outputDirectory, options.OutputDirectory);
             Assert.AreEqual(verbosity, options.Verbosity);
             Assert.AreEqual(VerbosityLevel.Default, options.VerbosityLevel);

--- a/src/CLITests/OutputGeneratorTests.cs
+++ b/src/CLITests/OutputGeneratorTests.cs
@@ -69,6 +69,10 @@ namespace AxeWindowsCLITests
             _optionsMock.Setup(x => x.ProcessName).Returns(processName);
             _optionsMock.Setup(x => x.ProcessId).Returns(processId);
             _optionsMock.Setup(x => x.ScanId).Returns(scanId);
+            if (processId > 0 || !string.IsNullOrEmpty(processName))
+            {
+                _optionsMock.Setup(x => x.ScanRootWindowHandle).Returns(IntPtr.Zero);
+            }
         }
 
         [TestMethod]

--- a/src/CLITests/OutputGeneratorTests.cs
+++ b/src/CLITests/OutputGeneratorTests.cs
@@ -26,6 +26,7 @@ namespace AxeWindowsCLITests
         const string ScanTargetIntro = "Scan Target:";
         const string ScanTargetProcessNameStart = " Process Name =";
         const string ScanTargetProcessIdStart = " Process ID =";
+        const string ScanTargetRootWindowHandleStart = " HWND =";
         const string ScanTargetComma = ",";
         const string ScanIdStart = "Scan Id =";
         const string ErrorCountGeneralStart = "{0} errors ";
@@ -63,7 +64,7 @@ namespace AxeWindowsCLITests
 
         private void SetOptions(VerbosityLevel verbosityLevel = VerbosityLevel.Default,
             string processName = null, int processId = -1,
-            string scanId = null)
+            string scanId = null, IntPtr? scanRootWindowHandle = null)
         {
             _optionsMock.Setup(x => x.VerbosityLevel).Returns(verbosityLevel);
             _optionsMock.Setup(x => x.ProcessName).Returns(processName);
@@ -71,7 +72,7 @@ namespace AxeWindowsCLITests
             _optionsMock.Setup(x => x.ScanId).Returns(scanId);
             if (processId > 0 || !string.IsNullOrEmpty(processName))
             {
-                _optionsMock.Setup(x => x.ScanRootWindowHandle).Returns(IntPtr.Zero);
+                _optionsMock.Setup(x => x.ScanRootWindowHandle).Returns(scanRootWindowHandle.GetValueOrDefault(IntPtr.Zero));
             }
         }
 
@@ -173,6 +174,28 @@ namespace AxeWindowsCLITests
                 new WriteCall(ScanTargetProcessNameStart, WriteSource.WriteOneParam),
                 new WriteCall(ScanTargetComma, WriteSource.WriteStringOnly),
                 new WriteCall(ScanTargetProcessIdStart, WriteSource.WriteOneParam),
+                new WriteCall(null, WriteSource.WriteLineEmpty),
+            };
+            TextWriterVerifier textWriterVerifier = new TextWriterVerifier(_writerMock, expectedCalls);
+
+            _testSubject.WriteBanner(_optionsMock.Object);
+
+            textWriterVerifier.VerifyAll();
+            VerifyAllMocks();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void WriteBanner_VerbosityIsDefault_ProcessId_ScanRootWindowHandle_WritesHWND()
+        {
+            SetOptions(processId: TestProcessId, scanRootWindowHandle: new(47));
+            WriteCall[] expectedCalls =
+            {
+                new WriteCall(AppTitleStart, WriteSource.WriteLineOneParam),
+                new WriteCall(ScanTargetIntro, WriteSource.WriteStringOnly),
+                new WriteCall(ScanTargetProcessIdStart, WriteSource.WriteOneParam),
+                new WriteCall(ScanTargetComma, WriteSource.WriteStringOnly),
+                new WriteCall(ScanTargetRootWindowHandleStart, WriteSource.WriteOneParam),
                 new WriteCall(null, WriteSource.WriteLineEmpty),
             };
             TextWriterVerifier textWriterVerifier = new TextWriterVerifier(_writerMock, expectedCalls);

--- a/src/CLITests/TextWriterVerifier.cs
+++ b/src/CLITests/TextWriterVerifier.cs
@@ -100,7 +100,7 @@ namespace AxeWindowsCLITests
                 }
                 else
                 {
-                    Assert.IsTrue(actualCall.Format.StartsWith(expectedWriteCall.Format), "Actual Format = " + actualCall.Format);
+                    Assert.IsTrue(actualCall.Format.StartsWith(expectedWriteCall.Format), $"Actual Format = '{actualCall.Format}'; Expected Format = '{expectedWriteCall.Format}'");
                 }
                 verified++;
             }

--- a/src/Core/Bases/A11yElement.cs
+++ b/src/Core/Bases/A11yElement.cs
@@ -75,6 +75,12 @@ namespace Axe.Windows.Core.Bases
         }
 
         /// <summary>
+        /// the HWND for the element
+        /// </summary>
+        [JsonIgnore]
+        public IntPtr NativeWindowHandle => new IntPtr(value: GetPropertySafely(PropertyType.UIA_NativeWindowHandlePropertyId)?.Value);
+
+        /// <summary>
         /// a text description of a keystroke which activates the element; valid within a dialog, pane, or app
         /// </summary>
         [JsonIgnore]

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -11,10 +11,16 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using UIAutomationClient;
-
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("AutomationTests")]
+#if ENABLE_SIGNING
+[assembly:         InternalsVisibleTo("AutomationTests,PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly:InternalsVisibleTo("DynamicProxyGenAssembly2,PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]    
+#else
+[assembly: InternalsVisibleTo("AutomationTests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+#endif
 
 namespace Axe.Windows.Desktop.UIAutomation
 {

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -61,13 +61,13 @@ namespace Axe.Windows.Desktop.UIAutomation
         {
             for (var child = walker.GetFirstChildElement(parent); child != null; child = walker.GetNextSiblingElement(child))
             {
-                TestProcessMatchingELement(pid, matchingElements, nonMatchingElements, child);
+                TestProcessMatchingElement(pid, matchingElements, nonMatchingElements, child);
             }
 
             return matchingElements.Any();
         }
 
-        private static void TestProcessMatchingELement(int pid, IList<IUIAutomationElement> matchingElements, IList<IUIAutomationElement> nonMatchingElements, IUIAutomationElement element)
+        private static void TestProcessMatchingElement(int pid, IList<IUIAutomationElement> matchingElements, IList<IUIAutomationElement> nonMatchingElements, IUIAutomationElement element)
         {
             if (element.CurrentProcessId == pid)
             {
@@ -89,7 +89,7 @@ namespace Axe.Windows.Desktop.UIAutomation
             {
                 if (includeSelf)
                 {
-                    TestProcessMatchingELement(pid, matchingElements, nonMatchingElements, root);
+                    TestProcessMatchingElement(pid, matchingElements, nonMatchingElements, root);
                 }
 
                 if (FindProcessMatchingChildren(root, walker, pid, matchingElements, nonMatchingElements))
@@ -183,7 +183,16 @@ namespace Axe.Windows.Desktop.UIAutomation
         {
             if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 
-            IUIAutomationElement subtreeRootElement = dataContext.A11yAutomation.UIAutomation.ElementFromHandle(rootWindowHandle);
+            IUIAutomationElement subtreeRootElement;
+            try
+            {
+                subtreeRootElement = dataContext.A11yAutomation.UIAutomation.ElementFromHandle(rootWindowHandle);
+            }
+            catch (COMException)
+            {
+                subtreeRootElement = null;
+            }
+
             if (subtreeRootElement is null)
             {
                 // If the root window handle is invalid, fallback to full-process scan.

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -109,10 +109,14 @@ namespace Axe.Windows.Desktop.UIAutomation
         /// <summary>
         /// Get DesktopElements based on Process Id.
         /// </summary>
-        /// <param name="pid"></param>
+        /// <param name="pid">The <see cref="Process.Id"/> whoese elements should be retrieved.</param>
+        /// <param name="rootWindowHandle">
+        /// The window handle for the <see cref="IUIAutomationElement"/> that should be used
+        /// as the root of the sub-tree to be scanned.
+        /// </param>
         /// <param name="dataContext">The data context</param>
         /// <returns>return null if we fail to get elements by process Id</returns>
-        public static IEnumerable<DesktopElement> ElementsFromProcessId(int pid, DesktopDataContext dataContext)
+        public static IEnumerable<DesktopElement> ElementsFromProcessId(int pid, IntPtr rootWindowHandle, DesktopDataContext dataContext)
         {
             if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 
@@ -130,7 +134,9 @@ namespace Axe.Windows.Desktop.UIAutomation
                     // exists inside UIAutomation.GetRootElement, and this works around the problem.
                     lock (LockObject)
                     {
-                        root = dataContext.A11yAutomation.UIAutomation.GetRootElement();
+                        root = rootWindowHandle == IntPtr.Zero
+                            ? dataContext.A11yAutomation.UIAutomation.GetRootElement()
+                            : dataContext.A11yAutomation.UIAutomation.ElementFromHandle(rootWindowHandle);
                     }
                     matchingElements = dataContext.A11yAutomation.FindProcessMatchingChildrenOrGrandchildren(root, pid);
                     elements = ElementsFromUIAElements(matchingElements, dataContext);

--- a/src/Desktop/UIAutomation/A11yAutomation.cs
+++ b/src/Desktop/UIAutomation/A11yAutomation.cs
@@ -155,35 +155,6 @@ namespace Axe.Windows.Desktop.UIAutomation
             return elements;
         }
 
-        internal static DesktopElement GetFocusedElement()
-        {
-            IUIAutomation uiAutomation = GetDefaultInstance().UIAutomation;
-            IUIAutomationElement focusedElement = uiAutomation.GetFocusedElement();
-            return new DesktopElement(focusedElement, keepElement: true, setMembers: true);
-        }
-
-        internal static DesktopElement GetDepthFirstLastLeafControlElement(DesktopElement rootElement)
-        {
-            var walker = GetDefaultInstance().GetTreeWalker(TreeViewMode.Control);
-            try
-            {
-                IUIAutomationElement leafElement = (IUIAutomationElement)rootElement.PlatformObject;
-                for (IUIAutomationElement currentElement = walker.GetLastChildElement(leafElement); currentElement != null; currentElement = walker.GetLastChildElement(leafElement))
-                {
-                    Marshal.ReleaseComObject(leafElement);
-                    leafElement = currentElement;
-                }
-
-                return leafElement is null
-                    ? rootElement
-                    : new DesktopElement(leafElement, keepElement: true, setMembers: true);
-            }
-            finally
-            {
-                Marshal.ReleaseComObject(walker);
-            }
-        }
-
         /// <summary>
         /// Get DesktopElement from UIAElement interface.
         /// </summary>

--- a/src/RulesTest/MockA11yElement.cs
+++ b/src/RulesTest/MockA11yElement.cs
@@ -299,7 +299,7 @@ namespace Axe.Windows.RulesTests
             }
         }
 
-        public int NativeWindowHandle
+        public new int NativeWindowHandle
         {
             get
             {


### PR DESCRIPTION
#### Details

Adds:
- ScanOptions property settable to IntPtr for HWND of root of subtree to be scanned
- Teach PID descendants search to operate on HWND's subtree instead of GetRootElement
- Add Integration test for test app leaf node scan

##### Motivation

Proposal to address issue #1021 

##### Context

I exposed internals of A11yAutomation to the Integration Tests project so I could find a relevant IUIAutomationElement for testing the ScanOptions' HWND constraint

You could implement this as a "ForWindowHandle()" constraint on the Config, but my external tools use the same scanner repeatedly - it's the individual Scans whose scope needs to be constrained.

#### Pull request checklist
- [X] Addresses an existing issue: #1021
