### PR TITLE
fix: Downgrade SiblingUniqueAndFocusable to NeedsReview for Win32 apps

### DIFF
--- a/docs/RulesDescription.md
+++ b/docs/RulesDescription.md
@@ -18,6 +18,7 @@ ButtonInvokeAndTogglePatterns | Error | A button must not support both the Invok
 ButtonInvokeAndExpandCollapsePatterns | Warning | A button may have the Invoke and ExpandCollapse patterns together, but it is not recommended. If possible, please have only one of them.  | WCAG 1.3.1 InfoAndRelationships
 ButtonToggleAndExpandCollapsePatterns | Error | A button must not support both the Toggle and ExpandCollapse patterns. | WCAG 4.1.2 NameRoleValue
 SiblingUniqueAndFocusable | Error | Focusable sibling elements must not have the same Name and LocalizedControlType. | WCAG 4.1.2 NameRoleValue
+SiblingUniqueAndFocusableWin32 | NeedsReview | Focusable sibling elements must not have the same Name and LocalizedControlType. | WCAG 4.1.2 NameRoleValue
 SiblingUniqueAndNotFocusable | NeedsReview | The given element has siblings with the same Name and LocalizedControlType. | WCAG 4.1.2 NameRoleValue
 ChildrenNotAllowedInContentView | Error | A separator must not have any children with IsContentElement set to true. | Section 508 502.3.1 ObjectInformation
 ContentViewButtonStructure | NeedsReview | The given element is expected to have the following structure: Button and NoChild(IsContentElement). | WCAG 1.3.1 InfoAndRelationships

--- a/src/Core/Enums/RuleId.cs
+++ b/src/Core/Enums/RuleId.cs
@@ -31,6 +31,7 @@ namespace Axe.Windows.Core.Enums
         ButtonToggleAndExpandCollapsePatterns, // Button should not have Toggle and ExpandCollapse patterns together.
 
         SiblingUniqueAndFocusable,
+        SiblingUniqueAndFocusableWin32,
         SiblingUniqueAndNotFocusable,
 
         ChildrenNotAllowedInContentView,

--- a/src/Rules/Library/SiblingUniqueAndFocusableWin32.cs
+++ b/src/Rules/Library/SiblingUniqueAndFocusableWin32.cs
@@ -16,18 +16,17 @@ using static Axe.Windows.Rules.PropertyConditions.StringProperties;
 
 namespace Axe.Windows.Rules.Library
 {
-    [RuleInfo(ID = RuleId.SiblingUniqueAndFocusable)]
-    class SiblingUniqueAndFocusable : Rule
+    [RuleInfo(ID = RuleId.SiblingUniqueAndFocusableWin32)]
+    class SiblingUniqueAndFocusableWin32 : Rule
     {
         private static readonly Condition EligibleChild = CreateEligibleChildCondition();
 
         private static Condition CreateEligibleChildCondition()
         {
-            var ExcludedType = DataItem | Image | Pane | ScrollBar | Thumb | TreeItem | ListItem | Hyperlink;
+            var ExcludedType = Image | Pane | ScrollBar | Thumb | TreeItem | ListItem | Hyperlink;
 
             return IsKeyboardFocusable
-                // #1047: covered by SiblingUniqueAndFocusableWin32
-                & ~Win32Framework
+                & Win32Framework
                 & IsContentOrControlElement
                 & ~ExcludedType
                 & ~Patterns.GridItem
@@ -37,12 +36,12 @@ namespace Axe.Windows.Rules.Library
                 & BoundingRectangle.Valid;
         }
 
-        public SiblingUniqueAndFocusable()
+        public SiblingUniqueAndFocusableWin32()
         {
             Info.Description = Descriptions.SiblingUniqueAndFocusable;
             Info.HowToFix = HowToFix.SiblingUniqueAndFocusable;
             Info.Standard = A11yCriteriaId.NameRoleValue;
-            Info.ErrorCode = EvaluationCode.Error;
+            Info.ErrorCode = EvaluationCode.NeedsReview;
         }
 
         public override bool PassesTest(IA11yElement e)
@@ -61,12 +60,7 @@ namespace Axe.Windows.Rules.Library
 
         protected override Condition CreateCondition()
         {
-            var wpfDataItem = DataItem
-                & WPF
-                & NoChild(Custom | Name.NullOrEmpty);
-
-            return EligibleChild
-                & NotParent(wpfDataItem);
+            return EligibleChild;
         }
-    } // class
-} // namespace
+    }
+}

--- a/src/props/version.props
+++ b/src/props/version.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SemVerNumber Condition="$(SemVerNumber) == ''">2.4.0</SemVerNumber>
+    <SemVerNumber Condition="$(SemVerNumber) == ''">2.4.1</SemVerNumber>
     <SemVerSuffix></SemVerSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### Details
Due to a large number of false positives (and given the fact that Win32 applications don't support UIA natively), downgrade `SiblingUniqueAndFocusable` to `NeedsReview` in Win32 applications.

##### Motivation
Addresses #1046. Supersedes #1038. Addresses microsoft/accessibility-insights-windows#1838.

#### Pull request checklist
- [x] Addresses an existing issue: #1046, microsoft/accessibility-insights-windows#1838.
