### PR TITLE
Chore: Bump minor version in preparation for release, fix-up #1020

### DIFF
--- a/src/Core/Misc/ExtensionMethods.cs
+++ b/src/Core/Misc/ExtensionMethods.cs
@@ -607,6 +607,8 @@ namespace Axe.Windows.Core.Misc
         public static Size ToSize(this A11yProperty property)
         {
             if (property?.Value is null) return Size.Empty;
+            if (property.Id != PropertyType.Axe_LogicalSizePseudoPropertyId) throw new ArgumentException("ToSize is not supported for this property type", nameof(property));
+
             return new Size(property.Value[0], property.Value[1]);
         }
 

--- a/src/props/version.props
+++ b/src/props/version.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SemVerNumber Condition="$(SemVerNumber) == ''">2.3.2</SemVerNumber>
+    <SemVerNumber Condition="$(SemVerNumber) == ''">2.4.0</SemVerNumber>
     <SemVerSuffix></SemVerSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### Details
Axe.Windows follows [semantic versioning](https://semver.org), which states:

> Given a version number MAJOR.MINOR.PATCH, increment the... MINOR version when you add functionality in a backward compatible manner

I think 6d72b85 and d2a5c65 qualify as "new functionality" for these purposes, justifying a minor version bump.

Also includes a small fix-up of #1020 to prevent execution of `a11yProperty.ToSize` on properties other than `LogicalSize`.
##### Motivation
Pre-release preparation.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
