### PR TITLE
chore: update binskim to optout 4.3.1 version

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -34,6 +34,7 @@ extends:
       name: MSEngSS-MicroBuild2022-1ES
     sdl:
       binskim:
+        preReleaseVersion: ''
         # If you modify this list, you also need to modify the list in the Run BinSkim task in Signed Release Job or vice-versa to keep them in sync
         analyzeTargetGlob: "$(System.DefaultWorkingDirectory)\\src\\CI\\bin\\**\\*.dll;\
                             $(System.DefaultWorkingDirectory)\\src\\Actions\\bin\\**\\*.dll;\

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -34,6 +34,7 @@ extends:
       name: MSEngSS-MicroBuild2022-1ES
     sdl:
       binskim:
+        # #1077: Hold BinSkim back at 4.3.1 to resolve a pipeline incompatibility
         preReleaseVersion: ''
         # If you modify this list, you also need to modify the list in the Run BinSkim task in Signed Release Job or vice-versa to keep them in sync
         analyzeTargetGlob: "$(System.DefaultWorkingDirectory)\\src\\CI\\bin\\**\\*.dll;\


### PR DESCRIPTION
#### Details

This is new pre release version used in 1ES pipeline templates. But our TSA upload task still uses the older version (1.9.5) so this conflict is resulting into pipeline failure.

For now updating pipeline to optout for new version. 

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

There will be separate work item to update binskim to 4.3.1 version as new rules in 4.3.1 might discover issues which also need to be resolved so that pipeline does not break.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
