### PR TITLE
fix: Exclude the win32 IP address control from the SiblingUniqueAndFocusable rule

### DIFF
--- a/src/Rules/Library/SiblingUniqueAndFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndFocusable.cs
@@ -63,7 +63,7 @@ namespace Axe.Windows.Rules.Library
                 & WPF
                 & NoChild(Custom | Name.NullOrEmpty);
 
-            var ipAddressControl = ClassName.Is("SysIPAddress32");
+            var ipAddressControl = Win32Framework & ClassName.Is("SysIPAddress32");
 
             return EligibleChild
                 & NotParent(wpfDataItem)

--- a/src/Rules/Library/SiblingUniqueAndFocusable.cs
+++ b/src/Rules/Library/SiblingUniqueAndFocusable.cs
@@ -63,7 +63,12 @@ namespace Axe.Windows.Rules.Library
                 & WPF
                 & NoChild(Custom | Name.NullOrEmpty);
 
-            return EligibleChild & NotParent(wpfDataItem);
+            var ipAddressControl = ClassName.Is("SysIPAddress32");
+
+            return EligibleChild
+                & NotParent(wpfDataItem)
+                // microsoft/accessibility-insights-windows#1838: The Win32 IP address control yields false positives for this rule.
+                & NotParent(ipAddressControl);
         }
     } // class
 } // namespace


### PR DESCRIPTION
#### Details
The Win32 IP address control consists of a pane of edit fields, one per octet of an IPV4 address. As such, the `SiblingUniqueAndFocusable` rule is not appropriate for this control.

#### Pull request checklist
- [x] Addresses an existing issue: microsoft/accessibility-insights-windows#1838
